### PR TITLE
修复线图active高亮不生效的bug

### DIFF
--- a/src/geom/mixin/active.js
+++ b/src/geom/mixin/active.js
@@ -270,6 +270,7 @@ const ActiveMixin = {
         shape.setZIndex(1); // 提前
       } else {
         Util.mix(changeAttrs, {
+          fillOpacity: 0.3,
           // @2018-07-11 by blue.lb 由于线图只有stoke，fillOpacity不生效，最好还是直接改成整个图形透明度opacity
           opacity: 0.3
         });

--- a/src/geom/mixin/active.js
+++ b/src/geom/mixin/active.js
@@ -270,7 +270,8 @@ const ActiveMixin = {
         shape.setZIndex(1); // 提前
       } else {
         Util.mix(changeAttrs, {
-          fillOpacity: 0.3
+          // @2018-07-11 by blue.lb 由于线图只有stoke，fillOpacity不生效，最好还是直接改成整个图形透明度opacity
+          opacity: 0.3
         });
         shape.setZIndex(0);
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
之前萧庆提的issue: https://github.com/antvis/g2/issues/723
看了一下源码确实是一个bug，原因是线图为stoke绘制，fillOpacity不生效，改成了整个shape的透明度，修复这个bug