### PR TITLE
Protect label of `null` value.

### DIFF
--- a/src/geom/label/geom-labels.js
+++ b/src/geom/label/geom-labels.js
@@ -194,6 +194,9 @@ class GeomLabels extends Group {
 */
   adjustItems(items) {
     Util.each(items, function(item) {
+      if (!item) {
+        return;
+      }
       if (item.offsetX) {
         item.x += item.offsetX;
       }


### PR DESCRIPTION
Protect `items`, because `getLabelItems` may get the result of `null`.