### PR TITLE
fix(scale): fixed bug of #520

### DIFF
--- a/src/geom/label/pie-labels.js
+++ b/src/geom/label/pie-labels.js
@@ -104,6 +104,12 @@ class PieLabels extends PolarLabels {
     };
   }
 
+  getDefaultOffset() {
+    const labelCfg = this.get('label');
+    const offset = labelCfg.offset || 0;
+    return offset;
+  }
+
   /**
    * @protected
    * to avoid overlapping
@@ -116,6 +122,7 @@ class PieLabels extends PolarLabels {
     if (offset > 0) {
       items = self._distribute(items, offset);
     }
+
     return items;
   }
 
@@ -240,6 +247,7 @@ class PieLabels extends PolarLabels {
     const self = this;
     const coord = self.get('coord');
     const center = coord.getCenter();
+
     let align;
     if (point.angle <= Math.PI / 2 && point.x >= center.x) {
       align = 'left';
@@ -269,10 +277,12 @@ class PieLabels extends PolarLabels {
       x: Util.isArray(point.x) ? point.x[0] : point.x,
       y: point.y[0]
     };
+    self.transLabelPoint(startPoint); // 转换到画布坐标，如果坐标系发生改变
     const endPoint = {
       x: Util.isArray(point.x) ? point.x[1] : point.x,
       y: point.y[1]
     };
+    self.transLabelPoint(endPoint); // 转换到画布坐标，如果坐标系发生改变
     let angle;
     const startAngle = PathUtil.getPointAngle(coord, startPoint);
     if (point.points && point.points[0].y === point.points[1].y) {

--- a/src/scale/linear.js
+++ b/src/scale/linear.js
@@ -155,6 +155,11 @@ class Linear extends Base {
           ticks.push(tick);
         }
       });
+      // 如果 ticks 为空，直接输入最小值、最大值
+      if (!ticks.length) {
+        ticks.push(self.min);
+        ticks.push(self.max);
+      }
       self.ticks = ticks;
     }
   }

--- a/test/bugs/issue-378-spec.js
+++ b/test/bugs/issue-378-spec.js
@@ -131,7 +131,7 @@ describe('#378', () => {
       // chart.changeData(data);
       chart.destroy();
       done();
-    }, 500);
+    }, 800);
   });
 
   it('animate dodge label override', done => {

--- a/test/bugs/issue-500-spec.js
+++ b/test/bugs/issue-500-spec.js
@@ -1,0 +1,46 @@
+const G2 = require('../../src/index');
+const expect = require('chai').expect;
+
+describe('#500', () => {
+  it('after pie rotated, label unchange', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const data = [
+      { genre: 'Sports', sold: 275, type: '1' },
+      { genre: 'Strategy', sold: 115, type: '1' },
+      { genre: 'Action', sold: 120, type: '1' },
+      { genre: 'Shooter', sold: 350, type: '1' },
+      { genre: 'Other', sold: 150, type: '1' }
+    ];
+
+    const chart = new G2.Chart({
+      container: div,
+      width: 500,
+      height: 540,
+      animate: false
+    });
+    chart.source(data);
+
+    const interval = chart.intervalStack()
+      .position('sold')
+      .color('genre')
+      .label('genre', {
+        offset: 20
+      });
+
+    chart.coord('theta', {
+      radius: 0.8
+    });
+
+    chart.render();
+    const labels = interval.get('labelContainer').get('labelsGroup').get('items');
+
+    chart.coord('theta', {
+      radius: 0.8
+    }).rotate(120);
+    chart.repaint();
+    const changeLabels = interval.get('labelContainer').get('labelsGroup').get('items');
+    expect(labels[0].x).not.equal(changeLabels[0].x);
+    expect(labels[0].y).not.equal(changeLabels[0].y);
+  });
+});

--- a/test/bugs/issue-520-spec.js
+++ b/test/bugs/issue-520-spec.js
@@ -1,0 +1,66 @@
+const G2 = require('../../src/index');
+const expect = require('chai').expect;
+
+describe('#520', () => {
+  it('time as y axis,double axis can not show', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const data = [
+      {
+        startTime: '2018-12-12 19:28:41',
+        duration: 3,
+        period: '2018-12-8 19:28:41'
+      },
+      {
+        startTime: '2018-12-12 19:33:11',
+        duration: 3,
+        period: '2018-12-9 19:33:11'
+      },
+      {
+        startTime: '2018-12-12 19:37:17',
+        duration: 4,
+        period: '2018-12-10 19:37:17'
+      },
+      {
+        startTime: '2018-12-12 19:28:30',
+        duration: 3,
+        period: '2018-12-11 19:28:30'
+      },
+      {
+        startTime: '2018-12-12 19:33:01',
+        duration: 4,
+        period: '2018-12-12 19:33:01'
+      },
+      {
+        startTime: '2018-12-12 19:37:17',
+        duration: 4,
+        period: '2018-12-12 19:37:17'
+      },
+      // 如果注释调下面这一条数据，则没有问题
+      {
+        startTime: '2018-12-12 01:45:28',
+        duration: 4,
+        period: '2018-12-12 01:45:28'
+      }
+    ];
+
+    const chart = new G2.Chart({
+      container: div,
+      width: 500,
+      height: 540,
+      animate: true
+    });
+    chart.source(data, {
+      startTime: {
+        mask: 'HH:mm:ss'
+      }
+    });
+    // chart.interval().position('period*duration');
+
+    // create point plot
+    const line = chart.line().position('period*startTime').color('#1ac44d');
+    // Step 4: 渲染图表
+    chart.render();
+    expect(line.getYScale().ticks.length).equal(2);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
* #520  由于目前 time scale 为了避免一次排序，所以仅仅取了第一个时间点和第二个时间点作为最小的间距，正好给出的 demo 的数据，第一个时间点和第二个时间点的日期间隔过大，导致仅生成了两个 ticks，而nice:f alse 又把两个坐标点都去掉了，目前先修复这个坐标轴不显示的问题。后面最小时间间隔的计算再进行调整。

* #500 文本布局时坐标系旋转时，需要将坐标转换成画布坐标，defaultOffset 的计算在饼图下也不应该计算，直接返回默认的即可。