### PR TITLE
修复显示钉子图后直接完全覆盖绘制的bug

### DIFF
--- a/src/geom/shape/interval.js
+++ b/src/geom/shape/interval.js
@@ -167,8 +167,6 @@ function getLineAttrs(cfg) {
   const defaultAttrs = Global.shape.hollowInterval;
   const attrs = Util.mix({}, defaultAttrs, cfg.style);
   ShapeUtil.addStrokeAttrs(attrs, cfg);
-  // @2018-12-10 by blue.lb 这里需要特殊处理，由于像tick这种shape名称在方法_applyViewThemeShapeStyle中，不会被当做hollow镂空图形处理，这导致lineWidth的值为0，所以无法绘制出内容，如果写在addStrokeAttrs中，又不能保证所有的默认lineWidth为2，这里做一下特殊处理解决
-  attrs.lineWidth = cfg.size || 2; // size 就是线的宽度
   return attrs;
 }
 
@@ -363,6 +361,10 @@ Shape.registerShape('interval', 'tick', {
   },
   draw(cfg, container) {
     const attrs = getLineAttrs(cfg);
+    // @2018-12-25 by blue.lb 经过测试发现size代表的是宽度，而style中的lineWidth才是设置线宽，放在interval暂时先特殊处理
+    if (!attrs.lineWidth) {
+      attrs.lineWidth = 2;
+    }
     let path = getTickPath(cfg.points);
     path = this.parsePath(path);
     return container.addShape('path', {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
https://antv.alipay.com/zh-cn/g2/3.x/demo/other/column-error.html#
抱歉，由于之前修复问题时没有验证完全，直接采用size为线宽的话违背了这个图想要展示的样子，引以为戒，之后验证实现会更仔细一点