### PR TITLE
add parameters `point` and `index` to the callback of label

### DIFF
--- a/src/geom/label/geom-labels.js
+++ b/src/geom/label/geom-labels.js
@@ -432,7 +432,7 @@ class GeomLabels extends Group {
         // callback中应使用原始数据，而不是数据字符串
         const originValues = scales.map(scale => origin[scale.field]);
         // 将point信息以及index信息也返回，方便能够根据point以及index，返回不同的配置
-        cfg = labelCfg.callback.apply(null, [...originValues, point, i]);
+        cfg = labelCfg.callback.apply(null, [ ...originValues, point, i ]);
       }
       if (!cfg && cfg !== 0) {
         cfgs.push(null);

--- a/src/geom/label/geom-labels.js
+++ b/src/geom/label/geom-labels.js
@@ -431,7 +431,8 @@ class GeomLabels extends Group {
       if (labelCfg.callback) {
         // callback中应使用原始数据，而不是数据字符串
         const originValues = scales.map(scale => origin[scale.field]);
-        cfg = labelCfg.callback.apply(null, originValues);
+        // 将point信息以及index信息也返回，方便能够根据point以及index，返回不同的配置
+        cfg = labelCfg.callback.apply(null, [...originValues, point, i]);
       }
       if (!cfg && cfg !== 0) {
         cfgs.push(null);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

When we add labels of geom, some labels are often overflowed because of the range of canvas. I want to add `point` and `index` to the callback of label to enable return different `offset` through calculating the position of geom. 

##### Related issues

- https://github.com/antvis/g2/issues/1045

