### PR TITLE
feat(legend): enable default legend-item handler

### DIFF
--- a/src/chart/controller/legend.js
+++ b/src/chart/controller/legend.js
@@ -101,9 +101,9 @@ class LegendController {
     const options = self.options;
 
     legend.on('itemclick', ev => {
-      if (options.onClick) { // 用户自定义了图例点击事件
+      if (options.onClick && options.defaultClickHandlerEnabled !== true) {
         options.onClick(ev);
-      } else {
+      } else {   // if 'defaultClickHandlerEnabled' is true the default click behavior would be worked.
         const item = ev.item;
         const checked = ev.checked;
         const isSingleSelected = legend.get('selectedMode') === 'single'; // 图例的选中模式
@@ -138,6 +138,9 @@ class LegendController {
               });
             }
           });
+        }
+        if (options.onClick) {
+          options.onClick(ev);
         }
         chart.set('keepLegend', true); // 图例不重新渲染
         chart.set('keepPadding', true); // 边框不重新计算

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -265,6 +265,7 @@ declare namespace G2 {
     textStyle?: Styles.text;
     clickable?: boolean;
     hoverable?: boolean;
+    defaultClickHandlerEnabled?:  boolean;
     selectedMode?: 'single' | 'multiple';
     onHover?: (e: MouseEvent) => void;
     onClick?: (e: MouseEvent) => void;


### PR DESCRIPTION
to enable/disable the default legend-item handler function when the legend's "itemclick" event
triggered, even if the customer defined his/her own click handler.

fix #1051

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
