### PR TITLE
fix 1271 supplementally to fit the tooltip rendered by canvas

### DIFF
--- a/src/chart/controller/tooltip.js
+++ b/src/chart/controller/tooltip.js
@@ -375,8 +375,8 @@ class TooltipController {
                     v.showMarker = true;
                     // bugfix
                     // 由于tooltip是DOM而不是Canvas，设置渐变色时，marker无法正常显示
-                    // 如果，设置的颜色是渐变色，则取渐变色的起始颜色作为marker的颜色，暂时解决这个问题
-                    if (v.color.substring(0, 2) === 'l(') {
+                    // 如果，设置的颜色是渐变色并且设置了tooltip使用html方式渲染，则取渐变色的起始颜色作为marker的颜色，暂时解决这个问题
+                    if (v.color.substring(0, 2) === 'l(' && (!options.hasOwnProperty('useHtml') || options.useHtml)) {
                       v.color = v.color.split(' ')[1].substring(2);
                     }
                     const itemMarker = self._getItemMarker(geom, v.color);

--- a/test/bugs/issue-1271-spec.js
+++ b/test/bugs/issue-1271-spec.js
@@ -60,6 +60,9 @@ describe('#1271', () => {
       stroke: '#fff',
       lineWidth: 1
     });
+    // chart.tooltip({
+    //   useHtml: false
+    // });
     chart.render();
 
     chart.showTooltip({ x: 100, y: 100 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
When the user sets the tooltip to be rendered in Canvas, previous fix to issue 1271 could cause problems. This commit fixes aforementioned problem.