### PR TITLE
fix(tooltip): fix tooltip position when panelGroup has clip attr

### DIFF
--- a/packages/component/__tests__/unit/tooltip/base-spec.js
+++ b/packages/component/__tests__/unit/tooltip/base-spec.js
@@ -21,13 +21,13 @@ describe('Tooltip基类测试', () => {
     br: { x: 425, y: 440 },
     cc: { x: 225, y: 245 },
   };
-
   it('initialize', () => {
     const tooltip = new Tooltip({
       x: 10,
       y: 10,
       items,
       titleContent: title,
+      panelGroup: new G.Group(),
       panelRange,
     });
     expect(tooltip).be.an.instanceof(Tooltip);
@@ -40,6 +40,7 @@ describe('Tooltip基类测试', () => {
     const tooltip = new Tooltip({
       x: 10,
       y: 10,
+      panelGroup: new G.Group(),
       panelRange,
     });
     tooltip.setContent(title, items);
@@ -53,6 +54,7 @@ describe('Tooltip基类测试', () => {
       y: 10,
       items,
       titleContent: title,
+      panelGroup: new G.Group(),
       panelRange,
     });
     const newItems = [
@@ -70,6 +72,7 @@ describe('Tooltip基类测试', () => {
       y: 10,
       items,
       titleContent: title,
+      panelGroup: new G.Group(),
       panelRange,
     });
     const newItems = [
@@ -86,6 +89,7 @@ describe('Tooltip基类测试', () => {
       y: 10,
       items,
       titleContent: title,
+      panelGroup: new G.Group(),
       panelRange,
     });
     const isChanged = tooltip.isContentChange(title, items);
@@ -98,6 +102,7 @@ describe('Tooltip基类测试', () => {
       y: 10,
       items,
       titleContent: title,
+      panelGroup: new G.Group(),
       panelRange,
     });
     tooltip.setPosition(20, 15);
@@ -111,6 +116,7 @@ describe('Tooltip基类测试', () => {
       y: 10,
       items,
       titleContent: title,
+      panelGroup: new G.Group(),
       panelRange,
     });
     tooltip.setPosition(20, 15);
@@ -124,6 +130,7 @@ describe('Tooltip基类测试', () => {
       y: 10,
       items,
       titleContent: title,
+      panelGroup: new G.Group(),
       panelRange,
     });
     tooltip.setPosition(20, 15);
@@ -148,6 +155,7 @@ describe('Tooltip基类测试', () => {
       items,
       titleContent: title,
       panelRange,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setMarkers(markerItems, { radius: 5 });
@@ -176,6 +184,7 @@ describe('Tooltip基类测试', () => {
       items,
       titleContent: title,
       panelRange,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setMarkers(markerItems, { radius: 5 });
@@ -205,6 +214,7 @@ describe('Tooltip基类测试', () => {
       items,
       titleContent: title,
       panelRange,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setMarkers(markerItems, { radius: 5 });

--- a/packages/component/__tests__/unit/tooltip/canvas-spec.js
+++ b/packages/component/__tests__/unit/tooltip/canvas-spec.js
@@ -38,6 +38,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     // tooltip.show();
@@ -57,6 +58,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       // items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     // tooltip.show();
@@ -80,6 +82,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     // tooltip.show();
@@ -99,6 +102,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     // tooltip.show();
@@ -118,6 +122,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.hide();
@@ -136,6 +141,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.clear();
@@ -157,6 +163,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       crosshairs: { type: 'cross' },
     });
@@ -175,12 +182,13 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setPosition(50, 10);
     canvas.draw();
-    expect(tooltip.get('x')).to.equal(70);// x+gap
-    expect(tooltip.get('y')).to.equal(50);// y+gap
+    expect(tooltip.get('x')).to.equal(70); // x+gap
+    expect(tooltip.get('y')).to.equal(50); // y+gap
     tooltip.destroy();
   });
 
@@ -195,6 +203,7 @@ describe('CanvasTooltip测试', () => {
       position: 'left',
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setPosition(50, 10);
@@ -215,13 +224,14 @@ describe('CanvasTooltip测试', () => {
       items,
       offset: 50,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       inPanel: false,
     });
     tooltip.setPosition(-100, 600);
     canvas.draw();
     const height = tooltip.get('container').getBBox().height;
-    expect(tooltip.get('x')).to.equal(20);// gap
+    expect(tooltip.get('x')).to.equal(20); // gap
     expect(tooltip.get('y')).to.equal(600 - height - 20);
     tooltip.destroy();
   });
@@ -244,6 +254,7 @@ describe('CanvasTooltip测试', () => {
       items,
       offset: 50,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setPosition(10, 20);
@@ -268,6 +279,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setPosition(300, 20);
@@ -294,6 +306,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setPosition(10, 20);
@@ -318,6 +331,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setPosition(10, 300);
@@ -337,6 +351,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       backgroundGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       crosshairs: { type: 'cross' },
@@ -362,6 +377,7 @@ describe('CanvasTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       backgroundGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       crosshair: { type: 'cross' },
@@ -381,5 +397,4 @@ describe('CanvasTooltip测试', () => {
     expect(markergroup.get('visible')).to.equal(true);
     tooltip.destroy();
   });
-
 });

--- a/packages/component/__tests__/unit/tooltip/html-spec.js
+++ b/packages/component/__tests__/unit/tooltip/html-spec.js
@@ -39,6 +39,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.show();
@@ -57,6 +58,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.show();
@@ -75,6 +77,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       // items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.show();
@@ -94,6 +97,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       crosshairs: { type: 'cross' },
     });
@@ -113,6 +117,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.clear();
@@ -134,6 +139,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.destroy();
@@ -151,12 +157,13 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setPosition(50, 10);
     tooltip.show();
-    expect(tooltip.get('x')).to.equal(70);// x+gap
-    expect(tooltip.get('y')).to.equal(50);// y+gap
+    expect(tooltip.get('x')).to.equal(70); // x+gap
+    expect(tooltip.get('y')).to.equal(50); // y+gap
     tooltip.destroy();
   });
 
@@ -170,6 +177,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       enterable: true,
     });
@@ -192,13 +200,14 @@ describe('HtmlTooltip测试', () => {
       items,
       offset: 50,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       inPanel: false,
     });
     tooltip.setPosition(-100, 600);
     tooltip.show();
     const height = tooltip.get('container').clientHeight;
-    expect(tooltip.get('x')).to.equal(20);// gap
+    expect(tooltip.get('x')).to.equal(20); // gap
     expect(tooltip.get('y')).to.equal(600 - height - 20);
     tooltip.destroy();
   });
@@ -221,6 +230,7 @@ describe('HtmlTooltip测试', () => {
       items,
       offset: 50,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setPosition(10, 20);
@@ -246,6 +256,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setPosition(300, 20);
@@ -272,6 +283,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setPosition(10, 20);
@@ -297,6 +309,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.setPosition(10, 300);
@@ -316,6 +329,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       enterable: true,
     });
@@ -336,6 +350,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       enterable: false,
       position: 'top',
@@ -355,6 +370,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       follow: true,
     });
@@ -372,6 +388,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       follow: false,
     });
@@ -390,6 +407,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       backgroundGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       crosshairs: { type: 'cross' },
@@ -410,6 +428,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       htmlContent: (title, items) => {
         let list = '<ul>';
@@ -450,6 +469,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       containerTpl: '#container',
     });
@@ -469,6 +489,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       containerTpl: `
       <div class="${CONTAINER_CLASS}">
@@ -492,6 +513,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       itemTpl: `<li data-index={index}>
         <span style="background-color:{color};" class="${MARKER_CLASS}"></span>
@@ -510,6 +532,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       htmlContent: (title, items) => {
         let list = '<ul>';
@@ -545,9 +568,9 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       htmlContent: (title, items) => {
-
         const tooltipContent = document.createElement('div');
         tooltipContent.className = 'g2-tooltip';
 
@@ -566,7 +589,6 @@ describe('HtmlTooltip测试', () => {
         tooltipContent.appendChild(tooltipList);
 
         return tooltipContent;
-
       },
     });
     tooltip.show();
@@ -598,6 +620,7 @@ describe('HtmlTooltip测试', () => {
       visible: true,
       items,
       canvas,
+      panelGroup: canvas.addGroup(),
       backgroundGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
       crosshair: { type: 'cross' },
@@ -617,6 +640,4 @@ describe('HtmlTooltip测试', () => {
     expect(markergroup.get('visible')).to.equal(true);
     tooltip.destroy();
   });
-
 });
-

--- a/packages/component/src/tooltip/canvas.ts
+++ b/packages/component/src/tooltip/canvas.ts
@@ -1,20 +1,15 @@
 // @ts-ignore // todo 等 g ready 好后再去掉这行 ignore
-import * as G from '@antv/g';
-import * as Util  from '@antv/util'
 import * as domUtil from '@antv/dom-util';
+import * as G from '@antv/g';
 import { transform } from '@antv/matrix-util';
-import Crosshair from './crosshair';
-import Tooltip from './base';
-import {
-  defaultPosition,
-  constraintPositionInBoundary,
-  constraintPositionInPanel,
-} from './util/position';
+import * as Util from '@antv/util';
 import { FONT_FAMILY } from '../const';
+import Tooltip from './base';
+import Crosshair from './crosshair';
 import { TooltipCfg, ToolTipContentItem } from './interface';
+import { constraintPositionInBoundary, constraintPositionInPanel, defaultPosition } from './util/position';
 
 export default class CanvasTooltip extends Tooltip {
-
   constructor(cfg: TooltipCfg) {
     super({
       /**
@@ -97,11 +92,16 @@ export default class CanvasTooltip extends Tooltip {
     const crosshair = this.get('crosshairs');
     if (crosshair) {
       const plot = this.get('frontgroundGroup');
-      const crosshairGroup = new Crosshair(Util.mix({
-        plot,
-        panelRange: this.get('panelRange'),
-        canvas: this.get('canvas'),
-      },                                            this.get('crosshairs')));
+      const crosshairGroup = new Crosshair(
+        Util.mix(
+          {
+            plot,
+            panelRange: this.get('panelRange'),
+            canvas: this.get('canvas'),
+          },
+          this.get('crosshairs')
+        )
+      );
       crosshairGroup.hide();
       this.set('crosshairGroup', crosshairGroup);
     }
@@ -112,7 +112,7 @@ export default class CanvasTooltip extends Tooltip {
     }
   }
 
-  _init_() {
+  public _init_() {
     const padding = this.get('padding');
     const parent = this.get('frontgroundGroup');
     // marker group
@@ -133,10 +133,13 @@ export default class CanvasTooltip extends Tooltip {
     const titleStyle = this.get('titleStyle');
     if (this.get('showTitle')) {
       const titleShape = container.addShape('text', {
-        attrs: Util.mix({
-          x: padding.left,
-          y: padding.top,
-        },              titleStyle),
+        attrs: Util.mix(
+          {
+            x: padding.left,
+            y: padding.top,
+          },
+          titleStyle
+        ),
       });
       this.set('titleShape', titleShape);
       titleShape.name = 'tooltip-title';
@@ -147,7 +150,7 @@ export default class CanvasTooltip extends Tooltip {
     this.set('itemsGroup', itemsGroup);
   }
 
-  render() {
+  public render() {
     this.clear();
     const container = this.get('container');
     const board = this.get('board');
@@ -182,7 +185,7 @@ export default class CanvasTooltip extends Tooltip {
     this._alignToRight(width);
   }
 
-  clear() {
+  public clear() {
     const titleShape = this.get('titleShape');
     const itemsGroup = this.get('itemsGroup');
     const board = this.get('board');
@@ -194,39 +197,52 @@ export default class CanvasTooltip extends Tooltip {
     board.attr('height', 0);
   }
 
-  show() {
+  public show() {
     const container = this.get('container');
     container.show();
     const crosshairGroup = this.get('crosshairGroup');
-    crosshairGroup && crosshairGroup.show();
+    if (crosshairGroup) {
+      crosshairGroup.show();
+    }
     const markerGroup = this.get('markerGroup');
-    markerGroup && markerGroup.show();
+    if (markerGroup) {
+      markerGroup.show();
+    }
     super.show();
     this.get('canvas').draw();
   }
 
-  hide() {
+  public hide() {
     const container = this.get('container');
     container.hide();
     const crosshairGroup = this.get('crosshairGroup');
-    crosshairGroup && crosshairGroup.hide();
+    if (crosshairGroup) {
+      crosshairGroup.hide();
+    }
     const markerGroup = this.get('markerGroup');
-    markerGroup && markerGroup.hide();
+    if (markerGroup) {
+      markerGroup.hide();
+    }
     super.hide();
     this.get('canvas').draw();
   }
 
-  destroy() {
+  public destroy() {
     const container = this.get('container');
     const crosshairGroup = this.get('crosshairGroup');
-    crosshairGroup && crosshairGroup.destroy();
+    if (crosshairGroup) {
+      crosshairGroup.destroy();
+    }
     const markerGroup = this.get('markerGroup');
-    markerGroup && markerGroup.remove();
+    if (markerGroup) {
+      markerGroup.remove();
+    }
     super.destroy();
     container.remove();
   }
 
-  setPosition(oldx: number, oldy: number, target?: any) { // todo
+  public setPosition(oldx: number, oldy: number, target?: any) {
+    // todo
     let x = oldx;
     let y = oldy;
     const container = this.get('container');
@@ -242,30 +258,27 @@ export default class CanvasTooltip extends Tooltip {
 
     let position;
     if (this.get('position')) {
-      const containerWidth = bbox.width;
-      const containerHeight = bbox.height;
-      position = defaultPosition(
-        x, y, this.get('position'),
-        containerWidth, containerHeight, target,
-      );
+      position = defaultPosition(x, y, this.get('position'), containerWidth, containerHeight, target);
       x = position[0];
       y = position[1];
     } else {
-      position = constraintPositionInBoundary(
-        x, y,
-        containerWidth, containerHeight,
-        viewWidth, viewHeight,
-      );
+      position = constraintPositionInBoundary(x, y, containerWidth, containerHeight, viewWidth, viewHeight);
       x = position[0];
       y = position[1];
     }
 
-    if (this.get('inPanel')) { // tooltip 必须限制在绘图区域内
+    if (this.get('inPanel')) {
+      // tooltip 必须限制在绘图区域内
       const panelRange = this.get('panelRange');
+      const panelGroup = this.get('panelGroup');
+      const panelClip = panelGroup.attr('clip');
       position = constraintPositionInPanel(
-        x, y,
-        containerWidth, containerHeight,
-        panelRange, this.get('enterable'),
+        x,
+        y,
+        containerWidth,
+        containerHeight,
+        panelClip ? panelClip.getBBox() : panelRange,
+        this.get('enterable')
       );
       x = position[0];
       y = position[1];
@@ -277,14 +290,15 @@ export default class CanvasTooltip extends Tooltip {
       endy = markerItems[0].y;
     }
 
-    const ulMatrix = [ 1, 0, 0, 0, 1, 0, 0, 0, 1 ];
-    const mat = transform(ulMatrix, [
-        [ 't', x, y ],
-    ]);
+    const ulMatrix = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+    const mat = transform(ulMatrix, [['t', x, y]]);
     container.stopAnimate();
-    container.animate({
-      matrix: mat,
-    },                this.get('animationDuration'));
+    container.animate(
+      {
+        matrix: mat,
+      },
+      this.get('animationDuration')
+    );
 
     const crosshairGroup = this.get('crosshairGroup');
     if (crosshairGroup) {
@@ -294,7 +308,7 @@ export default class CanvasTooltip extends Tooltip {
     super.setPosition(x, y);
   }
 
-  _addItem(item: ToolTipContentItem) {
+  public _addItem(item: ToolTipContentItem) {
     const group = new G.Group();
     let markerRadius = this.get('markerStyle').radius;
     // marker
@@ -312,29 +326,36 @@ export default class CanvasTooltip extends Tooltip {
     // name
     const nameStyle = this.get('nameStyle');
     group.addShape('text', {
-      attrs: Util.mix({
-        x: markerRadius + nameStyle.padding,
-        y: 0,
-        text: item.name,
-      },              nameStyle),
+      attrs: Util.mix(
+        {
+          x: markerRadius + nameStyle.padding,
+          y: 0,
+          text: item.name,
+        },
+        nameStyle
+      ),
     });
     // value
     const valueStyle = this.get('valueStyle');
     group.addShape('text', {
-      attrs: Util.mix({
-        x: group.getBBox().width + valueStyle.padding,
-        y: 0,
-        text: item.value,
-      },              valueStyle),
+      attrs: Util.mix(
+        {
+          x: group.getBBox().width + valueStyle.padding,
+          y: 0,
+          text: item.value,
+        },
+        valueStyle
+      ),
     });
 
     return group;
   }
 
-  _alignToRight(width: number): void {
+  public _alignToRight(width: number): void {
     const itemsGroup = this.get('itemsGroup');
     const groups = itemsGroup.get('children');
-    Util.each(groups, (g: any): void => { // todo
+    Util.each(groups, (g: any): void => {
+      // todo
       const children = g.get('children');
       const valueText = children[2];
       if (valueText) {

--- a/packages/component/src/tooltip/html.ts
+++ b/packages/component/src/tooltip/html.ts
@@ -285,7 +285,16 @@ export default class HtmlTooltip extends Tooltip {
     if (this.get('inPanel')) {
       // tooltip 必须限制在绘图区域内
       const panelRange = this.get('panelRange');
-      position = constraintPositionInPanel(x, y, containerWidth, containerHeight, panelRange, this.get('enterable'));
+      const panelGroup = this.get('panelGroup');
+      const panelClip = panelGroup.attr('clip');
+      position = constraintPositionInPanel(
+        x,
+        y,
+        containerWidth,
+        containerHeight,
+        panelClip ? panelClip.getBBox() : panelRange,
+        this.get('enterable')
+      );
       x = position[0];
       y = position[1];
     }

--- a/packages/g2/src/plot/controller/tooltip.ts
+++ b/packages/g2/src/plot/controller/tooltip.ts
@@ -91,6 +91,7 @@ export default class TooltipController {
     let options = this.options;
     options = _.deepMix(
       {
+        panelGroup: view.get('panelGroup'),
         panelRange: view.get('panelRange'),
         capture: false,
         canvas,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

修改Tooltip.setPosition方法，在inPanel条件下，去看panelRange是否有clip属性，如果有clip属性，则需要在clip range的范围内调整tooltip位置，应用在柱形图有滚动条的情景下；不影响原有情况即panelRange无clip的情形。
