### PR TITLE
 d.ts文件方法定义bug，修改tooltip方法，旧的存在bug，导致typscript报错，无法使用第一个方法。

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -492,8 +492,7 @@ declare namespace G2 {
     legend(option: boolean): this;
     legend(field: string, option: boolean): this;
     legend(field: string, legendConfig: LegendConfig): this;
-    tooltip(tooltipConfig: TooltipConfig): this;
-    tooltip(tooltipConfig: boolean): this;
+    tooltip(tooltipConfig: TooltipConfig | boolean): this;
     view: (
       option?: {
         start?: { x: number; y: number };


### PR DESCRIPTION
    原来为：
   tooltip(tooltipConfig: TooltipConfig): this;
    tooltip(tooltipConfig: boolean): this;
改为：
 tooltip(tooltipConfig: TooltipConfig | boolean ): this;

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
