### PR TITLE
fix: set theme for legend.html but not work

### DIFF
--- a/src/component/legend/category.js
+++ b/src/component/legend/category.js
@@ -6,7 +6,6 @@ const Util = require('../../util');
 const Base = require('./base');
 const { DomUtil, Event, Group } = require('@antv/g');
 const Global = require('../../global');
-const LEGEND_STYLE = Global.legend.html;
 
 const CONTAINER_CLASS = 'g2-legend';
 const TITLE_CLASS = 'g2-legend-title';
@@ -337,6 +336,7 @@ class Category extends Base {
     const itemListDom = findNodeByClass(legendWrapper, LIST_CLASS);
     const unCheckedColor = self.get('unCheckColor');
     const mode = self.get('selectedMode');
+    const LEGEND_STYLE = Global.legend.html;
 
     DomUtil.modifyCSS(itemListDom, Util.mix({}, LEGEND_STYLE[LIST_CLASS], self.get(LIST_CLASS)));
 


### PR DESCRIPTION
set theme in Global.legend.html, but the chart.legend({ useHtml: true }) still use default theme. Because category.js get the LEGEND_STYLE first and never change even after Global.setTheme(). So I move the LEGEND_STYLE into method  _renderHTML() , and set theme legend.html is ok now.