### PR TITLE
禁用crosshair辅助线的捕获

### DIFF
--- a/src/component/tooltip/index.js
+++ b/src/component/tooltip/index.js
@@ -317,6 +317,7 @@ class Tooltip extends Base {
   _addCrossLineShape(attrs, type) {
     const crosshairsGroup = this.get('crosshairsGroup');
     const shape = crosshairsGroup.addShape('line', {
+      capture: false,
       attrs
     });
     shape.hide();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
将crosshair的辅助线中增加capture属性设置为false，使其能够在鼠标滑动后不触发事件