### PR TITLE
fix(scale & filter): remove min max limit if field filtered

### DIFF
--- a/src/chart/controller/scale.js
+++ b/src/chart/controller/scale.js
@@ -19,6 +19,8 @@ class ScaleController {
     this.viewTheme = {
       scales: {}
     };
+    // filtered fields
+    this.filters = {};
     Util.assign(this, cfg);
   }
 
@@ -36,6 +38,10 @@ class ScaleController {
           def[k] = v;
         }
       });
+      if (this.filters[field]) {
+        delete def.min;
+        delete def.max;
+      }
     }
     return def;
   }

--- a/src/chart/view.js
+++ b/src/chart/view.js
@@ -688,6 +688,7 @@ class View extends Base {
       options.filters = {};
     }
     options.filters[field] = condition;
+    this.get('scaleController').filters = options.filters;
   }
 
   // 获取 filters


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
这个修复主要是针对用brush筛选数据时, 如果对应列指定了min和max, 那么筛选后生成的ticks还是会受其影响; 如下图
![image](https://user-images.githubusercontent.com/6942296/49210638-96aa9200-f3f8-11e8-9c2a-9845a8690352.png)

在个人从实际使用的角度来看, 对于filter后数据min max应该是没有意义的