### PR TITLE
fix(tooltip): rendering without geoms

### DIFF
--- a/src/chart/controller/tooltip.js
+++ b/src/chart/controller/tooltip.js
@@ -143,7 +143,7 @@ class TooltipController {
     }
 
     return Util.mix(defaultCfg, crosshairsCfg, {
-      isTransposed: geoms[0].get('coord').isTransposed
+      isTransposed: geoms.length && geoms[0].get('coord') ? geoms[0].get('coord').isTransposed : false
     });
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

React 的使用场景下出了一个 BUG，就是在某些情况下 geoms 为空，这时候 tooltip 的渲染就会报错。我先绕过这个错，发个小版本（3.0.4-beta.1）让 BizCharts 调试一下。
