### PR TITLE
判断layer销毁不执行创建shape的行为

### DIFF
--- a/src/component/guide/region-filter.js
+++ b/src/component/guide/region-filter.js
@@ -29,6 +29,8 @@ class RegionFilter extends Base {
     const view = self.view;
     const layer = group.addGroup();
     view.once('afterpaint', function() {
+      // 2018-08-08 by blue.lb padding为auto时，会导致重新绘制一次，这时候layer已经被销毁了
+      if (layer.get('destroyed')) return;
       self._drawShapes(view, layer);
       const clip = self._drawClip(coord, group);
       layer.attr({ clip });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
https://github.com/antvis/g2/blob/42c90bd66155bf1b2f1ff97c619bb89721387fc4/src/component/guide/region-filter.js#L32
https://riddle.alibaba-inc.com/riddles/7406c006
当padding为auto时，由于重绘导致第一次layer会销毁，闭包无法释放，直接写入shape会报错，判断是否已经销毁了，如果销毁了就不执行了
