### PR TITLE
Linear category axis

### DIFF
--- a/src/chart/controller/axis.js
+++ b/src/chart/controller/axis.js
@@ -353,7 +353,7 @@ class AxisController {
             });
           }
         });
-      }     
+      }
       cfg.grid.items = gridPoints;
       cfg.grid.tickValues = tickValues;
     }

--- a/src/chart/controller/axis.js
+++ b/src/chart/controller/axis.js
@@ -353,10 +353,11 @@ class AxisController {
             });
           }
         });
-      }
+      }     
       cfg.grid.items = gridPoints;
       cfg.grid.tickValues = tickValues;
     }
+    cfg.type = scale.type;
     return cfg;
   }
 

--- a/src/component/axis/base.js
+++ b/src/component/axis/base.js
@@ -65,7 +65,7 @@ class Base extends Group {
         textStyle: {} // 坐标轴标题样式
       },
       autoPaint: true,
-      alignWithLabel:false
+      alignWithLabel: false
     };
   }
 
@@ -182,24 +182,26 @@ class Base extends Group {
     }
   }
 
-  _processCatTicks(){
+  _processCatTicks() {
     const self = this;
     const labelCfg = self.get('label');
-    const subTickCount = self.get('subTickCount');
     const tickLineCfg = self.get('tickLine');
     let ticks = self.get('ticks');
     ticks = self._parseTicks(ticks);
-    const tickSeg = (ticks[1].value - ticks[0].value)/2;
+    let tickSeg = 0;
+    if (ticks.length > 1) {
+      tickSeg = (ticks[1].value - ticks[0].value) / 2;
+    }
 
-    Util.each(ticks, function(tick,index){
+    Util.each(ticks, function(tick, index) {
       const tickPoint = self.getTickPoint(tick.value, index);
-      const tickPoint0 = self.getTickPoint(tick.value-tickSeg, index);
-      const tickPoint1 = self.getTickPoint(tick.value+tickSeg, index);
-      if(tickLineCfg) {
+      const tickPoint0 = self.getTickPoint(tick.value - tickSeg, index);
+      const tickPoint1 = self.getTickPoint(tick.value + tickSeg, index);
+      if (tickLineCfg) {
         self._addTickItem(index, tickPoint0, tickLineCfg.length);
         self._addTickItem(index, tickPoint1, tickLineCfg.length);
       }
-      if(labelCfg){
+      if (labelCfg) {
         self.addLabel(tick, tickPoint, index);
       }
     });
@@ -297,10 +299,10 @@ class Base extends Group {
 
   paint() {
     this._renderLine();
-    const type = this.get("type");
-    if(type=="cat" || type=="timecat"){
+    const type = this.get('type');
+    if (type === 'cat' || type === 'timecat') {
       this._processCatTicks();
-    }else{
+    } else {
       this._processTicks();
     }
     this._renderTicks();

--- a/src/component/axis/base.js
+++ b/src/component/axis/base.js
@@ -64,7 +64,8 @@ class Base extends Group {
         autoRotate: true, // 文本是否自动旋转
         textStyle: {} // 坐标轴标题样式
       },
-      autoPaint: true
+      autoPaint: true,
+      alignWithLabel:false
     };
   }
 
@@ -181,6 +182,29 @@ class Base extends Group {
     }
   }
 
+  _processCatTicks(){
+    const self = this;
+    const labelCfg = self.get('label');
+    const subTickCount = self.get('subTickCount');
+    const tickLineCfg = self.get('tickLine');
+    let ticks = self.get('ticks');
+    ticks = self._parseTicks(ticks);
+    const tickSeg = (ticks[1].value - ticks[0].value)/2;
+
+    Util.each(ticks, function(tick,index){
+      const tickPoint = self.getTickPoint(tick.value, index);
+      const tickPoint0 = self.getTickPoint(tick.value-tickSeg, index);
+      const tickPoint1 = self.getTickPoint(tick.value+tickSeg, index);
+      if(tickLineCfg) {
+        self._addTickItem(index, tickPoint0, tickLineCfg.length);
+        self._addTickItem(index, tickPoint1, tickLineCfg.length);
+      }
+      if(labelCfg){
+        self.addLabel(tick, tickPoint, index);
+      }
+    });
+  }
+
   _processTicks() {
     const self = this;
     const labelCfg = self.get('label');
@@ -273,7 +297,12 @@ class Base extends Group {
 
   paint() {
     this._renderLine();
-    this._processTicks();
+    const type = this.get("type");
+    if(type=="cat" || type=="timecat"){
+      this._processCatTicks();
+    }else{
+      this._processTicks();
+    }
     this._renderTicks();
     this._renderGrid();
     const labelCfg = this.get('label');


### PR DESCRIPTION
坐标轴样式根据linear和category区分
使用：
默认为linear和cat样式分开
![image](https://user-images.githubusercontent.com/5888974/40528263-f37d0694-6022-11e8-82ac-efa51744813a.png)
如果在axis配置项设置为alignWithLabel:true,则cat数据坐标轴回到3.1默认状态：
![image](https://user-images.githubusercontent.com/5888974/40528378-6fba089c-6023-11e8-86d9-0eff41b27245.png)

—————————————————————————————

我们先讨论下这样区分可不可行，如果可行的话我把用例和文档加上
