### PR TITLE
Fix issue 1158

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@antv/adjust": "~0.1.0",
     "@antv/attr": "~0.1.2",
     "@antv/coord": "~0.1.0",
-    "@antv/g": "~3.3.5",
+    "@antv/g": "~3.3.6",
     "@antv/scale": "~0.1.0",
     "@antv/util": "~1.3.1",
     "venn.js": "~0.2.20",

--- a/src/chart/controller/legend.js
+++ b/src/chart/controller/legend.js
@@ -9,7 +9,20 @@ const FIELD_ORIGIN = '_origin';
 const MARKER_SIZE = 4.5;
 const requireAnimationFrameFn = window.requestAnimationFrame || window.mozRequestAnimationFrame ||
   window.webkitRequestAnimationFrame || window.msRequestAnimationFrame;
-const STROKE_MARKERS = [ 'cross', 'tick', 'plus', 'hyphen', 'line' ];
+const STROKE_MARKERS = [
+  'cross',
+  'tick',
+  'plus',
+  'hyphen',
+  'line',
+  'hollowCircle',
+  'hollowSquare',
+  'hollowDiamond',
+  'hollowTriangle',
+  'hollowTriangleDown',
+  'hollowHexagon',
+  'hollowBowtie'
+];
 
 function _snapEqual(v1, v2, scale) {
   let isEqual;
@@ -761,20 +774,25 @@ class LegendController {
     const geoms = chart.getAllGeoms();
     Util.each(items, item => {
       const geom = findGeom(geoms, item.value);
-      if (!Util.isObject(item.marker)) {
-        const symbol = item.marker || 'circle';
+      if (!Util.isPlainObject(item.marker)) { // 直接传入字符串或者回调函数时转换为对象，如 item.marker = 'circle'
         item.marker = {
-          symbol,
+          symbol: item.marker || 'circle',
           radius: MARKER_SIZE
         };
-        if (Util.indexOf(STROKE_MARKERS, symbol) !== -1) {
+        if (Util.indexOf(STROKE_MARKERS, item.marker.symbol) !== -1) {
           item.marker.stroke = item.fill;
         } else {
           item.marker.fill = item.fill;
         }
-      } else {
+      } else { // 用户传入对象 item.marker = { symbol: 'circle', fill: 'red', radius: 3 }
         item.marker.radius = item.marker.radius || MARKER_SIZE;
       }
+
+      const symbol = item.marker.symbol;
+      if (Util.isString(symbol) && symbol.indexOf('hollow') !== -1) {
+        item.marker.symbol = Util.lowerFirst(symbol.substr(6));
+      }
+
       item.checked = Util.isNil(item.checked) ? true : item.checked;
       item.geom = geom;
     });

--- a/src/chart/controller/legend.js
+++ b/src/chart/controller/legend.js
@@ -9,6 +9,7 @@ const FIELD_ORIGIN = '_origin';
 const MARKER_SIZE = 4.5;
 const requireAnimationFrameFn = window.requestAnimationFrame || window.mozRequestAnimationFrame ||
   window.webkitRequestAnimationFrame || window.msRequestAnimationFrame;
+const STROKE_MARKERS = [ 'cross', 'tick', 'plus', 'hyphen', 'line' ];
 
 function _snapEqual(v1, v2, scale) {
   let isEqual;
@@ -761,11 +762,16 @@ class LegendController {
     Util.each(items, item => {
       const geom = findGeom(geoms, item.value);
       if (!Util.isObject(item.marker)) {
+        const symbol = item.marker || 'circle';
         item.marker = {
-          symbol: item.marker ? item.marker : 'circle',
-          fill: item.fill,
+          symbol,
           radius: MARKER_SIZE
         };
+        if (Util.indexOf(STROKE_MARKERS, symbol) !== -1) {
+          item.marker.stroke = item.fill;
+        } else {
+          item.marker.fill = item.fill;
+        }
       } else {
         item.marker.radius = item.marker.radius || MARKER_SIZE;
       }

--- a/test/bugs/issue-1158-spec.js
+++ b/test/bugs/issue-1158-spec.js
@@ -41,9 +41,26 @@ describe('#1158', () => {
       custom: true,
       items: [
         {
-          value: 'hahaha',
+          value: 'Item A',
           fill: 'red',
-          marker: 'tick' // not working
+          marker: 'tick'
+        },
+        {
+          value: 'Item B',
+          fill: 'green',
+          marker: 'circle'
+        },
+        {
+          value: 'Item C',
+          fill: 'blue',
+          marker: 'hollowCircle'
+        },
+        {
+          value: 'Item D',
+          marker: {
+            symbol: 'hollowSquare',
+            stroke: 'yellow'
+          }
         }
       ]
     });
@@ -61,6 +78,21 @@ describe('#1158', () => {
       radius: 4.5,
       stroke: 'red',
       symbol: 'tick'
+    });
+    expect(legend.get('items')[1].marker).to.eql({
+      radius: 4.5,
+      fill: 'green',
+      symbol: 'circle'
+    });
+    expect(legend.get('items')[2].marker).to.eql({
+      radius: 4.5,
+      stroke: 'blue',
+      symbol: 'circle'
+    });
+    expect(legend.get('items')[3].marker).to.eql({
+      radius: 4.5,
+      stroke: 'yellow',
+      symbol: 'square'
     });
   });
 

--- a/test/bugs/issue-1158-spec.js
+++ b/test/bugs/issue-1158-spec.js
@@ -1,0 +1,71 @@
+const expect = require('chai').expect;
+const G2 = require('../../src/index');
+
+describe('#1158', () => {
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+  let chart;
+
+  it('some marker symbol not work', () => {
+    const data = [
+      { company: 'Apple', type: '整体', value: 30 },
+      { company: 'Facebook', type: '整体', value: 35 },
+      { company: 'Google', type: '整体', value: 28 },
+      { company: 'Apple', type: '非技术岗', value: 40 },
+      { company: 'Facebook', type: '非技术岗', value: 65 },
+      { company: 'Google', type: '非技术岗', value: 47 },
+      { company: 'Apple', type: '技术岗', value: 23 },
+      { company: 'Facebook', type: '技术岗', value: 18 },
+      { company: 'Google', type: '技术岗', value: 20 },
+      { company: 'Apple', type: '技术岗', value: 35 },
+      { company: 'Facebook', type: '技术岗', value: 30 },
+      { company: 'Google', type: '技术岗', value: 25 }
+    ];
+
+    chart = new G2.Chart({
+      container: div,
+      width: 400,
+      height: 300,
+      padding: 'auto'
+    });
+    chart.source(data);
+    chart.scale('value', {
+      alias: '占比（%）',
+      max: 75,
+      min: 0,
+      tickCount: 4
+    });
+
+    chart.legend({
+      position: 'top-center',
+      custom: true,
+      items: [
+        {
+          value: 'hahaha',
+          fill: 'red',
+          marker: 'tick' // not working
+        }
+      ]
+    });
+    chart.interval().position('type*value').color('company')
+      .opacity(1)
+      .adjust([{
+        type: 'dodge',
+        marginRatio: 1 / 32
+      }]);
+    chart.render();
+
+    const legendControler = chart.get('legendController');
+    const legend = legendControler.legends['top-center'][0];
+    expect(legend.get('items')[0].marker).to.eql({
+      radius: 4.5,
+      stroke: 'red',
+      symbol: 'tick'
+    });
+  });
+
+  after(() => {
+    chart.destroy();
+    document.body.removeChild(div);
+  });
+});

--- a/test/bugs/issue-439-spec.js
+++ b/test/bugs/issue-439-spec.js
@@ -5,6 +5,9 @@ describe('#439', () => {
   it('tooltip and size', () => {
     const div = document.createElement('div');
     document.body.appendChild(div);
+    div.style.position = 'fixed';
+    div.style.top = 0;
+    div.style.left = 0;
     const data = [
       { genre: 'Sports', sold: 275, type: '1' },
       { genre: 'Strategy', sold: 115, type: '1' },
@@ -47,8 +50,8 @@ describe('#439', () => {
     const canvas = chart.get('canvas');
     canvas.emit('click', {
       type: 'click',
-      x: 748 * 2,
-      y: 79 * 2,
+      x: 542 * 2,
+      y: 201 * 2,
       event: {
         toElement: canvas.get('el')
       }
@@ -64,6 +67,5 @@ describe('#439', () => {
         }
       });
     }).not.to.throw();
-
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

#1158  出现的原因是部分 marker 的绘制是需要设置 `stroke` 描边颜色的，而我们在代码里面统一使用了 `fill` 填充属性，另外对于不再支持的 marker 文档没有及时更新，同时 G 的 marker 也需要提供容错机制。