### PR TITLE
fix(legend): html legend checked status error. Closes #422

### DIFF
--- a/src/component/legend/category.js
+++ b/src/component/legend/category.js
@@ -417,11 +417,11 @@ class Category extends Base {
         if (!clickedItem) {
           return;
         }
-        // update checked status
-        clickedItem.checked = (mode === 'single') ? true : !(clickedItem.checked);
         const domClass = parentDom.className;
         const originColor = parentDom.getAttribute('data-color');
         if (mode === 'single') { // 单选模式
+          // update checked status
+          clickedItem.checked = true;
           // 其他图例项全部置灰
           Util.each(childNodes, child => {
             if (child !== parentDom) {
@@ -453,6 +453,8 @@ class Category extends Base {
           if (!this.get('allowAllCanceled') && clickedItemChecked && count === 1) {
             return;
           }
+          // 在判断最后一个图例后再更新checked状态，防止点击最后一个图例item时图例样式没有变化但是checked状态改变了 fix #422
+          clickedItem.checked = !clickedItem.checked;
           if (clickedItemChecked) {
             if (markerDom) {
               markerDom.style.backgroundColor = unCheckedColor;


### PR DESCRIPTION
- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
问题复现与 Issue #422 ，由于https://github.com/antvis/g2/blob/master/src/component/legend/category.js#L421 这里更新checked状态的时机不对导致的。于是这里把更新时机往后移，再判断跳过最后一个图例item的逻辑（L453）后面再作修改。由于比较难提供测试样例就没有添加对应的测试。
