### PR TITLE
fix(brush): brush filter wrong data when coord transpose

### DIFF
--- a/src/interaction/brush.js
+++ b/src/interaction/brush.js
@@ -62,6 +62,7 @@ class Brush extends Interaction {
         start: coord.start,
         end: coord.end
       };
+      me.isTransposed = coord.isTransposed;
       const xScales = view._getScales('x');
       const yScales = view._getScales('y');
       me.xScale = me.xField ? xScales[me.xField] : view.getXScale();
@@ -319,11 +320,11 @@ class Brush extends Interaction {
       } else if (chart && me.filter) {
         container.clear(); // clear the brush
         // filter data
-        if (type === 'X') {
+        if ((!me.isTransposed && type === 'X') || (me.isTransposed && type === 'Y')) {
           xScale && chart.filter(xScale.field, val => {
             return xValues.indexOf(val) > -1;
           });
-        } else if (type === 'Y') {
+        } else if ((!me.isTransposed && type === 'Y') || (me.isTransposed && type === 'X')) {
           yScale && chart.filter(yScale.field, val => {
             return yValues.indexOf(val) > -1;
           });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

现在brush的时候仍然会按transpose之前的字段进行filter，我加了一下tranpose的判断。
另外不太清楚brush type里 'X' 和 'Y' 需不需要受transpose影响