### PR TITLE
fix(tooltip): Theme.tooltipMarker invalid. Closes #757

### DIFF
--- a/src/component/tooltip/index.js
+++ b/src/component/tooltip/index.js
@@ -427,12 +427,14 @@ class Tooltip extends Base {
     Util.each(markerItems, item => {
       markerGroup.addShape('marker', {
         color: item.color,
-        attrs: Util.mix({}, markerCfg, {
-          x: item.x,
-          y: item.y,
+        attrs: Util.mix({
+          // fix: Theme.tooltipMarker invalid
           fill: item.color,
           symbol: 'circle',
           shadowColor: item.color
+        }, markerCfg, {
+          x: item.x,
+          y: item.y
         })
       });
     });


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change

将 tooltip.setMarkers 函数中 markerCfg 的 fill, symbol, shadowColor 属性调整到前面作为默认项。可以被 Theme 设置覆盖。
