### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ##### Bug Fixes
 
 * fix tooltip bug. ([2933b777](https://github.com/antvis/g2/commit/2933b7777c4365c5fd8f52bb37fd4ee35250c627))
-* Unified the easing funciton of all geoms. ([78849666](https://github.com/antvis/g2/commit/78849666be78b0b3754c1ed43bfff05e0fff1361))
+* Unified the easing function of all geoms. ([78849666](https://github.com/antvis/g2/commit/78849666be78b0b3754c1ed43bfff05e0fff1361))
 
 #### 3.0.0 (2017-11-22)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,11 +32,11 @@ $ git push origin branch-name
 
 Then you can create a Pull Request at [g2](https://github.com/antvis/g2/pulls).
 
-No one can garantee how much will be remembered about certain PR after some time. To make sure we can easily recap what happened previously, please provide the following information in your PR.
+No one can guarantee how much will be remembered about certain PR after some time. To make sure we can easily recap what happened previously, please provide the following information in your PR.
 
 1. Need: What function you want to achieve (Generally, please point out which issue is related).
 2. Updating Reason: Different with issue. Briefly describe your reason and logic about why you need to make such modification.
-3. Related Testing: Briefly descirbe what part of testing is relevant to your modification.
+3. Related Testing: Briefly describe what part of testing is relevant to your modification.
 4. User Tips: Notice for g2 users. You can skip this part, if the PR is not about update in API or potential compatibility problem.
 
 ### Style Guide
@@ -79,7 +79,7 @@ Use succinct words to describe what did you do in the commit change.
 
 （4）body
 
-Feel free to add more content in the body, if you think subject is not self-explanatory enough, such as what it is the purpose or reasone of you commit.
+Feel free to add more content in the body, if you think subject is not self-explanatory enough, such as what it is the purpose or reasons of you commit.
 
 （5）footer
 
@@ -104,7 +104,7 @@ BREAKING CHANGE:
   Breaks foo.bar api, foo.baz should be used instead
 ```
 
-Look at [these files](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit) for more detials.
+Look at [these files](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit) for more details.
 
 ## Release
 


### PR DESCRIPTION
##### Checklist
- [x] commit message follows commit guidelines

##### Description of change
Fixed some typos in the documentation.
