### PR TITLE
remove baseUrl of tsconfig

### DIFF
--- a/src/chart/__components__/mock-component.ts
+++ b/src/chart/__components__/mock-component.ts
@@ -1,5 +1,5 @@
-import { Position } from 'interface';
 import Component from '../../component';
+import { Position } from '../../interface';
 
 interface MockComponentProps {
   readonly text: string;

--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -1,5 +1,23 @@
 import EE from '@antv/event-emitter';
 import * as _ from '@antv/util';
+import Component from '../component';
+import { ComponentType, DIRECTION, GroupZIndex, LAYER, ViewLifeCircle } from '../constant';
+import { Coordinate, Scale } from '../dependents';
+import { Attribute } from '../dependents';
+import { BBox, ICanvas, IGroup } from '../dependents';
+import { Facet, getFacet } from '../facet';
+import { FacetCfgMap } from '../facet/interface';
+import Geometry from '../geometry/base';
+import Interaction from '../interaction';
+import { Point, Region } from '../interface';
+import { Data, Datum } from '../interface';
+import { isFullCircle } from '../util/coordinate';
+import { parsePadding } from '../util/padding';
+import { mergeTheme } from '../util/theme';
+import Chart from './chart';
+import { createAxes } from './controller/axis';
+import { createCoordinate } from './controller/coordinate';
+import { createLegends } from './controller/legend';
 import {
   AxisOption,
   ComponentOption,
@@ -10,25 +28,7 @@ import {
   Options,
   ScaleOption,
   ViewCfg,
-} from 'chart/interface';
-import Component from 'component';
-import { Coordinate, Scale } from 'dependents';
-import Geometry from 'geometry/base';
-import Interaction from 'interaction';
-import { Padding, Point, Region } from 'interface';
-import { ComponentType, DIRECTION, GroupZIndex, LAYER, ViewLifeCircle } from '../constant';
-import { Attribute } from '../dependents';
-import { BBox, ICanvas, IGroup } from '../dependents';
-import { Facet, getFacet } from '../facet';
-import { FacetCfg, FacetCfgMap } from '../facet/interface';
-import { Data, Datum } from '../interface';
-import { isFullCircle } from '../util/coordinate';
-import { parsePadding } from '../util/padding';
-import { mergeTheme } from '../util/theme';
-import Chart from './chart';
-import { createAxes } from './controller/axis';
-import { createCoordinate } from './controller/coordinate';
-import { createLegends } from './controller/legend';
+} from './interface';
 import defaultLayout, { Layout } from './layout';
 
 /*

--- a/src/geometry/interval.ts
+++ b/src/geometry/interval.ts
@@ -1,5 +1,5 @@
 import * as _ from '@antv/util';
-import { LooseObject } from 'interface';
+import { LooseObject } from '../interface';
 import { getXDimensionLength } from '../util/coordinate';
 import Geometry from './base';
 /** 引入对应的 ShapeFactory */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "lib": ["esnext", "dom"],
-    "baseUrl": "src",
     "types": ["jest"]
   },
   "include": ["src"]


### PR DESCRIPTION
`baseUrl` 会导致编译出来的代码一样是以 baseUrl 为相对路径的，那么在上层 import g2 的时候，会导致找不到文件路径。

所以删除掉，并更新 import 的写法，还是以相对路径来写。