### PR TITLE
feat(legend): add default size of custom legend marker

### DIFF
--- a/demos/multiple-chart.html
+++ b/demos/multiple-chart.html
@@ -47,7 +47,11 @@
       items: [
         { value: 'waiting', fill: '#3182bd' },
         { value: 'call', fill: '#99d8c9' },
-        { value: 'people', fill: '#fdae6b' }
+        { value: 'people', marker: {
+          symbol: 'square',
+          fill: '#fdae6b'
+          // radius: 4.5
+        } }
       ],
       onClick: ev => {
         const item = ev.item;

--- a/src/chart/controller/legend.js
+++ b/src/chart/controller/legend.js
@@ -6,6 +6,7 @@ const Shape = require('../../geom/shape/index');
 const FIELD_ORIGIN = '_origin';
 const MARGIN = 24;
 const MARGIN_LEGEND = 24;
+const MARKER_SIZE = 4.5;
 const requireAnimationFrameFn = window.requestAnimationFrame || window.mozRequestAnimationFrame ||
   window.webkitRequestAnimationFrame || window.msRequestAnimationFrame;
 
@@ -522,8 +523,10 @@ class LegendController {
         item.marker = {
           symbol: item.marker ? item.marker : 'circle',
           fill: item.fill,
-          radius: 4.5
+          radius: MARKER_SIZE
         };
+      } else {
+        item.marker.radius = item.marker.radius || MARKER_SIZE;
       }
       item.checked = Util.isNil(item.checked) ? true : item.checked;
       item.geom = geom;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

* 用户自定义 legend 时传入 marker 的配置项而不是名称，为了保持兼容性，保持原先的写法，但是在文档中移除。

```js
{ value: 'people', marker: {
          symbol: 'square',
          fill: '#fdae6b'
          // radius: 4.5  
} 
```