### PR TITLE
修复 package.json 中的 main 字段

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.2",
   "description": "the Grammar of Graphics in Javascript",
   "browser": "build/g2.js",
-  "main": "lib/g2.js",
+  "main": "lib/index.js",
   "module": "src/index.js",
   "homepage": "https://github.com/antvis/g2",
   "repository": {


### PR DESCRIPTION
 + fix typescipt requirement issue
 + package.json 中 `main` 字段指向无效，build 过后的 lib 文件夹中并没有 g2.js。
 + 由于 `browser` 字段指向是对的，所以通常使用的时候会直接用 `browser` 代替掉 `main`，所以不会有问题。
 + 在 typescript 中引用的话就会找不到导致编译失败。
<img width="463" alt="2018-06-12 5 43 57" src="https://user-images.githubusercontent.com/566097/41283116-510ec858-6e68-11e8-970f-736768ca3da9.png">
