### PR TITLE
添加 Tooltip 相关的工具函数

### DIFF
--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -248,9 +248,6 @@ export default class View extends EE {
     return this;
   }
 
-  /**
-   * 坐标轴配置
-   */
   public axis(field: boolean): View;
   public axis(field: string, axisOption: AxisOption): View;
   public axis(field: string | boolean, axisOption?: AxisOption): View {

--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -116,10 +116,10 @@ export default class Geometry {
   public dataArray: Data[];
 
   // 配置项属性存储
+  /** tooltip 配置项 */
+  public tooltipOption: TooltipOption | boolean;
   /** 图形属性映射配置 */
   protected attributeOption: Record<string, AttributeOption> = {};
-  /** tooltip 配置项 */
-  protected tooltipOption: TooltipOption | boolean;
   /** adjust 配置项 */
   protected adjustOption: AdjustOption[];
   /** style 配置项 */

--- a/src/util/scale.ts
+++ b/src/util/scale.ts
@@ -112,3 +112,7 @@ export function syncScale(scale: Scale, newScale: Scale) {
     scale.change(obj);
   }
 }
+
+export function getName(scale: Scale): string {
+  return scale.alias || scale.field;
+}

--- a/src/util/tooltip.ts
+++ b/src/util/tooltip.ts
@@ -1,0 +1,365 @@
+import * as _ from '@antv/util';
+import { FIELD_ORIGIN, GROUP_ATTRS } from '../constant';
+import { Attribute, Scale } from '../dependents';
+import Geometry from '../geometry/base';
+import { Data, Datum, Point } from '../interface';
+import { getName } from './scale';
+
+function snapEqual(v1: any, v2: any, scale: Scale) {
+  const value1 = scale.translate(v1);
+  const value2 = scale.translate(v2);
+
+  if (scale.isCategory) {
+    return value1 === value2;
+  }
+  return _.isNumberEqual(value1, value2);
+}
+
+function getXValueByPoint(point: Point, geometry: Geometry): number {
+  let result = 0;
+  const coordinate = geometry.coordinate;
+  const xScale = geometry.getXScale();
+  const range = xScale.range;
+  const rangeMax = range[range.length - 1];
+  const rangeMin = range[0];
+
+  const invertPoint = coordinate.invert(point);
+
+  let xValue = invertPoint.x;
+  if (coordinate.isPolar && xValue > (1 + rangeMax) / 2) {
+    xValue = rangeMin; // 极坐标下，scale 的 range 被做过特殊处理
+  }
+
+  result = xScale.invert(xValue);
+  if (xScale.isCategory) {
+    // 分类类型，要将字符串类型转换成数字
+    result = xScale.translate(result);
+  }
+
+  return result;
+}
+
+function filterYValue(arr: Data, point: Point, geometry: Geometry) {
+  const coordinate = geometry.coordinate;
+  const yScale = geometry.getYScale();
+  const yField = yScale.field;
+  const invertPoint = coordinate.invert(point);
+
+  const yValue = yScale.invert(invertPoint.y);
+  let rst = arr[arr.length - 1];
+
+  _.each(arr, (obj) => {
+    const origin = obj[FIELD_ORIGIN];
+    if (origin[yField][0] <= yValue && origin[yField][1] >= yValue) {
+      rst = obj;
+      return false;
+    }
+  });
+  return rst;
+}
+
+function getXDistance(geometry: Geometry) {
+  // @ts-ignore 缓存，但是不对外暴露
+  let distance = geometry._xDistance;
+  if (!distance) {
+    const xScale = geometry.getXScale();
+    if (xScale.isCategory) {
+      distance = 1;
+    } else {
+      const values = xScale.values; // values 是无序的
+      let min = xScale.translate(values[0]);
+      let max = min;
+      _.each(values, (value) => {
+        // 时间类型需要 translate
+        const numericValue = xScale.translate(value);
+        if (numericValue < min) {
+          min = numericValue;
+        }
+        if (numericValue > max) {
+          max = numericValue;
+        }
+      });
+      const length = values.length;
+      // 应该是除以 length - 1
+      distance = (max - min) / (length - 1);
+    }
+    // @ts-ignore
+    geometry._xDistance = distance; // 缓存，防止重复计算
+  }
+
+  return distance;
+}
+
+function getTooltipTitle(originData: Datum, geometry: Geometry) {
+  const scales = geometry.scales;
+  const positionAttr = geometry.getAttribute('position');
+  const fields = positionAttr.getFields();
+  const titleScale = scales[fields[0]];
+
+  if (titleScale) {
+    return titleScale.getText(originData[titleScale.field]);
+  }
+  return '';
+}
+
+function getAttributesForLegend(geometry: Geometry) {
+  const attributes = _.values(geometry.attributes);
+  return _.filter(attributes, (attribute: Attribute) => _.contains(GROUP_ATTRS, attribute.type));
+}
+
+function getTooltipValueScale(geometry: Geometry) {
+  const attributes = getAttributesForLegend(geometry);
+  let scale;
+  _.each(attributes, (attribute: Attribute) => {
+    const tmpScale = attribute.getScale(attribute.type);
+    if (tmpScale && tmpScale.isLinear) {
+      // 如果指定字段是非 position 的，同时是连续的
+      scale = tmpScale;
+      return false;
+    }
+  });
+
+  const xScale = geometry.getXScale();
+  const yScale = geometry.getYScale();
+
+  return scale || yScale || xScale;
+}
+
+function getTooltipValue(originData: Datum, valueScale: Scale) {
+  const field = valueScale.field;
+  const value = originData[field];
+
+  if (_.isArray(value)) {
+    const values = value.map((eachValue) => {
+      return valueScale.getText(eachValue);
+    });
+    return values.join('-');
+  }
+  return valueScale.getText(value);
+}
+
+// 根据原始数据获取 tooltip item 中 name 值
+function getTooltipName(originData: Datum, geometry: Geometry) {
+  let nameScale: Scale;
+  const groupScales = geometry.getGroupScales();
+  if (groupScales.length) {
+    // 如果存在分组类型，取第一个分组类型
+    _.each(groupScales, (scale: Scale) => {
+      nameScale = scale;
+      return false;
+    });
+  }
+  if (nameScale) {
+    const field = nameScale.field;
+    return nameScale.getText(originData[field]);
+  }
+
+  const valueScale = getTooltipValueScale(geometry);
+  return getName(valueScale);
+}
+
+export function findDataByPoint(point: Point, data: Data, geometry: Geometry) {
+  if (data.length === 0) {
+    return null;
+  }
+
+  const geometryType = geometry.type;
+  const xScale = geometry.getXScale();
+  const yScale = geometry.getYScale();
+
+  const xField = xScale.field;
+  const yField = yScale.field;
+
+  let rst = null;
+
+  // 点图以及热力图采用最小逼近策略查找 point 击中的数据
+  if (geometryType === 'point' /* || geometryType === 'heatmap' */) {
+    // 将 point 画布坐标转换为原始数据值
+    const coordinate = geometry.coordinate;
+    const invertPoint = coordinate.invert(point); // 转换成归一化的数据
+    const x = xScale.invert(invertPoint.x); // 转换为原始值
+    const y = yScale.invert(invertPoint.y); // 转换为原始值
+
+    let min = Infinity;
+    _.each(data, (obj: Datum) => {
+      const originData = obj[FIELD_ORIGIN];
+      const range = (originData[xField] - x) ** 2 + (originData[yField] - y) ** 2;
+      if (range < min) {
+        min = range;
+        rst = obj;
+      }
+    });
+
+    return rst;
+  }
+
+  // 其他 Geometry 类型按照 x 字段数据进行查找
+  const first = data[0];
+  let last = data[data.length - 1];
+
+  const xValue = getXValueByPoint(point, geometry);
+  const firstXValue = first[FIELD_ORIGIN][xField];
+  const firstYValue = first[FIELD_ORIGIN][yField];
+  const lastXValue = last[FIELD_ORIGIN][xField];
+  const isYArray = yScale.isLinear && _.isArray(firstYValue); // 考虑 x 维度相同，y 是数组区间的情况
+
+  // 如果 x 的值是数组
+  if (_.isArray(firstXValue)) {
+    _.each(data, (record: Datum) => {
+      const origin = record[FIELD_ORIGIN];
+      // xValue 在 origin[xField] 的数值区间内
+      if (xScale.translate(origin[xField][0]) <= xValue && xScale.translate(origin[xField][1]) >= xValue) {
+        if (isYArray) {
+          // 层叠直方图场景，x 和 y 都是数组区间
+          if (!_.isArray(rst)) {
+            rst = [];
+          }
+          rst.push(record);
+        } else {
+          rst = record;
+          return false;
+        }
+      }
+    });
+    if (_.isArray(rst)) {
+      rst = filterYValue(rst, point, geometry);
+    }
+  } else {
+    let next;
+    if (!xScale.isLinear && xScale.type !== 'timeCat') {
+      // x 轴对应的数据为非线性以及非时间类型的数据采用遍历查找
+      _.each(data, (record: Datum, index: number) => {
+        const origin = record[FIELD_ORIGIN];
+        if (snapEqual(origin[xField], xValue, xScale)) {
+          if (isYArray) {
+            if (!_.isArray(rst)) {
+              rst = [];
+            }
+            rst.push(record);
+          } else {
+            rst = record;
+            return false;
+          }
+        } else if (xScale.translate(origin[xField]) <= xValue) {
+          last = record;
+          next = data[index + 1];
+        }
+      });
+
+      if (_.isArray(rst)) {
+        rst = filterYValue(rst, point, geometry);
+      }
+    } else {
+      // x 轴对应的数据为线性以及时间类型，进行二分查找，性能更好
+      if (xValue > xScale.translate(lastXValue) || xValue < xScale.translate(firstXValue)) {
+        // 不在数据范围内
+        return null;
+      }
+
+      let firstIdx = 0;
+      let lastIdx = data.length - 1;
+      let middleIdx;
+      while (firstIdx <= lastIdx) {
+        middleIdx = Math.floor((firstIdx + lastIdx) / 2);
+        const item = data[middleIdx][FIELD_ORIGIN][xField];
+        if (snapEqual(item, xValue, xScale)) {
+          return data[middleIdx];
+        }
+
+        if (xScale.translate(item) <= xScale.translate(xValue)) {
+          firstIdx = middleIdx + 1;
+          last = data[middleIdx];
+          next = data[middleIdx + 1];
+        } else {
+          if (lastIdx === 0) {
+            last = data[0];
+          }
+          lastIdx = middleIdx - 1;
+        }
+      }
+    }
+
+    if (last && next) {
+      // 计算最逼近的
+      if (
+        Math.abs(xScale.translate(last[FIELD_ORIGIN][xField]) - xValue) >
+        Math.abs(xScale.translate(next[FIELD_ORIGIN][xField]) - xValue)
+      ) {
+        last = next;
+      }
+    }
+  }
+
+  const distance = getXDistance(geometry); // 每个分类间的平均间距
+  if (!rst && Math.abs(xScale.translate(last[FIELD_ORIGIN][xField]) - xValue) <= distance / 2) {
+    rst = last;
+  }
+
+  return rst;
+}
+
+export function getTooltipItems(data: Datum, geometry: Geometry) {
+  const origin = data[FIELD_ORIGIN];
+  const tooltipTitle = getTooltipTitle(origin, geometry);
+  const tooltipOption = geometry.tooltipOption;
+  const { defaultColor } = geometry.theme;
+  const items = [];
+  let name;
+  let value;
+
+  function addItem(itemName, itemValue) {
+    if (!_.isNil(itemValue) && itemValue !== '') {
+      // 值为 null的时候，忽视
+      const item = {
+        title: tooltipTitle,
+        data: origin, // 原始数据
+        name: itemName || tooltipTitle,
+        value: itemValue,
+        color: data.color || defaultColor,
+        marker: true,
+      };
+
+      items.push(item);
+    }
+  }
+
+  if (_.isObject(tooltipOption)) {
+    const { fields, callback } = tooltipOption;
+    if (callback) {
+      // 用户定义了回调函数
+      const callbackParams = fields.map((field: string) => {
+        return data[FIELD_ORIGIN][field];
+      });
+      const cfg = callback(...callbackParams);
+      const itemCfg = {
+        data: data[FIELD_ORIGIN], // 原始数据
+        title: tooltipTitle,
+        color: data.color || defaultColor,
+        marker: true, // 默认展示 marker
+        ...cfg,
+      };
+
+      items.push(itemCfg);
+    } else {
+      const scales = geometry.scales;
+      _.each(fields, (field: string) => {
+        if (!_.isNil(origin[field])) {
+          // 字段数据为null, undefined 时不显示
+          const scale = scales[field];
+          name = getName(scale);
+          value = scale.getText(origin[field]);
+          addItem(name, value);
+        }
+      });
+    }
+  } else {
+    const valueScale = getTooltipValueScale(geometry);
+    if (!_.isNil(origin[valueScale.field])) {
+      // 字段数据为null ,undefined时不显示
+      value = getTooltipValue(origin, valueScale);
+      name = getTooltipName(origin, geometry);
+      addItem(name, value);
+    }
+  }
+  return items;
+}

--- a/tests/unit/util/scale-spec.ts
+++ b/tests/unit/util/scale-spec.ts
@@ -1,4 +1,4 @@
-import { createScaleByField, syncScale } from '../../../src/util/scale';
+import { createScaleByField, getName, syncScale } from '../../../src/util/scale';
 
 describe('ScaleUtil', () => {
   const data1 = [{ a: 1, b: '2', c: '2010-01-01', d: 1, e: null }];
@@ -86,5 +86,12 @@ describe('ScaleUtil', () => {
     const newScale = createScaleByField('name', newData);
     syncScale(oldScale, newScale);
     expect(oldScale.values).toEqual(['C', 'B']);
+  });
+
+  it('getName', () => {
+    const scale = createScaleByField('b', data1);
+    expect(getName(scale)).toBe('b');
+    const aliasScale = createScaleByField('b', data1, { alias: '字段 B' });
+    expect(getName(aliasScale)).toBe('字段 B');
   });
 });

--- a/tests/unit/util/tooltip-spec.ts
+++ b/tests/unit/util/tooltip-spec.ts
@@ -1,0 +1,137 @@
+import { getCoordinate } from '@antv/coord';
+import Interval from '../../../src/geometry/interval';
+import Line from '../../../src/geometry/line';
+import Point from '../../../src/geometry/point';
+import Theme from '../../../src/theme/antv';
+import { findDataByPoint, getTooltipItems } from '../../../src/util/tooltip';
+import { CITY_SALE, DIAMOND } from '../../util/data';
+import { createCanvas, createDiv, removeDom } from '../../util/dom';
+
+const CartesianCoordinate = getCoordinate('rect');
+
+describe('Tooltip functions', () => {
+  const div = createDiv();
+  const canvas = createCanvas({
+    container: div,
+  });
+  const rectCoord = new CartesianCoordinate({
+    start: { x: 0, y: 180 },
+    end: { x: 180, y: 0 },
+  });
+
+  describe('x is category', () => {
+    const interval = new Interval({
+      data: CITY_SALE,
+      theme: Theme,
+      coordinate: rectCoord,
+      scaleDefs: {
+        city: {
+          range: [0.25, 0.75],
+        },
+      },
+      container: canvas.addGroup(),
+    });
+
+    interval
+      .position('city*sale')
+      .color('category')
+      .adjust('stack');
+    interval.init();
+    interval.paint();
+
+    it('findDataByPoint', () => {
+      expect(findDataByPoint({ x: 100, y: 200 }, [], interval)).toBe(null);
+
+      const point = { x: 100, y: 30 };
+      const data = interval.dataArray[0];
+      const result = findDataByPoint(point, data, interval);
+      expect(result._origin).toEqual({ city: '上海', sale: 110, category: '电脑' });
+    });
+
+    it('getTooltipItems', () => {
+      const data = findDataByPoint({ x: 100, y: 30 }, interval.dataArray[0], interval);
+      const tooltipItems = getTooltipItems(data, interval);
+      expect(tooltipItems.length).toBe(1);
+      expect(tooltipItems[0]).toEqual({
+        title: '上海',
+        data: { city: '上海', sale: 110, category: '电脑' },
+        name: '电脑',
+        value: '110',
+        color: '#5B8FF9',
+        marker: true,
+      });
+
+      interval.destroy();
+    });
+  });
+
+  describe('geometry is point', () => {
+    const point = new Point({
+      data: DIAMOND,
+      theme: Theme,
+      coordinate: rectCoord,
+      container: canvas.addGroup(),
+    });
+
+    point.position('carat*price').color('cut');
+    point.init();
+    point.paint();
+
+    it('findDataByPoint', () => {
+      const data = point.dataArray[0];
+      const result = findDataByPoint({ x: 100, y: 90 }, data, point);
+      expect(result._origin.carat).toBe(1.5);
+      expect(result._origin.price).toBe(9996);
+      expect(result._origin.cut).toBe('Ideal');
+
+      point.destroy();
+    });
+  });
+
+  describe('x is linear', () => {
+    const line = new Line({
+      data: [
+        { year: 1991, value: 15468 },
+        { year: 1992, value: 16100 },
+        { year: 1993, value: 15900 },
+        { year: 1994, value: 20000 },
+        { year: 1995, value: 17000 },
+        { year: 1996, value: 31056 },
+        { year: 1997, value: 31982 },
+        { year: 1998, value: 32040 },
+        { year: 1999, value: 33233 },
+      ],
+      theme: Theme,
+      coordinate: rectCoord,
+      container: canvas.addGroup(),
+    });
+
+    line.position('year*value');
+    line.init();
+    line.paint();
+
+    it('findDataByPoint', () => {
+      const data = line.dataArray[0];
+      const result = findDataByPoint({ x: 100, y: 90 }, data, line);
+      expect(result._origin).toEqual({ year: 1995, value: 17000 });
+    });
+
+    it('getTooltipItems', () => {
+      const data = findDataByPoint({ x: 100, y: 90 }, line.dataArray[0], line);
+      const tooltipItems = getTooltipItems(data, line);
+      expect(tooltipItems[0]).toEqual({
+        title: '1995',
+        data: { year: 1995, value: 17000 },
+        name: 'value',
+        value: '17000',
+        color: '#1890FF',
+        marker: true,
+      });
+    });
+  });
+
+  afterAll(() => {
+    canvas.destroy();
+    removeDom(div);
+  });
+});


### PR DESCRIPTION
主要迁移 3.6.x 中的 geometry 下 tooltipController 的代码，在 4.0 里面通过工具函数的形式提供

* `findDataByPoint(point, data, geometry)` 对应 3.6 的 `findPoint(point, data)`
* `getTooltipItems(data, geometry)` 对应 3.6 的 `getTooltipItems(data, title)`，4.0 中不再支持传入 title 字段，后续以 Tooltip 组件的需求为准，看是否加入