### PR TITLE
修复重复调用 chart.render() 绘制出错的问题

### DIFF
--- a/src/geometry/geometry.ts
+++ b/src/geometry/geometry.ts
@@ -106,14 +106,9 @@ export default class Geometry {
   /** Geometry 类型 */
   public readonly type: string = 'base';
   /** Geometry 对应的 shapeFactory 类型 */
-  public shapeType: string;
-  /** 图形属性对象 */
-  public attributes: Record<string, Attribute> = {};
-  /** scale·实例集合 */
-  public scales: Record<string, Scale> = {};
-  /** Element 实例集合 */
-  public elements: Element[] = [];
+  public readonly shapeType: string;
 
+  // 创建 Geometry 对象可传入的属性
   /** 坐标系对象 */
   public coordinate: Coordinate = null;
   /** data 数据 */
@@ -122,7 +117,6 @@ export default class Geometry {
   public readonly container: Group = null;
   /** scale 配置 */
   public scaleDefs: ScaleOption = {};
-
   /** 是否生成多个点来绘制图形 */
   public generatePoints: boolean = false;
   /** 是否对数据进行排序 */
@@ -131,28 +125,35 @@ export default class Geometry {
   public visible: boolean = true;
   /** 配置主题 */
   public theme: LooseObject = null;
+  /** scale·实例集合 */
+  public scales: Record<string, Scale> = {};
 
-  /** 图形属性映射配置 */
-  public attributeOption: Record<string, AttributeOption> = {};
-  /** tooltip 配置项 */
-  public tooltipOption = null;
-  /** adjust 配置项 */
-  public adjustOption = null;
-  /** style 配置项 */
-  public styleOption = null;
-  /** label 配置项 */
-  public labelOption = null;
-  /** animate 配置项 */
-  public animateOption = null;
-
+  // 计算生成的属性
+  /** 图形属性对象 */
+  public attributes: Record<string, Attribute> = {};
+  /** Element 实例集合 */
+  public elements: Element[] = [];
   /** 分组、数字化、adjust 后的数据 */
   public dataArray;
+
+  // 配置项属性存储
+  /** 图形属性映射配置 */
+  protected attributeOption: Record<string, AttributeOption> = {};
+  /** tooltip 配置项 */
+  protected tooltipOption = null;
+  /** adjust 配置项 */
+  protected adjustOption = null;
+  /** style 配置项 */
+  protected styleOption = null;
+  /** label 配置项 */
+  protected labelOption = null;
+  /** animate 配置项 */
+  protected animateOption = null;
 
   private shapeFactory;
   private adjusts: Record<string, Adjust> = {};
   private elementsMap: Record<string, Element> = {};
   private lastElementsMap: Record<string, Element> = {};
-  private groupScales: Scale[];
 
   constructor(cfg) {
     _.mix(this, cfg);
@@ -362,7 +363,6 @@ export default class Geometry {
     this.elementsMap = {};
     this.lastElementsMap = {};
     this.elements = [];
-    this.groupScales = null;
     this.dataArray = null;
   }
 
@@ -376,23 +376,19 @@ export default class Geometry {
   }
 
   public getGroupScales() {
-    let scales = this.groupScales;
-    if (!scales) {
-      scales = [];
-      const attributes = this.attributes;
-      _.each(attributes, (attr: Attribute) => {
-        if (GROUP_ATTRS.indexOf(attr.type) !== -1) {
-          const attrScales = attr.scales;
-          _.each(attrScales, (scale: Scale) => {
-            if (scale.isCategory && _.indexOf(scales, scale) === -1) {
-              scales.push(scale);
-            }
-          });
-        }
-      });
+    const scales = [];
+    const attributes = this.attributes;
+    _.each(attributes, (attr: Attribute) => {
+      if (GROUP_ATTRS.indexOf(attr.type) !== -1) {
+        const attrScales = attr.scales;
+        _.each(attrScales, (scale: Scale) => {
+          if (scale.isCategory && _.indexOf(scales, scale) === -1) {
+            scales.push(scale);
+          }
+        });
+      }
+    });
 
-      this.groupScales = scales;
-    }
     return scales;
   }
 

--- a/tests/unit/geometry/geometry-spec.ts
+++ b/tests/unit/geometry/geometry-spec.ts
@@ -442,7 +442,6 @@ describe('Geometry', () => {
       expect(geometry.elementsMap).to.eql({});
       expect(geometry.lastElementsMap).to.eql({});
       expect(geometry.elements).to.eql([]);
-      expect(geometry.groupScales).to.equal(null);
     });
 
     it('destroy()', () => {


### PR DESCRIPTION
https://github.com/antvis/g2/issues/1511 

是由于缓存了 groupScales 导致的，如果重复调用 chart.render() 方法，在进行 geometry.init() 时会影响数据的分组。

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is an new feature.
-->

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [ ] All tests pass and/or benchmarks are included
- [ ] Commit message follows commit guidelines
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
