### PR TITLE
legend在panelGroup有clip属性的时候的高宽限制

### DIFF
--- a/packages/g2/src/plot/controller/legend.ts
+++ b/packages/g2/src/plot/controller/legend.ts
@@ -330,12 +330,19 @@ export default class LegendController {
     const view = this.view;
     const viewTheme = this.theme;
     const canvas = view.get('canvas');
-    const panelRange = this.panelRange;
-    const viewRange = this.viewRange;
+    const panelGroup = view.get('panelGroup');
+    const panelGroupClip = panelGroup.attr('clip');
+    const panelGroupClipBox = panelGroupClip ? panelGroupClip.getBBox() : undefined;
+    const panelRange = view.get('panelRange');
+    const viewRange = view.get('viewRange');
     const posArray = position.split('-');
     const maxLength =
       posArray[0] === 'right' || posArray[0] === 'left' // TODO
-        ? panelRange.height
+        ? panelGroupClipBox
+          ? panelGroupClipBox.height
+          : panelRange.height
+        : panelGroupClipBox
+        ? viewRange.width - (panelRange.width - panelGroupClipBox.width)
         : viewRange.width;
     _.each(ticks, (tick) => {
       const text = tick.text;
@@ -392,14 +399,14 @@ export default class LegendController {
       case 'left':
         /*maxHeight = viewRange.height;
           maxWidth = panelRange.x - viewRange.x;*/
-        maxHeight = panelRange.height;
+        maxHeight = panelGroupClipBox ? panelGroupClipBox.height : panelRange.height;
         maxWidth = panelRange.x - viewRange.x;
         layout = 'vertical';
         break;
       case 'right':
         /*maxHeight = viewRange.height;
           maxWidth = viewRange.tr.x - panelRange.tr.x;*/
-        maxHeight = panelRange.height;
+        maxHeight = panelGroupClipBox ? panelGroupClipBox.height : panelRange.height;
         maxWidth = viewRange.tr.x - panelRange.tr.x;
         layout = 'vertical';
         break;
@@ -407,14 +414,14 @@ export default class LegendController {
         /*maxHeight = panelRange.tr.y - viewRange.tr.y;
           maxWidth = viewRange.width;*/
         maxHeight = panelRange.tr.y - viewRange.tr.y;
-        maxWidth = viewRange.width;
+        maxWidth = panelGroupClipBox ? viewRange.width - (panelRange.width - panelGroupClipBox.width) : viewRange.width;
         layout = 'horizontal';
         break;
       case 'bottom':
         /*maxHeight = viewRange.br.y - panelRange.br.y;
           maxWidth = viewRange.width;*/
         maxHeight = viewRange.br.y - panelRange.br.y;
-        maxWidth = viewRange.width;
+        maxWidth = panelGroupClipBox ? viewRange.width - (panelRange.width - panelGroupClipBox.width) : viewRange.width;
         layout = 'horizontal';
         break;
       default:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
在滚动条场景下给panelGroup设置了clip后，需要对legend的maxWidth/maxHeight做修正
