### PR TITLE
bugfix/legend: fix continuous legend got error position when useHtml is true

### DIFF
--- a/src/component/legend/base.js
+++ b/src/component/legend/base.js
@@ -28,6 +28,11 @@ class Base extends Group {
        */
       useHtml: false,
       /**
+       * useHtml 为 true 时生效，用于自动定位
+       * @type {[type]}
+       */
+      autoPosition: true,
+      /**
        * 图例是否绘制在绘图区域内
        * @type {Boolean}
        */

--- a/src/component/legend/category.js
+++ b/src/component/legend/category.js
@@ -150,11 +150,6 @@ class Category extends Base {
        * @type {Boolean}
        */
       useHtml: false,
-      /**
-       * useHtml 为 true 时生效，用于自动定位
-       * @type {[type]}
-       */
-      autoPosition: true,
       container: null,
       /**
        * 使用html时的外层模板
@@ -782,6 +777,8 @@ class Category extends Base {
         left: x + 'px',
         top: y + 'px'
       });
+      this.set('x', x);
+      this.set('y', y);
     } else {
       super.move(x, y);
     }


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change
在useHtml=true时，category legend会使用html渲染，而continuous legend还是在canvas里渲染，这时候一是没有`autoPosition`无法自动定位，二是拿不到`category legend`的坐标导致计算坐标失败

![127 0 0 1_2046_demos_index html](https://user-images.githubusercontent.com/6942296/43683255-5d9b155a-98ba-11e8-81b4-ef6c3d0c640f.png)
![127 0 0 1_2046_demos_index html 1](https://user-images.githubusercontent.com/6942296/43683257-61adee24-98ba-11e8-9bcb-86b34633c3da.png)
