### PR TITLE
feat(legend):extend current four legend positions to twelve

### DIFF
--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -330,25 +330,8 @@ const Theme = {
     // 在theta坐标系下的饼图文本的样式
   },
   legend: {
-    right: {
-      position: 'right',
-      layout: 'vertical',
-      itemMarginBottom: 8, // layout 为 vertical 时各个图例项的间距
-      width: 16,
-      height: 156,
-      title: null,
-      textStyle: {
-        fill: '#8C8C8C',
-        fontSize: 12,
-        textAlign: 'start',
-        textBaseline: 'middle',
-        lineHeight: 20,
-        fontFamily: FONT_FAMILY
-      }, // 图例项文本的样式
-      unCheckColor: '#bfbfbf'
-    },
-    left: {
-      position: 'left',
+    left_top: {
+      position: [ 'left', 'top' ],
       layout: 'vertical',
       itemMarginBottom: 8,
       width: 16,
@@ -364,8 +347,93 @@ const Theme = {
       }, // 图例项文本的样式
       unCheckColor: '#bfbfbf'
     },
-    top: {
-      position: 'top',
+    left_center: {
+      position: [ 'left', 'center' ],
+      layout: 'vertical',
+      itemMarginBottom: 8,
+      width: 16,
+      height: 156,
+      title: null,
+      textStyle: {
+        fill: '#8C8C8C',
+        fontSize: 12,
+        textAlign: 'start',
+        textBaseline: 'middle',
+        lineHeight: 20,
+        fontFamily: FONT_FAMILY
+      }, // 图例项文本的样式
+      unCheckColor: '#bfbfbf'
+    },
+    left_bottom: {
+      position: [ 'left', 'bottom' ],
+      layout: 'vertical',
+      itemMarginBottom: 8,
+      width: 16,
+      height: 156,
+      title: null,
+      textStyle: {
+        fill: '#8C8C8C',
+        fontSize: 12,
+        textAlign: 'start',
+        textBaseline: 'middle',
+        lineHeight: 20,
+        fontFamily: FONT_FAMILY
+      }, // 图例项文本的样式
+      unCheckColor: '#bfbfbf'
+    },
+    right_top: {
+      position: [ 'right', 'top' ],
+      layout: 'vertical',
+      itemMarginBottom: 8,
+      width: 16,
+      height: 156,
+      title: null,
+      textStyle: {
+        fill: '#8C8C8C',
+        fontSize: 12,
+        textAlign: 'start',
+        textBaseline: 'middle',
+        lineHeight: 20,
+        fontFamily: FONT_FAMILY
+      }, // 图例项文本的样式
+      unCheckColor: '#bfbfbf'
+    },
+    right_center: {
+      position: [ 'right', 'center' ],
+      layout: 'vertical',
+      itemMarginBottom: 8,
+      width: 16,
+      height: 156,
+      title: null,
+      textStyle: {
+        fill: '#8C8C8C',
+        fontSize: 12,
+        textAlign: 'start',
+        textBaseline: 'middle',
+        lineHeight: 20,
+        fontFamily: FONT_FAMILY
+      }, // 图例项文本的样式
+      unCheckColor: '#bfbfbf'
+    },
+    right_bottom: {
+      position: [ 'right', 'bottom' ],
+      layout: 'vertical',
+      itemMarginBottom: 8,
+      width: 16,
+      height: 156,
+      title: null,
+      textStyle: {
+        fill: '#8C8C8C',
+        fontSize: 12,
+        textAlign: 'start',
+        textBaseline: 'middle',
+        lineHeight: 20,
+        fontFamily: FONT_FAMILY
+      }, // 图例项文本的样式
+      unCheckColor: '#bfbfbf'
+    },
+    top_left: {
+      position: [ 'top', 'left' ],
       offset: 6,
       layout: 'horizontal',
       title: null,
@@ -382,12 +450,84 @@ const Theme = {
       }, // 图例项文本的样式
       unCheckColor: '#bfbfbf'
     },
-    bottom: {
-      position: 'bottom',
-      offset: 58,
+    top_center: {
+      position: [ 'top', 'center' ],
+      offset: 6,
       layout: 'horizontal',
       title: null,
-      itemGap: 24,
+      itemGap: 10,
+      width: 156,
+      height: 16,
+      textStyle: {
+        fill: '#8C8C8C',
+        fontSize: 12,
+        textAlign: 'start',
+        textBaseline: 'middle',
+        lineHeight: 20,
+        fontFamily: FONT_FAMILY
+      }, // 图例项文本的样式
+      unCheckColor: '#bfbfbf'
+    },
+    top_right: {
+      position: [ 'top', 'right' ],
+      offset: 6,
+      layout: 'horizontal',
+      title: null,
+      itemGap: 10,
+      width: 156,
+      height: 16,
+      textStyle: {
+        fill: '#8C8C8C',
+        fontSize: 12,
+        textAlign: 'start',
+        textBaseline: 'middle',
+        lineHeight: 20,
+        fontFamily: FONT_FAMILY
+      }, // 图例项文本的样式
+      unCheckColor: '#bfbfbf'
+    },
+    bottom_left: {
+      position: [ 'bottom', 'left' ],
+      offset: 6,
+      layout: 'horizontal',
+      title: null,
+      itemGap: 10,
+      width: 156,
+      height: 16,
+      textStyle: {
+        fill: '#8C8C8C',
+        fontSize: 12,
+        textAlign: 'start',
+        textBaseline: 'middle',
+        lineHeight: 20,
+        fontFamily: FONT_FAMILY
+      }, // 图例项文本的样式
+      unCheckColor: '#bfbfbf'
+    },
+    bottom_center: {
+      position: [ 'bottom', 'center' ],
+      offset: 6,
+      layout: 'horizontal',
+      title: null,
+      itemGap: 10,
+      width: 156,
+      height: 16,
+      textStyle: {
+        fill: '#8C8C8C',
+        fontSize: 12,
+        textAlign: 'start',
+        textBaseline: 'middle',
+        lineHeight: 20,
+        fontFamily: FONT_FAMILY
+      }, // 图例项文本的样式
+      unCheckColor: '#bfbfbf'
+    },
+    bottom_right: {
+      position: [ 'bottom', 'right' ],
+      offset: 6,
+      layout: 'horizontal',
+      title: null,
+      itemGap: 10,
       width: 156,
       height: 16,
       textStyle: {

--- a/test/bugs/issue-406-spec.js
+++ b/test/bugs/issue-406-spec.js
@@ -37,7 +37,7 @@ describe('#406', () => {
 
     chart.render();
 
-    const legend = chart.get('legendController').legends.right[0];
+    const legend = chart.get('legendController').legends.right_bottom[0];
     expect(legend.get('minTextElement').attr('text')).equal('0元');
     chart.destroy();
   });
@@ -77,7 +77,7 @@ describe('#406', () => {
 
     chart.render();
 
-    const legend = chart.get('legendController').legends.right[0];
+    const legend = chart.get('legendController').legends.right_bottom[0];
     expect(legend.get('items')[0].value).equal('Sports-xxx');
     chart.destroy();
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
* 将legend position的'top'、'bottom'、'left'、'right'4个位置扩展至12个
left-top     left-center     left-bottom
right-top  right-top  right-bottom
top-left  top-center  top-bottom
bottom-left  bottom-center  bottom-right
* 用法
chart.legend( {
  position: 'right-center'
});
* 同时向上兼容，保证所有现有的涉及legend position的代码能够正常运行。
chart.legend( {
  position: 'right'
});