### PR TITLE
fix: 多y轴无法隐藏指定legend

### DIFF
--- a/src/chart/controller/legend.js
+++ b/src/chart/controller/legend.js
@@ -853,11 +853,13 @@ class LegendController {
 
   addMixedLegend(scales, geoms) {
     const self = this;
+    const legendOptions = self.options;
     const items = [];
     Util.each(scales, scale => {
       const value = scale.alias || scale.field;
+      const fieldLegendOptions = legendOptions[value];
       Util.each(geoms, geom => {
-        if (geom.getYScale() === scale && scale.values && scale.values.length > 0) {
+        if (geom.getYScale() === scale && scale.values && scale.values.length > 0 && fieldLegendOptions !== false) {
           const shapeType = geom.get('shapeType') || 'point';
           const shape = geom.getDefaultValue('shape') || 'circle';
           const shapeObject = Shape.getShapeFactory(shapeType);

--- a/src/chart/controller/legend.js
+++ b/src/chart/controller/legend.js
@@ -857,7 +857,7 @@ class LegendController {
     const items = [];
     Util.each(scales, scale => {
       const value = scale.alias || scale.field;
-      const fieldLegendOptions = legendOptions[value];
+      const fieldLegendOptions = legendOptions[scale.field];
       Util.each(geoms, geom => {
         if (geom.getYScale() === scale && scale.values && scale.values.length > 0 && fieldLegendOptions !== false) {
           const shapeType = geom.get('shapeType') || 'point';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

[Demo Link](https://jsfiddle.net/hengwensite/6Lrhkqfx/4/)

### 💡 Background and solution

场景：一个图里有三条线，当日值，对比日值和比对比日的比率，希望图里只展示当日值和对比日值两条线，比对比日的数据不在趋势图和图例上呈现，只在 tooltip 显示。
解决方案：在 `addMixedLegend` 方法中过滤掉不需要展示的y轴。

### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix failure of `chart.legend(field, false)` in case of multiple y axes      |
| 🇨🇳 Chinese |  修复多y轴情况下`chart.legend(field, false)`失效问题    |

### ☑️ Self Check before Merge

- [x] All tests pass and/or benchmarks are included
- [x] Commit message follows commit guidelines
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
