### PR TITLE
修复多面图时导致的legend显示位置bug

### DIFF
--- a/src/chart/controller/legend.js
+++ b/src/chart/controller/legend.js
@@ -333,7 +333,8 @@ class LegendController {
       height = plotRange.br.y;
       x = self._getXAlign(posArray[0], width, region, backRange, legendWidth, borderMargin);
       if (pre) {
-        y = pre.get('y') + pre.getHeight() + innerMargin;
+        // @2018-10-19 by blue.lb 由于legend中并不存在y属性，这里需要先获取group再获取y值
+        y = pre.get('group').get('y') + pre.getHeight() + innerMargin;
       } else {
         y = self._getYAlignVertical(posArray[1], height, tempoRegion, backRange, 0, borderMargin, canvas.get('height'));
       }
@@ -341,7 +342,8 @@ class LegendController {
       y = self._getYAlignHorizontal(posArray[0], height, region, backRange, legendHeight, borderMargin);
       if (pre) {
         const preWidth = pre.getWidth();
-        x = pre.get('x') + preWidth + innerMargin;
+        // @2018-10-19 by blue.lb 由于legend中并不存在x属性，这里需要先获取group再获取x值
+        x = pre.get('group').get('x') + preWidth + innerMargin;
       } else {
         x = self._getXAlign(posArray[1], width, tempoRegion, backRange, 0, borderMargin);
         if (posArray[1] === 'right') x = plotRange.br.x - tempoRegion.totalWidth;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
问题描述：https://riddle.alibaba-inc.com/riddles/c8576dc9
如上述riddle展示的，新版本g23.3.1中由于legend直接获取x和y的值为undefined，导致后续矩阵计算时出现NaN，引起legend位置错乱。

修复方案：
获取的实际x和y的值是在legend内部的示例group上，所以加深获取一层，通过先获取group再获取其上的坐标值