### PR TITLE
fix(PathUtil.convertPolarPath): 保证极坐标图形圆弧方向为圆心向外

### DIFF
--- a/src/geom/util/path.js
+++ b/src/geom/util/path.js
@@ -65,7 +65,8 @@ function convertPolarPath(pre, cur, coord) {
   // innerRadius = innerRadius || 0;
   const xDim = transposed ? 'y' : 'x';
   const angleRange = Math.abs(curPoint[xDim] - prePoint[xDim]) * (endAngle - startAngle);
-  const direction = curPoint[xDim] >= prePoint[xDim] ? 1 : 0; // 圆弧的方向
+  const _arcDirection = coord.endAngle >= coord.startAngle ? [ 0, 1 ] : [ 1, 0 ]; // 极坐标方向决定哪个方向是`圆弧向外`
+  const direction = _arcDirection[curPoint[xDim] >= prePoint[xDim] ? 1 : 0]; // 描点顺序决定`圆弧的方向`
   const flag = angleRange > Math.PI ? 1 : 0; // 大弧还是小弧标志位
   const convertPoint = coord.convertPoint(curPoint);
   const r = getPointRadius(coord, convertPoint);

--- a/test/bugs/issue-730-spec.js
+++ b/test/bugs/issue-730-spec.js
@@ -1,0 +1,55 @@
+const expect = require('chai').expect;
+const { Canvas } = require('../../src/renderer');
+const Shape = require('../../src/geom/shape/shape');
+const Coord = require('../../src/coord/');
+require('../../src/geom/shape/edge');
+
+const div = document.createElement('div');
+div.id = 'csedge';
+document.body.appendChild(div);
+const canvas = new Canvas({
+  containerId: 'csedge',
+  width: 500,
+  height: 500
+});
+describe('#730', () => {
+  it('arc direction', () => {
+
+    const coord = new Coord.Polar({
+      start: { x: 0, y: 500 },
+      end: { x: 500, y: 0 },
+      startAngle: 6,
+      endAngle: 3,
+      innerRadius: 0.3
+    });
+    const shapeObj = Shape.getShapeFactory('edge');
+    shapeObj._coord = coord;
+    const obj = {
+      x: [ 0.2, 0.4, 0.6, 0.7 ],
+      y: [ 0.5, 0.5, 0.5, 0.5 ]
+    };
+    const points = shapeObj.getShapePoints('arc', obj);
+    const shape = shapeObj.drawShape('arc', {
+      points,
+      color: 'green',
+      isInCircle: true,
+      center: {
+        x: 230,
+        y: 250
+      }
+    }, canvas);
+    expect(shape.attr('path').length).equal(8);
+    expect(shape.attr('path')).eql(
+      [
+        [ 'M', 360.27450827599966, 231.34131348761517 ],
+        [ 'Q', 499.99999999999994, 288.2096172921748, 134.6177879398623, 245.43810097501847 ],
+        [ 'A', 165.84782027366163, 165.84782027366163, 0, 0, 0, 134.6177879398623, 245.43810097501847 ],
+        [ 'A', 165.84782027366163, 165.84782027366163, 0, 0, 1, 173.7033896727621, 214.95367727554216 ],
+        [ 'Q', 499.99999999999994, 288.2096172921748, 269.52359393728557, 194.29089032447982 ],
+        [ 'A', 165.84782027366163, 165.84782027366163, 0, 0, 0, 269.52359393728557, 194.29089032447982 ],
+        [ 'A', 165.84782027366163, 165.84782027366163, 0, 0, 1, 360.27450827599966, 231.34131348761517 ],
+        [ 'Z' ]
+      ]
+    );
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

修复 #730

保证极坐标图形圆弧方向为圆心向外