### PR TITLE
fix(Coord.Polar): 修复极坐标图像超出画布的问题

### DIFF
--- a/src/coord/polar.js
+++ b/src/coord/polar.js
@@ -89,7 +89,7 @@ class Polar extends Base {
   getOneBox() {
     const startAngle = this.startAngle;
     const endAngle = this.endAngle;
-    if (endAngle - startAngle >= Math.PI * 2) {
+    if (Math.abs(endAngle - startAngle) >= Math.PI * 2) {
       return {
         minX: -1,
         maxX: 1,
@@ -100,7 +100,7 @@ class Polar extends Base {
     const xs = [ 0, Math.cos(startAngle), Math.cos(endAngle) ];
     const ys = [ 0, Math.sin(startAngle), Math.sin(endAngle) ];
 
-    for (let i = startAngle; i < endAngle; i += Math.PI / 18) {
+    for (let i = Math.min(startAngle, endAngle); i < Math.max(startAngle, endAngle); i += Math.PI / 18) {
       xs.push(Math.cos(i));
       ys.push(Math.sin(i));
     }

--- a/src/coord/polar.js
+++ b/src/coord/polar.js
@@ -100,11 +100,9 @@ class Polar extends Base {
     const xs = [ 0, Math.cos(startAngle), Math.cos(endAngle) ];
     const ys = [ 0, Math.sin(startAngle), Math.sin(endAngle) ];
 
-    for (let i = -Math.PI * 5 / 2; i < Math.PI * 3 / 2; i += Math.PI / 2) {
-      if (startAngle <= i && i <= endAngle) {
-        xs.push(Math.cos(i));
-        ys.push(Math.sin(i));
-      }
+    for (let i = startAngle; i < endAngle; i += Math.PI / 18) {
+      xs.push(Math.cos(i));
+      ys.push(Math.sin(i));
     }
 
     return {

--- a/test/bugs/issue-689-spec.js
+++ b/test/bugs/issue-689-spec.js
@@ -1,0 +1,93 @@
+const expect = require('chai').expect;
+const Coord = require('../../src/coord/index');
+
+describe('#689 极坐标图形在画布内', () => {
+  it('锐角扇形 宽画布', () => {
+    const width = 800;
+    const height = 400;
+    const startAngle = Math.PI * (8 / 6);
+    const endAngle = Math.PI * (10 / 6);
+
+    const coord = new Coord.Polar({
+      start: { x: 0, y: height },
+      end: { x: width, y: 0 },
+      startAngle,
+      endAngle
+    });
+    for (let i = startAngle; i <= endAngle; i += Math.PI / 180) {
+      const point = {
+        x: Math.cos(i) * coord.radius + coord.center.x,
+        y: Math.sin(i) * coord.radius + coord.center.y
+      };
+      expect(point.x >= 0 && point.x <= width).to.be.true;
+      expect(point.y >= 0 && point.y <= height).to.be.true;
+    }
+    expect(coord.center.y >= 0 && coord.center.y <= height).to.be.true;
+    expect(coord.center.x >= 0 && coord.center.x <= width).to.be.true;
+  });
+  it('锐角扇形 高画布', () => {
+    const width = 400;
+    const height = 800;
+    const startAngle = Math.PI * (7 / 6);
+    const endAngle = Math.PI * (8 / 6);
+
+    const coord = new Coord.Polar({
+      start: { x: 0, y: height },
+      end: { x: width, y: 0 },
+      startAngle,
+      endAngle
+    });
+    for (let i = startAngle; i <= endAngle; i += Math.PI / 180) {
+      const point = {
+        x: Math.cos(i) * coord.radius + coord.center.x,
+        y: Math.sin(i) * coord.radius + coord.center.y
+      };
+      expect(point.x >= 0 && point.x <= width).to.be.true;
+      expect(point.y >= 0 && point.y <= height).to.be.true;
+    }
+    expect(coord.center.y >= 0 && coord.center.y <= height).to.be.true;
+    expect(coord.center.x >= 0 && coord.center.x <= width).to.be.true;
+  });
+  it('钝角扇形 宽画布', () => {
+    const width = 800;
+    const height = 400;
+    const startAngle = Math.PI * (5 / 6);
+    const endAngle = Math.PI * (15 / 6);
+
+    const coord = new Coord.Polar({
+      start: { x: 0, y: height },
+      end: { x: width, y: 0 },
+      startAngle,
+      endAngle
+    });
+    for (let i = startAngle; i <= endAngle; i += Math.PI / 180) {
+      const point = {
+        x: Math.cos(i) * coord.radius + coord.center.x,
+        y: Math.sin(i) * coord.radius + coord.center.y
+      };
+      expect(point.x >= 0 && point.x <= width).to.be.true;
+      expect(point.y >= 0 && point.y <= height).to.be.true;
+    }
+  });
+  it('钝角扇形 高画布', () => {
+    const width = 400;
+    const height = 800;
+    const startAngle = Math.PI * (1 / 6);
+    const endAngle = Math.PI * (12 / 6);
+
+    const coord = new Coord.Polar({
+      start: { x: 0, y: height },
+      end: { x: width, y: 0 },
+      startAngle,
+      endAngle
+    });
+    for (let i = startAngle; i <= endAngle; i += Math.PI / 180) {
+      const point = {
+        x: Math.cos(i) * coord.radius + coord.center.x,
+        y: Math.sin(i) * coord.radius + coord.center.y
+      };
+      expect(point.x >= 0 && point.x <= width).to.be.true;
+      expect(point.y >= 0 && point.y <= height).to.be.true;
+    }
+  });
+});

--- a/test/bugs/issue-689-spec.js
+++ b/test/bugs/issue-689-spec.js
@@ -25,6 +25,29 @@ describe('#689 极坐标图形在画布内', () => {
     expect(coord.center.y >= 0 && coord.center.y <= height).to.be.true;
     expect(coord.center.x >= 0 && coord.center.x <= width).to.be.true;
   });
+  it('锐角扇形 宽画布 反向', () => {
+    const width = 800;
+    const height = 400;
+    const startAngle = Math.PI * (10 / 6);
+    const endAngle = Math.PI * (8 / 6);
+
+    const coord = new Coord.Polar({
+      start: { x: 0, y: height },
+      end: { x: width, y: 0 },
+      startAngle,
+      endAngle
+    });
+    for (let i = startAngle; i <= endAngle; i += Math.PI / 180) {
+      const point = {
+        x: Math.cos(i) * coord.radius + coord.center.x,
+        y: Math.sin(i) * coord.radius + coord.center.y
+      };
+      expect(point.x >= 0 && point.x <= width).to.be.true;
+      expect(point.y >= 0 && point.y <= height).to.be.true;
+    }
+    expect(coord.center.y >= 0 && coord.center.y <= height).to.be.true;
+    expect(coord.center.x >= 0 && coord.center.x <= width).to.be.true;
+  });
   it('锐角扇形 高画布', () => {
     const width = 400;
     const height = 800;

--- a/test/unit/chart/controller/axis-spec.js
+++ b/test/unit/chart/controller/axis-spec.js
@@ -211,7 +211,7 @@ describe('AxisController', function() {
       expect(circleCfg.endAngle).to.equal(3.141592653589794);
       expect(circleCfg.center).to.eql({
         x: 250.70494165327872,
-        y: 124.64752917336064
+        y: 124.94090329888789
       });
     });
 
@@ -265,11 +265,11 @@ describe('AxisController', function() {
       expect(radiusCfg.factor).to.equal(1);
       expect(radiusCfg.start).to.eql({
         x: 250.70494165327872,
-        y: 124.64752917336064
+        y: 124.94090329888789
       });
       expect(radiusCfg.end).to.eql({
         x: 500.00000000000006,
-        y: 151.1982665130035
+        y: 151.49164063853073
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

修复 #689 

修改边缘检测逻辑:  从startAngle到endAngle 每10角度取样
