### PR TITLE
change downloadImage func

### DIFF
--- a/src/chart/chart.js
+++ b/src/chart/chart.js
@@ -554,9 +554,13 @@ class Chart extends View {
   downloadImage(name) {
     const dataURL = this.toDataURL();
     const link = document.createElement('a');
-    link.download = (name || 'chart') + '.png';
-    link.href = dataURL.replace('image/png', 'image/octet-stream');
-    link.click();
+    link.addEventListener('click', function() {
+      link.download = (name || 'chart') + '.png';
+      link.href = dataURL.replace('image/png', 'image/octet-stream');
+    });
+    const e = document.createEvent('MouseEvents');
+    e.initEvent('click', false, false);
+    link.dispatchEvent(e);
     return dataURL;
   }
 


### PR DESCRIPTION
For compatible FireFox (-v 57.0.4 in macOS)

The function downloadImage of chart is not work in FireFox, because of in Firefox, you can explicitly add the created element to the DOM【`document.body.appendChild(link)`】 or deal with the commit code.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Description of change
<!-- Provide a description of the change below this comment. -->
