### PR TITLE
fix: 修复了demos/arc.html初始化左右padding过小引起的文字遮盖

### DIFF
--- a/demos/arc.html
+++ b/demos/arc.html
@@ -33,7 +33,7 @@
       container: 'canvas',
       forceFit: true,
       height: window.innerHeight,
-      padding: [ 120, 0, 120, 0 ]
+      padding: [ 120, 150, 120, 150 ]
     });
     chart.legend(false);
     chart.tooltip({


### PR DESCRIPTION
当视口宽度过小时，chart的初始化左右padding为0会造成节点上的文字溢出而被遮盖

**修改前**

![Screen Shot 2019-06-25 at 2 57 28 PM](https://user-images.githubusercontent.com/18437297/60076761-f254b800-975a-11e9-802d-1a849dfcd1e0.png)

**修改后**

![Screen Shot 2019-06-25 at 3 01 35 PM](https://user-images.githubusercontent.com/18437297/60076769-f84a9900-975a-11e9-9e4b-37b266ffbe5c.png)

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
