### PR TITLE
fix: default style of legend.useHtml has scroll bar

### DIFF
--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -337,7 +337,7 @@ const Theme = {
         height: 'auto',
         width: 'auto',
         position: 'absolute',
-        overflow: 'scroll',
+        overflow: 'auto',
         fontSize: '12px',
         fontFamily: FONT_FAMILY,
         lineHeight: '20px',


### PR DESCRIPTION
Because the default style in Global.legend.html[LEGEND_CONTAINER_CLASS] set "overflow: scroll", the html legend always has the scroll bar. So I set it "overflow: auto" to make it more beautiful.

This issue like this -> https://codepen.io/anon/pen/rpWRyq