### PR TITLE
fix: left axis grid cover the axis line

### DIFF
--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -115,6 +115,7 @@ const Theme = {
       line: null,
       tickLine: null,
       grid: {
+        zIndex: -1,
         lineStyle: {
           stroke: '#E9E9E9',
           lineWidth: 1,


### PR DESCRIPTION
If the color of the left axis line is different from the grid line, we will see the gird line overlay on the axis line. So I set the grid default zIndex to -1 to fix it.

Please make sure this change didn't effect other render.
