### PR TITLE
fix(legend):chart backplot range calculation

### DIFF
--- a/src/chart/controller/legend.js
+++ b/src/chart/controller/legend.js
@@ -65,10 +65,9 @@ class LegendController {
     if (!backRange) {
       backRange = this.chart.get('backPlot').getBBox();
       const plotRange = this.plotRange;
-      if (backRange.minX === 0 || (
-        backRange.maxX - backRange.minX < plotRange.br.x - plotRange.tl.x) || (
-        backRange.maxY - backRange.minY) < plotRange.br.y - plotRange.tl.y
-      ) { // 如果背景不占宽高，或者背景小于则直接使用 plotRange
+      if (backRange.maxX - backRange.minX < plotRange.br.x - plotRange.tl.x &&
+        backRange.maxY - backRange.minY < plotRange.br.y - plotRange.tl.y) {
+          // 如果背景小于则直接使用 plotRange
         backRange = {
           minX: plotRange.tl.x,
           minY: plotRange.tl.y,

--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -493,7 +493,6 @@ const Theme = {
       width: '5px',
       height: '5px',
       borderRadius: '50%',
-      border: '1px solid #fff',
       display: 'inline-block',
       marginRight: '8px'
     },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
修复了svg支持时变更的backrange计算问题，此问题会导致使用自定义legend和使用guide的场景下legend定位错误。