### PR TITLE
fix(tooltip position):position will be wrong when tooltip init

### DIFF
--- a/src/component/tooltip/index.js
+++ b/src/component/tooltip/index.js
@@ -455,6 +455,14 @@ class Tooltip extends Base {
 
   setPosition(x, y, target) {
     const container = this.get('container');
+    // 修复tooltip初始位置错误，是由于container隐藏时获取不到宽高导致
+    // 记住上次可见性
+    const lastVisibility = container.style.visibility;
+    const lastDisplay = container.style.display;
+    // 设为可见
+    container.style.visibility = 'visible';
+    container.style.display = 'block';
+
     const crossLineShapeX = this.get('crossLineShapeX');
     const crossLineShapeY = this.get('crossLineShapeY');
     const crosshairsRectShape = this.get('crosshairsRectShape');
@@ -545,6 +553,9 @@ class Tooltip extends Base {
       container.style.left = follow ? (x + 'px') : 0;
       container.style.top = follow ? (y + 'px') : 0;
     }
+    // 设为可见
+    container.style.visibility = lastVisibility;
+    container.style.display = lastDisplay;
   }
 
   show() {


### PR DESCRIPTION
…init

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
modify file: /src/component/tooltip/index.js
modify function: setPosition.
change container to visible before get width&height of container, and change back after set position.