### PR TITLE
fix issue1014

### DIFF
--- a/src/theme/dark.js
+++ b/src/theme/dark.js
@@ -165,13 +165,13 @@ const DarkTheme = Util.deepMix({}, BasicTheme, {
   },
   tooltipCrosshairsRect: {
     type: 'rect',
-    style: {
+    rectStyle: {
       fill: '#fff',
       opacity: 0.1
     }
   }, // tooltip 辅助背景框样式
   tooltipCrosshairsLine: {
-    style: {
+    lineStyle: {
       stroke: 'rgba(255, 255, 255, 0.45)'
     }
   },

--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -527,13 +527,13 @@ const Theme = {
   }, // 提示信息在折线图、区域图上形成点的样式
   tooltipCrosshairsRect: {
     type: 'rect',
-    style: {
+    reactStyle: {
       fill: '#CCD6EC',
       opacity: 0.3
     }
   }, // tooltip 辅助背景框样式
   tooltipCrosshairsLine: {
-    style: {
+    lineStyle: {
       stroke: 'rgba(0, 0, 0, 0.25)',
       lineWidth: 1
     }


### PR DESCRIPTION
theme 中的 tooltipCrosshairsLine 和 tooltipCrosshairsRect 无效。
原因 theme 中的命名是 tooltipCrosshairsRect: {
     style: {
      fill: '#CCD6EC',
      opacity: 0.3
    }
  },

在 crosshair 组件中使用样式时区分的，分别是 lineStyle 和 reactStyle

使用直接取 lineStyle 和 reactStyle  所以 theme 中的 style 失效了。


因此修改 theme 模板命名，这样就不用动代码了。