### PR TITLE
fix(legend):tail-legend position incorerct when the padding-top prope…

### DIFF
--- a/src/component/legend/tail.js
+++ b/src/component/legend/tail.js
@@ -116,6 +116,8 @@ class Tail extends Category {
     const self = this;
     const geom = self.get('geom');
     if (geom) {
+      const groupMatrix = self.get('group').attr('matrix');
+      groupMatrix[7] = 0;
       const dataArray = self.get('geom').get('dataArray');
       const groups = this.get('itemsGroup').get('children');
       let index = 0;
@@ -127,10 +129,7 @@ class Tail extends Category {
         }
         const groupHeight = groupItem.getBBox().height;
         const x = groupItem.get('x');
-        const y = lastY - (groupHeight / 2);
-
-        // groupItem.set('y', lastY - groupHeight);
-        // adjust y position by previous
+        const y = lastY - groupHeight / 2;
         groupItem.translate(x, y);
         index++;
       });
@@ -138,7 +137,6 @@ class Tail extends Category {
       if (self.get('autoLayout')) {
         self._antiCollision(groups);
       }
-
     }
   }
 

--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -458,7 +458,7 @@ const Theme = {
       },
       unCheckColor: '#bfbfbf'
     },
-    margin: [ 0, 20, 24, 5 ], // 图例跟四个边的坐标轴、绘图区域的间距
+    margin: [ 0, 5, 24, 5 ], // 图例跟四个边的坐标轴、绘图区域的间距
     legendMargin: 24 // 图例之间的间距
   },
   tooltip: {

--- a/test/bugs/issue-472-spec.js
+++ b/test/bugs/issue-472-spec.js
@@ -43,7 +43,7 @@ describe('#472', () => {
     chart.repaint();
 
     plotRange = chart.get('plotRange');
-    expect(500 - plotRange.tr.x > 85).equal(true);
+    expect(500 - plotRange.tr.x > 75).equal(true);
 
     chart.legend({ position: 'top' });
     chart.repaint();
@@ -88,6 +88,6 @@ describe('#472', () => {
     chart.repaint();
 
     plotRange = chart.get('plotRange');
-    expect(500 - plotRange.tr.x > 85).equal(true);
+    expect(500 - plotRange.tr.x > 75).equal(true);
   });
 });


### PR DESCRIPTION
…rty of chart was manully setted

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

* 修复手动设置padding-top时，tail-legend位置错误问题
* 上次kick off与设计师商议后，将legend的padding-right设置为8像素
