### PR TITLE
perf(legend): optimize performance of legend filter check

### DIFF
--- a/src/chart/controller/legend.js
+++ b/src/chart/controller/legend.js
@@ -304,6 +304,22 @@ class LegendController {
     return rst;
   }
 
+  _isFilteredBuilder(scale, values) {
+    if (!values || !scale.isCategory) {
+      return () => true;
+    }
+
+    const valuesMap = Util.reduce(values, (acc, val) => Util.assign(acc, {
+      [scale.getText(val)]: 1
+    }), {});
+
+    return value => {
+      value = scale.invert(value);
+      const result = scale.getText(value) in valuesMap;
+      return result;
+    };
+  }
+
   _alignLegend(legend, pre, region, position) {
     const self = this;
     const viewTheme = self.viewTheme;
@@ -446,6 +462,7 @@ class LegendController {
     const plotRange = self.plotRange;
     const posArray = position.split('-');
     const maxLength = (posArray[0] === 'right' || posArray[0] === 'left') ? plotRange.bl.y - plotRange.tr.y : canvas.get('width');
+    const isFiltered = self._isFilteredBuilder(scale, filterVals);
     Util.each(ticks, tick => {
       const text = tick.text;
       const name = text;
@@ -454,7 +471,7 @@ class LegendController {
       const cfg = {
         isInCircle: geom.isInCircle()
       };
-      const checked = filterVals ? self._isFiltered(scale, filterVals, scaleValue) : true;
+      const checked = isFiltered(scaleValue);
 
       const colorAttr = geom.getAttr('color');
       const shapeAttr = geom.getAttr('shape');


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change
优化了在legend非常多的情况下的性能
`useHtml: true`时有1573个legend情况下，`_addCategroyLegend` 的执行时间 4350ms -> 600ms

另外在`useHtml: false`时，`_getNextX`也有同样的性能问题，不过在canvas里这么多legend也显示不下，就没必要优化了。