### PR TITLE
Hotfix force fit clear resize timer after destroyed

### DIFF
--- a/src/chart/chart.js
+++ b/src/chart/chart.js
@@ -270,7 +270,7 @@ class Chart extends View {
    */
   forceFit() {
     const self = this;
-    if (self.destroyed) {
+    if (!self || self.destroyed) {
       return;
     }
     const container = self.get('container');

--- a/src/chart/chart.js
+++ b/src/chart/chart.js
@@ -270,6 +270,9 @@ class Chart extends View {
    */
   forceFit() {
     const self = this;
+    if (self.destroyed) {
+      return;
+    }
     const container = self.get('container');
     const oldWidth = self.get('width');
     const width = DomUtil.getWidth(container, oldWidth);
@@ -613,6 +616,7 @@ class Chart extends View {
    */
   destroy() {
     this.emit('beforedestroy');
+    clearTimeout(this.get('resizeTimer'));
     const canvas = this.get('canvas');
     const wrapperEl = this.get('wrapperEl');
     wrapperEl.parentNode.removeChild(wrapperEl);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

BizCharts 现在支持改 Padding 之后自动重绘，这时旧的 chart instance 会被销毁，但 resize 事件是延后 200ms 执行的，就会出现 resize 事件执行时 chart instance 已销毁的问题