### PR TITLE
修复如果legend值中存在双引号"时，导致的无法点击触发legend正常操作bug

### DIFF
--- a/src/component/legend/category.js
+++ b/src/component/legend/category.js
@@ -408,7 +408,7 @@ class Category extends Base {
         value,
         color,
         originColor: markerColor,
-        // @2018-07-09 by blue.lb 修复如果legend值中存在双引号"时，导致的无法点击触发legend正常操作bug
+        // @2018-07-09 by blue.lb 修复如果legend值中存在双引号"时, 导致的无法点击触发legend正常操作bug
         originValue: item.value.replace(/\"/g, '&quot;')
       });
       const itemDom = DomUtil.createDom(itemDiv);

--- a/src/component/legend/category.js
+++ b/src/component/legend/category.js
@@ -408,7 +408,8 @@ class Category extends Base {
         value,
         color,
         originColor: markerColor,
-        originValue: item.value
+        // @2018-07-09 by blue.lb 修复如果legend值中存在双引号"时，导致的无法点击触发legend正常操作bug
+        originValue: item.value.replace(/\"/g,'&quot;')
       });
       const itemDom = DomUtil.createDom(itemDiv);
       const markerDom = findNodeByClass(itemDom, MARKER_CLASS);

--- a/src/component/legend/category.js
+++ b/src/component/legend/category.js
@@ -409,7 +409,7 @@ class Category extends Base {
         color,
         originColor: markerColor,
         // @2018-07-09 by blue.lb 修复如果legend值中存在双引号"时，导致的无法点击触发legend正常操作bug
-        originValue: item.value.replace(/\"/g,'&quot;')
+        originValue: item.value.replace(/\"/g, '&quot;')
       });
       const itemDom = DomUtil.createDom(itemDiv);
       const markerDom = findNodeByClass(itemDom, MARKER_CLASS);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
当使用legend的useHtml为true时，由于传入的字段name中存在双引号会直接导致在legend的节点中data-value的数据出现问题，之后点击legend无法顺利隐藏图例，使用正则转义一下