### PR TITLE
fix(schema): use cfg.color for lineAttrs.stroke if available.

### DIFF
--- a/src/geom/shape/schema.js
+++ b/src/geom/shape/schema.js
@@ -49,7 +49,7 @@ function getFillAttrs(cfg) {
   const lineAttrs = Util.mix({}, defaultAttrs, cfg.style);
   ShapeUtil.addFillAttrs(lineAttrs, cfg);
   if (cfg.color) {
-    lineAttrs.stroke = lineAttrs.stroke || cfg.color;
+    lineAttrs.stroke = cfg.color || lineAttrs.stroke;
   }
   return lineAttrs;
 }


### PR DESCRIPTION
##### Checklist
- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Description of change
Uses cfg.color if available.
