### PR TITLE
fix(geom-labels): if htmlTemplate is set, useHtml is true by default

### DIFF
--- a/src/geom/label/geom-labels.js
+++ b/src/geom/label/geom-labels.js
@@ -442,6 +442,7 @@ class GeomLabels extends Group {
       // 兼容旧的源数据写在item.point中
       point.point = origin;
       if (cfg.htmlTemplate) {
+        cfg.useHtml = true;
         cfg.text = cfg.htmlTemplate.call(null, cfg.text, point, i);
         delete cfg.htmlTemplate;
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
