### PR TITLE
fix(demo): buttons and html tag is hidden, but they should be visible

### DIFF
--- a/demos/assets/index.css
+++ b/demos/assets/index.css
@@ -58,7 +58,7 @@ iframe {
   width: 400px;
   height: 100%;
   overflow: hidden;
-  padding: 0 1rem 1em 0;
+  padding: 0 1rem 0 0;
   position: relative;
   right: 0;
   top: 0;
@@ -70,12 +70,17 @@ iframe {
 }
 
 .code-banner {
-  padding: .5em 0;
+  padding: .5rem 0;
 }
 
-.code-panel, .code-editor, .code-editor .CodeMirror {
+.code-panel, .code-editor .CodeMirror {
   height: 100%;
 }
+
+.code-editor {
+  height: calc(100% - 3.375rem);
+}
+
 
 #chart-panel {
   flex: 1;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
问题描述如下：
1. html标签不该被隐藏
![1](https://user-images.githubusercontent.com/22412030/33702629-753849a8-db5f-11e7-83cc-155330d107ef.png)
2. 在最下方敲击几个回车后，上面的按钮被挤出去，滚动也不能恢复
![2](https://user-images.githubusercontent.com/22412030/33702659-917ca712-db5f-11e7-8bd9-b86afd3b15df.png)
修复完样子如下：
![3](https://user-images.githubusercontent.com/22412030/33702669-9bccbd38-db5f-11e7-8dfa-73e608400944.png)
