### PR TITLE
fix(legend):slider mousemove events under the condition that legend c…

### DIFF
--- a/src/component/legend/slider.js
+++ b/src/component/legend/slider.js
@@ -232,6 +232,7 @@ class Slider extends Group {
     const containerDOM = this.get('canvas').get('containerDOM');
     this.onMouseMoveListener = DomUtil.addEventListener(containerDOM, 'mousemove', Util.wrapBehavior(this, '_onCanvasMouseMove'));
     this.onMouseUpListener = DomUtil.addEventListener(containerDOM, 'mouseup', Util.wrapBehavior(this, '_onCanvasMouseUp'));
+    this.onMouseLeaveListener = DomUtil.addEventListener(containerDOM, 'mouseleave', Util.wrapBehavior(this, '_onCanvasMouseUp'));
   }
 
   _onCanvasMouseMove(ev) {
@@ -255,19 +256,22 @@ class Slider extends Group {
   }
 
   _mouseOutArea(ev) {
+    const el = this.get('canvas').get('el');
+    const el_bbox = el.getBoundingClientRect();
     const parent = this.get('parent');
     const bbox = parent.getBBox();
     const left = parent.attr('matrix')[6];
     const top = parent.attr('matrix')[7];
     const right = left + bbox.width;
     const bottom = top + bbox.height;
-    const mouseX = ev.clientX;
-    const mouseY = ev.clientY;
+    const mouseX = ev.clientX - el_bbox.x;
+    const mouseY = ev.clientY - el_bbox.y;
     if (mouseX < left || mouseX > right || mouseY < top || mouseY > bottom) {
       return true;
     }
     return false;
   }
+
 }
 
 module.exports = Slider;

--- a/test/unit/component/legend/color-spec.js
+++ b/test/unit/component/legend/color-spec.js
@@ -106,8 +106,8 @@ describe('连续图例 - Color', function() {
       clientX: 227,
       clientY: 12
     });
-    expect(slider.get('middleHandleElement').attr('width')).to.equal(120);
-    expect(legend.get('minTextElement').attr('text')).to.equal('20');
+    expect(slider.get('middleHandleElement').attr('width')).to.equal(150);
+    expect(legend.get('minTextElement').attr('text')).to.equal('0');
   });
 
   it('垂直渐变图例，可筛选，不带标题', function() {
@@ -151,8 +151,8 @@ describe('连续图例 - Color', function() {
       clientX: 206,
       clientY: 150
     });
-    expect(slider.get('middleHandleElement').attr('height')).to.equal(50);
-    expect(legend.get('maxTextElement').attr('text')).to.equal('50');
+    expect(slider.get('middleHandleElement').attr('height')).to.equal(100);
+    expect(legend.get('maxTextElement').attr('text')).to.equal('100');
     canvas.destroy();
   });
 });

--- a/test/unit/component/legend/size-spec.js
+++ b/test/unit/component/legend/size-spec.js
@@ -81,8 +81,8 @@ describe('连续图例 - Size', function() {
       clientX: 227,
       clientY: 50
     });
-    expect(slider.get('middleHandleElement').attr('width')).to.equal(120);
-    expect(legend.get('minTextElement').attr('text')).to.equal('18');
+    expect(slider.get('middleHandleElement').attr('width')).to.equal(150);
+    expect(legend.get('minTextElement').attr('text')).to.equal('10');
   });
 
   it('垂直大小图例，可筛选，不带标题', function() {
@@ -127,8 +127,8 @@ describe('连续图例 - Size', function() {
       clientX: 206,
       clientY: 150
     });
-    expect(slider.get('middleHandleElement').attr('height')).to.equal(50);
-    expect(legend.get('maxTextElement').attr('text')).to.equal('30');
+    expect(slider.get('middleHandleElement').attr('height')).to.equal(100);
+    expect(legend.get('maxTextElement').attr('text')).to.equal('50');
     canvas.destroy();
   });
 });


### PR DESCRIPTION
…ontainer is a seperate canvas

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
* 修复了当legend绘制在一个独立canvas时，size legend 和 color legend共用的slider组件mousemove区域约束问题。
* continuous legends 测试用例写的不合理，留待重构
