### PR TITLE
开放定制tooltip中marker，以及图形上对应的marker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
   apt:
     packages:
       - xvfb
+      - libgconf-2-4
 
 install:
   - export DISPLAY=':99.0'

--- a/demos/area-line-stack.html
+++ b/demos/area-line-stack.html
@@ -46,6 +46,13 @@
       { country: 'Oceania', year: '2050', value: 460 }
     ];
 
+    const shapeMap = {
+      Asia: 'diamond',
+      Africa: 'triangle',
+      Europe: 'square',
+      Oceania: 'hexagon'
+    };
+
     const chart = new G2.Chart({
       container: 'canvas',
       forceFit: true,
@@ -73,7 +80,18 @@
       .position('year*value')
       .color('country')
       .style({ lineWidth: 2 })
-      .adjust('stack');
+      .adjust('stack')
+      .shape('country', val => {
+        return shapeMap[val];
+      });
+    chart.tooltip(true, {
+      marker: (markerObj, item) => {
+        return {
+          ...markerObj,
+          activeSymbol: shapeMap[item.name]
+        };
+      }
+    });
     chart.render();
   </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -100,9 +100,9 @@
     "silent": false
   },
   "dependencies": {
-    "@antv/component": "~0.3.2",
     "@antv/adjust": "~0.1.0",
     "@antv/attr": "~0.1.2",
+    "@antv/component": "^0.3.3",
     "@antv/coord": "~0.1.0",
     "@antv/g": "~3.3.6",
     "@antv/scale": "~0.1.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "dependencies": {
     "@antv/adjust": "~0.1.0",
     "@antv/attr": "~0.1.2",
-    "@antv/component": "^0.3.3",
+    "@antv/component": "~0.3.3",
     "@antv/coord": "~0.1.0",
     "@antv/g": "~3.3.6",
     "@antv/scale": "~0.1.1",

--- a/src/component/tooltip/index.js
+++ b/src/component/tooltip/index.js
@@ -176,7 +176,11 @@ class Tooltip extends Base {
        * 是否允许鼠标停留在 tooltip 上，默认不允许
        * @type {Boolean}
        */
-      enterable: false
+      enterable: false,
+      /**
+       * 设置几何体对应的maker
+       */
+      marker: null
     };
   }
 
@@ -436,7 +440,8 @@ class Tooltip extends Base {
           shadowColor: item.color
         }, markerCfg, {
           x: item.x,
-          y: item.y
+          y: item.y,
+          symbol: item.symbol
         })
       });
     });

--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -496,7 +496,6 @@ const Theme = {
     [`${TOOLTIP_MARKER_CLASS}`]: {
       width: '5px',
       height: '5px',
-      borderRadius: '50%',
       display: 'inline-block',
       marginRight: '8px'
     },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
tooltip开放`marker`配置，能够返回`activeSymbol`来实现如下效果：

![image](https://user-images.githubusercontent.com/6111424/61929280-82319000-afad-11e9-9619-da525af64a3e.png)

