### PR TITLE
fix(legend):constrain size legend scroll bar size

### DIFF
--- a/src/component/legend/size.js
+++ b/src/component/legend/size.js
@@ -8,6 +8,8 @@ const Global = require('../../global');
 const Continuous = require('./continuous');
 const SLIDER_HEIGHT = 2;
 const CIRCLE_GAP = 8;
+const MAX_SIZE = 15;
+const MIN_SIZE = 5;
 
 class Size extends Continuous {
   getDefaultCfg() {
@@ -48,10 +50,8 @@ class Size extends Continuous {
   }
 
   _renderSliderShape() {
-    const min = this.get('firstItem');
-    const max = this.get('lastItem');
-    const minRadius = parseFloat(min.attrValue);
-    const maxRadius = parseFloat(max.attrValue);
+    const minRadius = MIN_SIZE;
+    const maxRadius = MAX_SIZE;
     const slider = this.get('slider');
     const backgroundElement = slider.get('backgroundElement');
     const layout = this.get('layout');
@@ -155,8 +155,8 @@ class Size extends Continuous {
     const inRange = this.get('inRange');
     const minBlockAttr = Util.mix({}, inRange);
     const maxBlockAttr = Util.mix({}, inRange);
-    const minRadius = parseFloat(min.attrValue);
-    const maxRadius = parseFloat(max.attrValue);
+    const minRadius = MIN_SIZE;
+    const maxRadius = MAX_SIZE;
 
     const minTextAttr = Util.mix({
       text: this._formatItemValue(min.value) + ''
@@ -177,7 +177,6 @@ class Size extends Continuous {
   _bindUI() {
     const self = this;
     if (self.get('slidable')) {
-      // const canvas = self.get('canvas');
       const slider = self.get('slider');
       slider.on('sliderchange', ev => {
         const range = ev.range;
@@ -185,10 +184,8 @@ class Size extends Continuous {
         const lastItemValue = self.get('lastItem').value * 1;
         const minValue = firstItemValue + (range[0] / 100) * (lastItemValue - firstItemValue);
         const maxValue = firstItemValue + (range[1] / 100) * (lastItemValue - firstItemValue);
-        const firstItemRadius = parseFloat(self.get('firstItem').attrValue) * 1;
-        const lastItemRadius = parseFloat(self.get('lastItem').attrValue) * 1;
-        const minRadius = firstItemRadius + (range[0] / 100) * (lastItemRadius - firstItemRadius);
-        const maxRadius = firstItemRadius + (range[1] / 100) * (lastItemRadius - firstItemRadius);
+        const minRadius = MIN_SIZE + (range[0] / 100) * (MAX_SIZE - MIN_SIZE);
+        const maxRadius = MIN_SIZE + (range[1] / 100) * (MAX_SIZE - MIN_SIZE);
         self._updateElement(minValue, maxValue, minRadius, maxRadius);
         const itemFiltered = new Event('itemfilter', ev, true, true);
         itemFiltered.range = [ minValue, maxValue ];

--- a/src/component/legend/slider.js
+++ b/src/component/legend/slider.js
@@ -235,11 +235,13 @@ class Slider extends Group {
   }
 
   _onCanvasMouseMove(ev) {
-    const layout = this.get('layout');
-    if (layout === 'horizontal') {
-      this._updateStatus('x', ev);
-    } else {
-      this._updateStatus('y', ev);
+    if (!this._mouseOutArea(ev)) {
+      const layout = this.get('layout');
+      if (layout === 'horizontal') {
+        this._updateStatus('x', ev);
+      } else {
+        this._updateStatus('y', ev);
+      }
     }
   }
 
@@ -250,6 +252,21 @@ class Slider extends Group {
   _removeDocumentEvents() {
     this.onMouseMoveListener.remove();
     this.onMouseUpListener.remove();
+  }
+
+  _mouseOutArea(ev) {
+    const parent = this.get('parent');
+    const bbox = parent.getBBox();
+    const left = parent.attr('matrix')[6];
+    const top = parent.attr('matrix')[7];
+    const right = left + bbox.width;
+    const bottom = top + bbox.height;
+    const mouseX = ev.clientX;
+    const mouseY = ev.clientY;
+    if (mouseX < left || mouseX > right || mouseY < top || mouseY > bottom) {
+      return true;
+    }
+    return false;
   }
 }
 

--- a/test/unit/component/legend/color-spec.js
+++ b/test/unit/component/legend/color-spec.js
@@ -85,7 +85,7 @@ describe('连续图例 - Color', function() {
     const slider = legend.get('slider');
     const event = new Event('mousedown', {
       pageX: 197,
-      pageY: 260,
+      pageY: 12,
       stopPropagation() {
         return true;
       },
@@ -99,12 +99,12 @@ describe('连续图例 - Color', function() {
     const canvasDOM = canvas.get('el');
     Simulate.simulate(canvasDOM, 'mousemove', {
       clientX: 227,
-      clientY: 260
+      clientY: 12
     });
 
     Simulate.simulate(canvasDOM, 'mouseup', {
       clientX: 227,
-      clientY: 260
+      clientY: 12
     });
     expect(slider.get('middleHandleElement').attr('width')).to.equal(120);
     expect(legend.get('minTextElement').attr('text')).to.equal('20');
@@ -130,7 +130,7 @@ describe('连续图例 - Color', function() {
     const slider = legend.get('slider');
     const event = new Event('mousedown', {
       pageX: 206,
-      pageY: 300,
+      pageY: 100,
       stopPropagation() {
         return true;
       },
@@ -144,12 +144,12 @@ describe('连续图例 - Color', function() {
     const canvasDOM = canvas.get('el');
     Simulate.simulate(canvasDOM, 'mousemove', {
       clientX: 206,
-      clientY: 350
+      clientY: 150
     });
 
     Simulate.simulate(canvasDOM, 'mouseup', {
       clientX: 206,
-      clientY: 350
+      clientY: 150
     });
     expect(slider.get('middleHandleElement').attr('height')).to.equal(50);
     expect(legend.get('maxTextElement').attr('text')).to.equal('50');

--- a/test/unit/component/legend/size-spec.js
+++ b/test/unit/component/legend/size-spec.js
@@ -74,12 +74,12 @@ describe('连续图例 - Size', function() {
     const canvasDOM = canvas.get('el');
     Simulate.simulate(canvasDOM, 'mousemove', {
       clientX: 227,
-      clientY: 260
+      clientY: 50
     });
 
     Simulate.simulate(canvasDOM, 'mouseup', {
       clientX: 227,
-      clientY: 260
+      clientY: 50
     });
     expect(slider.get('middleHandleElement').attr('width')).to.equal(120);
     expect(legend.get('minTextElement').attr('text')).to.equal('18');
@@ -106,7 +106,7 @@ describe('连续图例 - Size', function() {
     const slider = legend.get('slider');
     const event = new Event('mousedown', {
       pageX: 206,
-      pageY: 300,
+      pageY: 100,
       stopPropagation() {
         return true;
       },
@@ -120,12 +120,12 @@ describe('连续图例 - Size', function() {
     const canvasDOM = canvas.get('el');
     Simulate.simulate(canvasDOM, 'mousemove', {
       clientX: 206,
-      clientY: 350
+      clientY: 150
     });
 
     Simulate.simulate(canvasDOM, 'mouseup', {
       clientX: 206,
-      clientY: 350
+      clientY: 150
     });
     expect(slider.get('middleHandleElement').attr('height')).to.equal(50);
     expect(legend.get('maxTextElement').attr('text')).to.equal('30');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
* size-legend的scroll-bar尺寸加约束
* 修复了(size/color legend里slider的mousemove事件，使mousemove的作用域限定在legend本身的区域范围内）
* 将pie chart label的布局算法移植到tail legend，基本解决了纵向布局问题。同时开启了autoLayout配置项，默认开启，如设置为false，则不进行legend的重新布局。
