### PR TITLE
Shape 添加 getMarker() 方法

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@antv/component": "^0.5.0-beta.1",
     "@antv/coord": "^0.2.1",
     "@antv/event-emitter": "~0.1.0",
-    "@antv/g-base": "^0.1.0-beta.7",
+    "@antv/g-base": "^0.1.0-beta.8",
     "@antv/g-canvas": "^0.1.0-beta.8",
     "@antv/matrix-util": "^2.0.4",
     "@antv/path-util": "^2.0.3",

--- a/src/dependents.ts
+++ b/src/dependents.ts
@@ -4,6 +4,7 @@
 export { registerAdjust, getAdjust, Adjust } from '@antv/adjust/lib/factory';
 export { getAttribute, Attribute, colorUtil } from '@antv/attr/lib/factory';
 export { ICanvas, IGroup, IShape } from '@antv/g-base/lib/interfaces';
+export { PathCommand } from '@antv/g-base/lib/types';
 
 // coordinate 全部引入即可
 export { getCoordinate, registerCoordinate, Coordinate, CoordinateCfg } from '@antv/coord';

--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -614,7 +614,7 @@ export default class Geometry {
       const shapeType = this.shapeType;
       const coordinate = this.coordinate;
       shapeFactory = getShapeFactory(shapeType);
-      shapeFactory.setCoordinate(coordinate);
+      shapeFactory.coordinate = coordinate;
       this.shapeFactory = shapeFactory;
     }
 

--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -453,6 +453,21 @@ export default class Geometry {
     return this.adjusts[adjustType];
   }
 
+  // 获取 element 对应 shape 的工厂对象
+  public getShapeFactory() {
+    let shapeFactory = this.shapeFactory;
+    if (!shapeFactory) {
+      const shapeType = this.shapeType;
+      const coordinate = this.coordinate;
+      shapeFactory = getShapeFactory(shapeType);
+      shapeFactory.coordinate = coordinate;
+      shapeFactory.theme = _.get(this.theme, shapeType, {});
+      this.shapeFactory = shapeFactory;
+    }
+
+    return shapeFactory;
+  }
+
   protected updateScales() {
     const { scaleDefs, scales, data } = this;
     _.each(scales, (scale) => {
@@ -605,21 +620,6 @@ export default class Geometry {
     }
 
     return id;
-  }
-
-  // 获取 element 对应 shape 的工厂对象
-  protected getShapeFactory() {
-    let shapeFactory = this.shapeFactory;
-    if (!shapeFactory) {
-      const shapeType = this.shapeType;
-      const coordinate = this.coordinate;
-      shapeFactory = getShapeFactory(shapeType);
-      shapeFactory.coordinate = coordinate;
-      shapeFactory.theme = _.get(this.theme, shapeType, {});
-      this.shapeFactory = shapeFactory;
-    }
-
-    return shapeFactory;
   }
 
   // 创建图形属性相关的配置项

--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -615,6 +615,7 @@ export default class Geometry {
       const coordinate = this.coordinate;
       shapeFactory = getShapeFactory(shapeType);
       shapeFactory.coordinate = coordinate;
+      shapeFactory.theme = _.get(this.theme, shapeType, {});
       this.shapeFactory = shapeFactory;
     }
 

--- a/src/geometry/shape/area.ts
+++ b/src/geometry/shape/area.ts
@@ -65,7 +65,7 @@ function getStyle(shapeName: string, cfg: ShapeDrawCFG) {
   return attrs;
 }
 
-function getAttrs(
+function getShapeAttrs(
   shapeName: string,
   cfg: ShapeDrawCFG,
   smooth: boolean,
@@ -90,6 +90,16 @@ function getConstraint(coordinate: Coordinate): Position[] {
   return [[start.x, end.y], [end.x, start.y]];
 }
 
+function getMarkerCfg(color: string) {
+  return {
+    symbol(x: number, y: number, r: number = 5.5) {
+      return [['M', x - r, y - 4], ['L', x + r, y - 4], ['L', x + r, y + 4], ['L', x - r, y + 4], ['Z']];
+    },
+    r: 5,
+    fill: color,
+  };
+}
+
 const AreaShapeFactory = registerShapeFactory('area', {
   defaultShapeType: 'area',
   getDefaultPoints(pointInfo: ShapePoint): Point[] {
@@ -109,7 +119,7 @@ const AreaShapeFactory = registerShapeFactory('area', {
 // 填充的区域图
 registerShape('area', 'area', {
   draw(cfg: ShapeDrawCFG, element: Element) {
-    const attrs = getAttrs('area', cfg, false, this);
+    const attrs = getShapeAttrs('area', cfg, false, this);
     const shape = element.container.addShape({
       type: 'path',
       attrs,
@@ -123,19 +133,22 @@ registerShape('area', 'area', {
   },
   update(cfg: ShapeDrawCFG, element: Element) {
     const shape = element.shape;
-    const attrs = getAttrs('area', cfg, false, this);
+    const attrs = getShapeAttrs('area', cfg, false, this);
     if (cfg.animate) {
       doAnimate(shape, cfg, this.coordinate, attrs);
     } else {
       shape.attr(attrs);
     }
+  },
+  getMarker(color: string, isInCircle: boolean) {
+    return getMarkerCfg(color);
   },
 });
 
 // 描边不填充的区域图
 registerShape('area', 'line', {
   draw(cfg: ShapeDrawCFG, element: Element) {
-    const attrs = getAttrs('line', cfg, false, this);
+    const attrs = getShapeAttrs('line', cfg, false, this);
     const shape = element.container.addShape({
       type: 'path',
       attrs,
@@ -149,12 +162,15 @@ registerShape('area', 'line', {
   },
   update(cfg: ShapeDrawCFG, element: Element) {
     const shape = element.shape;
-    const attrs = getAttrs('line', cfg, false, this);
+    const attrs = getShapeAttrs('line', cfg, false, this);
     if (cfg.animate) {
       doAnimate(shape, cfg, this.coordinate, attrs);
     } else {
       shape.attr(attrs);
     }
+  },
+  getMarker(color: string, isInCircle: boolean) {
+    return getMarkerCfg(color);
   },
 });
 
@@ -162,7 +178,7 @@ registerShape('area', 'line', {
 registerShape('area', 'smooth', {
   draw(cfg: ShapeDrawCFG, element: Element) {
     const coordinate = this.coordinate;
-    const attrs = getAttrs('smooth', cfg, true, this, getConstraint(coordinate));
+    const attrs = getShapeAttrs('smooth', cfg, true, this, getConstraint(coordinate));
     const shape = element.container.addShape({
       type: 'path',
       attrs,
@@ -177,12 +193,15 @@ registerShape('area', 'smooth', {
   update(cfg: ShapeDrawCFG, element: Element) {
     const shape = element.shape;
     const coordinate = this.coordinate;
-    const attrs = getAttrs('smooth', cfg, true, this, getConstraint(coordinate));
+    const attrs = getShapeAttrs('smooth', cfg, true, this, getConstraint(coordinate));
     if (cfg.animate) {
       doAnimate(shape, cfg, coordinate, attrs);
     } else {
       shape.attr(attrs);
     }
+  },
+  getMarker(color: string, isInCircle: boolean) {
+    return getMarkerCfg(color);
   },
 });
 
@@ -190,7 +209,7 @@ registerShape('area', 'smooth', {
 registerShape('area', 'smoothLine', {
   draw(cfg: ShapeDrawCFG, element: Element) {
     const coordinate = this.coordinate;
-    const attrs = getAttrs('smoothLine', cfg, true, this, getConstraint(coordinate));
+    const attrs = getShapeAttrs('smoothLine', cfg, true, this, getConstraint(coordinate));
     const shape = element.container.addShape({
       type: 'path',
       attrs,
@@ -205,12 +224,15 @@ registerShape('area', 'smoothLine', {
   update(cfg: ShapeDrawCFG, element: Element) {
     const shape = element.shape;
     const coordinate = this.coordinate;
-    const attrs = getAttrs('smoothLine', cfg, true, this, getConstraint(coordinate));
+    const attrs = getShapeAttrs('smoothLine', cfg, true, this, getConstraint(coordinate));
     if (cfg.animate) {
       doAnimate(shape, cfg, coordinate, attrs);
     } else {
       shape.attr(attrs);
     }
+  },
+  getMarker(color: string, isInCircle: boolean) {
+    return getMarkerCfg(color);
   },
 });
 

--- a/src/geometry/shape/area.ts
+++ b/src/geometry/shape/area.ts
@@ -90,16 +90,6 @@ function getConstraint(coordinate: Coordinate): Position[] {
   return [[start.x, end.y], [end.x, start.y]];
 }
 
-function getMarkerCfg(color: string) {
-  return {
-    symbol(x: number, y: number, r: number = 5.5) {
-      return [['M', x - r, y - 4], ['L', x + r, y - 4], ['L', x + r, y + 4], ['L', x - r, y + 4], ['Z']];
-    },
-    r: 5,
-    fill: color,
-  };
-}
-
 const AreaShapeFactory = registerShapeFactory('area', {
   defaultShapeType: 'area',
   getDefaultPoints(pointInfo: ShapePoint): Point[] {
@@ -141,7 +131,13 @@ registerShape('area', 'area', {
     }
   },
   getMarker(color: string, isInCircle: boolean) {
-    return getMarkerCfg(color);
+    return {
+      symbol: (x: number, y: number, r: number = 5.5) => {
+        return [['M', x - r, y - 4], ['L', x + r, y - 4], ['L', x + r, y + 4], ['L', x - r, y + 4], ['Z']];
+      },
+      r: 5,
+      fill: color,
+    };
   },
 });
 
@@ -170,7 +166,13 @@ registerShape('area', 'line', {
     }
   },
   getMarker(color: string, isInCircle: boolean) {
-    return getMarkerCfg(color);
+    return {
+      symbol: (x: number, y: number, r: number = 5.5) => {
+        return [['M', x - r, y - 4], ['L', x + r, y - 4], ['L', x + r, y + 4], ['L', x - r, y + 4], ['Z']];
+      },
+      r: 5,
+      stroke: color,
+    };
   },
 });
 
@@ -201,7 +203,13 @@ registerShape('area', 'smooth', {
     }
   },
   getMarker(color: string, isInCircle: boolean) {
-    return getMarkerCfg(color);
+    return {
+      symbol: (x: number, y: number, r: number = 5.5) => {
+        return [['M', x - r, y - 4], ['L', x + r, y - 4], ['L', x + r, y + 4], ['L', x - r, y + 4], ['Z']];
+      },
+      r: 5,
+      fill: color,
+    };
   },
 });
 
@@ -232,7 +240,13 @@ registerShape('area', 'smoothLine', {
     }
   },
   getMarker(color: string, isInCircle: boolean) {
-    return getMarkerCfg(color);
+    return {
+      symbol: (x: number, y: number, r: number = 5.5) => {
+        return [['M', x - r, y - 4], ['L', x + r, y - 4], ['L', x + r, y + 4], ['L', x - r, y + 4], ['Z']];
+      },
+      r: 5,
+      stroke: color,
+    };
   },
 });
 

--- a/src/geometry/shape/area.ts
+++ b/src/geometry/shape/area.ts
@@ -1,5 +1,5 @@
 import * as _ from '@antv/util';
-import { Coordinate } from '../../dependents';
+import { Coordinate, PathCommand } from '../../dependents';
 import { Point, Position, Shape, ShapeDrawCFG, ShapePoint } from '../../interface';
 import { doAnimate } from '../animate/index';
 import Element from '../element';
@@ -13,7 +13,7 @@ function getPath(
   smooth: boolean,
   registeredShape: Shape,
   constraint?: Position[]
-) {
+): PathCommand[] {
   const topLinePoints = []; // area 区域上部分
   let bottomLinePoints = []; // area 区域下部分
   _.each(points, (point) => {

--- a/src/geometry/shape/base.ts
+++ b/src/geometry/shape/base.ts
@@ -23,6 +23,8 @@ const ShapeFactoryBase = {
   coordinate: null,
   /** 默认绘制的 Shape 类型 */
   defaultShapeType: null,
+  /** 主题样式 */
+  theme: null,
   /**
    * 获取 shape 绘制需要的关键点
    * @param shapeType shape 类型

--- a/src/geometry/shape/base.ts
+++ b/src/geometry/shape/base.ts
@@ -57,17 +57,23 @@ const ShapeFactoryBase = {
     return [];
   },
   /**
-   * 获取 shape 对应的缩略图
-   * @override
-   * @param shapeType shape 类型
-   * @param markerCfg 样式配置
-   * @returns
+   * get the shape's thumbnail configuration
+   * @param shapeType the shape type
+   * @param color the shape color
+   * @param isInPolar is polar coordinate
+   * @returns the thumbnail configuration
    */
-  getMarker(shapeType: string, markerCfg: LooseObject) {
+  getMarker(shapeType: string, color: string, isInPolar: boolean) {
     const shape = this.getShape(shapeType);
 
     if (shape.getMarker) {
-      return shape.getMarker(markerCfg);
+      const theme = this.theme;
+      const shapeStyle = _.get(theme, [shapeType, 'default'], {});
+      const markerStyle = shape.getMarker(color, isInPolar);
+      return {
+        ...shapeStyle,
+        ...markerStyle,
+      };
     }
   },
   /**

--- a/src/geometry/shape/base.ts
+++ b/src/geometry/shape/base.ts
@@ -23,10 +23,6 @@ const ShapeFactoryBase = {
   coordinate: null,
   /** 默认绘制的 Shape 类型 */
   defaultShapeType: null,
-
-  setCoordinate(coordinate: Coordinate) {
-    this.coordinate = coordinate;
-  },
   /**
    * 获取 shape 绘制需要的关键点
    * @param shapeType shape 类型

--- a/src/geometry/shape/index.ts
+++ b/src/geometry/shape/index.ts
@@ -1,3 +1,6 @@
 export * from './base';
 export { default as IntervalShapeFactoty } from './interval';
 export { default as PolygonShapeFactoty } from './polygon';
+export { default as AreaShapeFactory } from './area';
+export { default as LineShapeFactory } from './line';
+export { default as PointhapeFactory } from './point';

--- a/src/geometry/shape/interval.ts
+++ b/src/geometry/shape/interval.ts
@@ -206,6 +206,21 @@ registerShape('interval', 'rect', {
       shape.attr(attrs);
     }
   },
+  getMarker(color: string, isInPolar: boolean) {
+    if (isInPolar) {
+      return {
+        symbol: 'circle',
+        r: 4.5,
+        fill: color,
+      };
+    }
+
+    return {
+      symbol: 'square',
+      r: 4,
+      fill: color,
+    };
+  },
 });
 
 // 描边柱状图
@@ -246,6 +261,21 @@ registerShape('interval', 'hollowRect', {
     } else {
       shape.attr(attrs);
     }
+  },
+  getMarker(color: string, isInPolar: boolean) {
+    if (isInPolar) {
+      return {
+        symbol: 'circle',
+        r: 4.5,
+        stroke: color,
+      };
+    }
+
+    return {
+      symbol: 'square',
+      r: 4,
+      stroke: color,
+    };
   },
 });
 
@@ -297,6 +327,15 @@ registerShape('interval', 'line', {
       shape.attr(attrs);
     }
   },
+  getMarker(color: string, isInPolar: boolean) {
+    return {
+      symbol: (x: number, y: number, r: number) => {
+        return [['M', x, y - r], ['L', x, y + r]];
+      },
+      r: 5,
+      stroke: color,
+    };
+  },
 });
 
 // I 形状柱状图，常用于 error bar chart
@@ -339,6 +378,22 @@ registerShape('interval', 'tick', {
     } else {
       shape.attr(attrs);
     }
+  },
+  getMarker(color: string, isInPolar: boolean) {
+    return {
+      symbol: (x: number, y: number, r: number) => {
+        return [
+          ['M', x - r / 2, y - r],
+          ['L', x + r / 2, y - r],
+          ['M', x, y - r],
+          ['L', x, y + r],
+          ['M', x - r / 2, y + r],
+          ['L', x + r / 2, y + r],
+        ];
+      },
+      r: 5,
+      stroke: color,
+    };
   },
 });
 
@@ -385,6 +440,13 @@ registerShape('interval', 'funnel', {
       shape.attr(attrs);
     }
   },
+  getMarker(color: string, isInPolar: boolean) {
+    return {
+      symbol: 'square',
+      r: 4,
+      fill: color,
+    };
+  },
 });
 
 // 金字塔图，尖底漏斗图
@@ -429,6 +491,13 @@ registerShape('interval', 'pyramid', {
     } else {
       shape.attr(attrs);
     }
+  },
+  getMarker(color: string, isInPolar: boolean) {
+    return {
+      symbol: 'square',
+      r: 4,
+      fill: color,
+    };
   },
 });
 

--- a/src/geometry/shape/line.ts
+++ b/src/geometry/shape/line.ts
@@ -7,6 +7,48 @@ import { getPathPoints } from './util/get-path-points';
 import { getLinePath, getSplinePath } from './util/path';
 import { splitPoints } from './util/split-points';
 
+const LineSymbols = {
+  line: (x: number, y: number, r: number) => {
+    return [['M', x - r, y], ['L', x + r, y]];
+  },
+  dot: (x: number, y: number, r: number) => {
+    return [['M', x - r, y], ['L', x + r, y]];
+  },
+  dash: (x: number, y: number, r: number) => {
+    return [['M', x - r, y], ['L', x + r, y]];
+  },
+  smooth: (x: number, y: number, r: number) => {
+    return [['M', x - r, y], ['A', r / 2, r / 2, 0, 1, 1, x, y], ['A', r / 2, r / 2, 0, 1, 0, x + r, y]];
+  },
+  hv: (x: number, y: number, r: number) => {
+    return [['M', x - r - 1, y - 2.5], ['L', x, y - 2.5], ['L', x, y + 2.5], ['L', x + r + 1, y + 2.5]];
+  },
+  vh: (x: number, y: number, r: number) => {
+    return [['M', x - r - 1, y + 2.5], ['L', x, y + 2.5], ['L', x, y - 2.5], ['L', x + r + 1, y - 2.5]];
+  },
+  hvh: (x: number, y: number, r: number) => {
+    return [
+      ['M', x - (r + 1), y + 2.5],
+      ['L', x - r / 2, y + 2.5],
+      ['L', x - r / 2, y - 2.5],
+      ['L', x + r / 2, y - 2.5],
+      ['L', x + r / 2, y + 2.5],
+      ['L', x + r + 1, y + 2.5],
+    ];
+  },
+  vhv: (x: number, y: number) => {
+    // 宽 13px，高 8px
+    return [
+      ['M', x - 5, y + 2.5],
+      ['L', x - 5, y],
+      ['L', x, y],
+      ['L', x, y - 3],
+      ['L', x, y + 3],
+      ['L', x + 6.5, y + 3],
+    ];
+  },
+};
+
 function getStyle(cfg: ShapeDrawCFG) {
   const { style, color, size } = cfg;
   const result = {
@@ -201,6 +243,14 @@ _.each(['line', 'dot', 'dash', 'smooth'], (shapeType) => {
         shape.attr(attrs);
       }
     },
+    getMarker(color: string, isInCircle: boolean) {
+      return {
+        symbol: LineSymbols[shapeType],
+        lineWidth: 2,
+        r: 6,
+        stroke: color,
+      };
+    },
   });
 });
 
@@ -227,6 +277,14 @@ _.each(['hv', 'vh', 'hvh', 'vhv'], (shapeType) => {
       } else {
         shape.attr(attrs);
       }
+    },
+    getMarker(color: string, isInCircle: boolean) {
+      return {
+        symbol: LineSymbols[shapeType],
+        lineWidth: 2,
+        r: 6,
+        stroke: color,
+      };
     },
   });
 });

--- a/src/geometry/shape/point.ts
+++ b/src/geometry/shape/point.ts
@@ -7,6 +7,46 @@ import { splitPoints } from './util/split-points';
 
 const SHAPES = ['circle', 'square', 'bowtie', 'diamond', 'hexagon', 'triangle', 'triangleDown'];
 const HOLLOW_SHAPES = ['cross', 'tick', 'plus', 'hyphen', 'line'];
+const PointSymbols = {
+  hexagon: (x: number, y: number, r: number) => {
+    const diffX = (r / 2) * Math.sqrt(3);
+    return [
+      ['M', x, y - r],
+      ['L', x + diffX, y - r / 2],
+      ['L', x + diffX, y + r / 2],
+      ['L', x, y + r],
+      ['L', x - diffX, y + r / 2],
+      ['L', x - diffX, y - r / 2],
+      ['Z'],
+    ];
+  },
+  bowtie: (x: number, y: number, r: number) => {
+    const diffY = r - 1.5;
+    return [['M', x - r, y - diffY], ['L', x + r, y + diffY], ['L', x + r, y - diffY], ['L', x - r, y + diffY], ['Z']];
+  },
+  cross: (x: number, y: number, r: number) => {
+    return [['M', x - r, y - r], ['L', x + r, y + r], ['M', x + r, y - r], ['L', x - r, y + r]];
+  },
+  tick: (x: number, y: number, r: number) => {
+    return [
+      ['M', x - r / 2, y - r],
+      ['L', x + r / 2, y - r],
+      ['M', x, y - r],
+      ['L', x, y + r],
+      ['M', x - r / 2, y + r],
+      ['L', x + r / 2, y + r],
+    ];
+  },
+  plus: (x: number, y: number, r: number) => {
+    return [['M', x - r, y], ['L', x + r, y], ['M', x, y - r], ['L', x, y + r]];
+  },
+  hyphen: (x: number, y: number, r: number) => {
+    return [['M', x - r, y], ['L', x + r, y]];
+  },
+  line: (x: number, y: number, r: number) => {
+    return [['M', x, y - r], ['L', x, y + r]];
+  },
+};
 
 function getAttributes(cfg, shapeName) {
   const style = cfg.style;
@@ -61,6 +101,13 @@ _.each(SHAPES, (shapeName: string) => {
         shape.attr(attrs);
       }
     },
+    getMarker(color: string, isInCircle: boolean) {
+      return {
+        symbol: PointSymbols[shapeName] || shapeName,
+        r: 4.5,
+        fill: color,
+      };
+    },
   });
   // 添加该 shape 对应的 hollow-shape
   registerShape('point', `hollow${_.upperFirst(shapeName)}`, {
@@ -85,6 +132,13 @@ _.each(SHAPES, (shapeName: string) => {
       } else {
         shape.attr(attrs);
       }
+    },
+    getMarker(color: string, isInCircle: boolean) {
+      return {
+        symbol: PointSymbols[shapeName] || shapeName,
+        r: 4.5,
+        stroke: color,
+      };
     },
   });
 });
@@ -112,6 +166,13 @@ _.each(HOLLOW_SHAPES, (shapeName: string) => {
       } else {
         shape.attr(attrs);
       }
+    },
+    getMarker(color: string, isInCircle: boolean) {
+      return {
+        symbol: PointSymbols[shapeName] || shapeName,
+        r: 4.5,
+        fill: color,
+      };
     },
   });
 });

--- a/src/geometry/shape/point.ts
+++ b/src/geometry/shape/point.ts
@@ -169,9 +169,9 @@ _.each(HOLLOW_SHAPES, (shapeName: string) => {
     },
     getMarker(color: string, isInCircle: boolean) {
       return {
-        symbol: PointSymbols[shapeName] || shapeName,
+        symbol: PointSymbols[shapeName],
         r: 4.5,
-        fill: color,
+        stroke: color,
       };
     },
   });

--- a/src/geometry/shape/polygon.ts
+++ b/src/geometry/shape/polygon.ts
@@ -80,6 +80,13 @@ registerShape('polygon', 'polygon', {
       });
     }
   },
+  getMarker(color: string, isInCircle) {
+    return {
+      symbol: 'square',
+      r: 4,
+      fill: color,
+    };
+  },
 });
 
 export default PolygonShapeFactory;

--- a/src/geometry/shape/util/path.ts
+++ b/src/geometry/shape/util/path.ts
@@ -1,10 +1,10 @@
 import { vec2 } from '@antv/matrix-util';
 import * as _ from '@antv/util';
-import { Coordinate } from '../../../dependents';
+import { Coordinate, PathCommand } from '../../../dependents';
 import { Point, Position } from '../../../interface';
 import { getDistanceToCenter } from '../../../util/coordinate';
 
-function _points2path(points: Point[], isInCircle: boolean): any[] {
+function _points2path(points: Point[], isInCircle: boolean): PathCommand[] {
   const path = [];
   if (points.length) {
     for (let i = 0, length = points.length; i < length; i += 1) {
@@ -33,7 +33,7 @@ function _convertArr(arr: number[], coord: Coordinate): any[] {
   return tmp;
 }
 
-function _convertPolarPath(pre: any[], cur: any[], coord: Coordinate): any[] {
+function _convertPolarPath(pre: PathCommand, cur: PathCommand, coord: Coordinate): PathCommand[] {
   const { isTransposed, startAngle, endAngle } = coord;
 
   const prePoint = {
@@ -69,7 +69,7 @@ function _convertPolarPath(pre: any[], cur: any[], coord: Coordinate): any[] {
 }
 
 // 当存在整体的圆时，去除圆前面和后面的线，防止出现直线穿过整个圆的情形
-function _filterFullCirleLine(path: any[]): void {
+function _filterFullCirleLine(path: PathCommand[]) {
   _.each(path, (subPath, index) => {
     const cur = subPath;
     if (cur[0].toLowerCase() === 'a') {
@@ -166,7 +166,7 @@ export const smoothBezier = (
 };
 
 /** 贝塞尔曲线 */
-export function catmullRom2bezier(crp: number[], z: boolean, constraint: Position[]): any[] {
+export function catmullRom2bezier(crp: number[], z: boolean, constraint: Position[]): PathCommand[] {
   const isLoop = !!z;
   const pointList = [];
   for (let i = 0, l = crp.length; i < l; i += 2) {
@@ -200,12 +200,12 @@ export function catmullRom2bezier(crp: number[], z: boolean, constraint: Positio
 }
 
 /** 将点连接成路径 path */
-export function getLinePath(points: Point[], isInCircle?: boolean): any[] {
+export function getLinePath(points: Point[], isInCircle?: boolean): PathCommand[] {
   return _points2path(points, isInCircle);
 }
 
 /** 根据关键点获取限定了范围的平滑线 */
-export function getSplinePath(points: Point[], isInCircle?: boolean, constaint?: Position[]): any[] {
+export function getSplinePath(points: Point[], isInCircle?: boolean, constaint?: Position[]): PathCommand[] {
   const data = [];
   const first = points[0];
   let prePoint = null;
@@ -242,7 +242,7 @@ export function getPointAngle(coord, point: Point): number {
 }
 
 /** 将归一化后的路径数据转换成坐标 */
-export function convertNormalPath(coord, path: any[]): any[] {
+export function convertNormalPath(coord, path: PathCommand[]): PathCommand[] {
   const tmp = [];
   _.each(path, (subPath) => {
     const action = subPath[0];
@@ -262,10 +262,10 @@ export function convertNormalPath(coord, path: any[]): any[] {
 }
 
 /** 将路径转换为极坐标下的真实路径 */
-export function convertPolarPath(coord, path: any[]): any[] {
+export function convertPolarPath(coord, path: PathCommand[]): PathCommand[] {
   let tmp = [];
-  let pre: any[];
-  let cur: any[];
+  let pre: PathCommand;
+  let cur: PathCommand;
   let transposed: boolean;
   let equals: boolean;
   _.each(path, (subPath, index) => {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -124,8 +124,8 @@ export interface RegisterShapeFactory {
   readonly defaultShapeType: string;
   /** 返回绘制 shape 所有的关键点集合 */
   readonly getDefaultPoints?: (pointInfo: ShapePoint) => Point[];
-  /** 获取 shape 对应的缩略图 */
-  readonly getMarker?: (shapeType: string, markerCfg: LooseObject) => IShape | IGroup;
+  /** 获取 shape 对应的缩略图配置 */
+  readonly getMarker?: (shapeType: string, color: string, isInPolar: boolean) => LooseObject;
   /** 创建具体的 G.Shape 实例 */
   readonly drawShape?: (shapeType: string, cfg: ShapeDrawCFG, element: Element) => IShape | IGroup;
   /** 更新 shape */
@@ -141,7 +141,7 @@ export interface RegisterShape {
   /** 计算绘制需要的关键点，在注册具体的 shape 时由开发者自己定义 */
   readonly getPoints?: (pointInfo: ShapePoint) => Point[];
   /** 获取 shape 对应的缩略图样式配置，在注册具体的 shape 时由开发者自己定义 */
-  readonly getMarker?: (markerCfg: LooseObject) => IShape | IGroup;
+  readonly getMarker?: (color: string, isInPolar: boolean) => LooseObject;
   /** 绘制 */
   readonly draw: (cfg: ShapeDrawCFG, container: Element) => IShape | IGroup;
   /** 更新 shape */

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,4 +1,4 @@
-import { Coordinate, IGroup, IShape, ScaleConfig } from './dependents';
+import { Coordinate, IGroup, IShape, PathCommand, ScaleConfig } from './dependents';
 import Element from './geometry/element';
 
 /** G 的渲染类型 */
@@ -117,6 +117,12 @@ export interface ShapePoint {
   size?: number;
 }
 
+export interface ShapeMarkerCfg {
+  symbol: string | ShapeMarkerSymbol;
+  stroke?: string;
+  fill?: string;
+  r: number;
+}
 // Shape Module start
 /** 注册 ShapeFactory 需要实现的接口 */
 export interface RegisterShapeFactory {
@@ -125,7 +131,7 @@ export interface RegisterShapeFactory {
   /** 返回绘制 shape 所有的关键点集合 */
   readonly getDefaultPoints?: (pointInfo: ShapePoint) => Point[];
   /** 获取 shape 对应的缩略图配置 */
-  readonly getMarker?: (shapeType: string, color: string, isInPolar: boolean) => LooseObject;
+  readonly getMarker?: (shapeType: string, color: string, isInPolar: boolean) => ShapeMarkerCfg;
   /** 创建具体的 G.Shape 实例 */
   readonly drawShape?: (shapeType: string, cfg: ShapeDrawCFG, element: Element) => IShape | IGroup;
   /** 更新 shape */
@@ -141,7 +147,7 @@ export interface RegisterShape {
   /** 计算绘制需要的关键点，在注册具体的 shape 时由开发者自己定义 */
   readonly getPoints?: (pointInfo: ShapePoint) => Point[];
   /** 获取 shape 对应的缩略图样式配置，在注册具体的 shape 时由开发者自己定义 */
-  readonly getMarker?: (color: string, isInPolar: boolean) => LooseObject;
+  readonly getMarker?: (color: string, isInPolar: boolean) => ShapeMarkerCfg;
   /** 绘制 */
   readonly draw: (cfg: ShapeDrawCFG, container: Element) => IShape | IGroup;
   /** 更新 shape */
@@ -184,3 +190,4 @@ export type AttributeType = 'position' | 'size' | 'color' | 'shape';
 export type ScaleType = 'linear' | 'cat' | 'identity' | 'log' | 'pow' | 'time' | 'timeCat';
 export type AdjustType = 'stack' | 'jitter' | 'dodge' | 'symmetric';
 export type ShapeVertices = RangePoint[] | Point[] | Point[][];
+export type ShapeMarkerSymbol = (x: number, y: number, r: number) => PathCommand[];

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -122,6 +122,7 @@ export interface ShapeMarkerCfg {
   stroke?: string;
   fill?: string;
   r: number;
+  [key: string]: any;
 }
 // Shape Module start
 /** 注册 ShapeFactory 需要实现的接口 */

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -170,6 +170,8 @@ export interface ShapeFactory extends RegisterShapeFactory {
   geometryType: string;
   /** 坐标系对象 */
   coordinate: Coordinate;
+  /** ShapeFactory 下所有的主题样式 */
+  theme: LooseObject;
   /** 根据名称获取具体的 shape 对象 */
   getShape: (shapeType: string | string[]) => Shape;
   /** 获取构成 shape 的关键点 */

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -170,8 +170,6 @@ export interface ShapeFactory extends RegisterShapeFactory {
   geometryType: string;
   /** 坐标系对象 */
   coordinate: Coordinate;
-  /** 设置坐标系 */
-  setCoordinate: (coord: Coordinate) => void;
   /** 根据名称获取具体的 shape 对象 */
   getShape: (shapeType: string | string[]) => Shape;
   /** 获取构成 shape 的关键点 */

--- a/tests/unit/geometry/element/index-spec.ts
+++ b/tests/unit/geometry/element/index-spec.ts
@@ -182,7 +182,7 @@ describe('Element', () => {
       end: { x: 200, y: 200 },
     });
     const shapeFactory = Shape.getShapeFactory('interval');
-    shapeFactory.setCoordinate(coordinate);
+    shapeFactory.coordinate = coordinate;
 
     it('model.animate is false', () => {
       element = new Element({

--- a/tests/unit/geometry/shape/area-spec.ts
+++ b/tests/unit/geometry/shape/area-spec.ts
@@ -4,6 +4,8 @@ import AreaShapeFactory from '../../../../src/geometry/shape/area';
 import Theme from '../../../../src/theme/antv';
 import { createCanvas, createDiv, removeDom } from '../../../util/dom';
 
+import 'jest-extended';
+
 const Rect = getCoordinate('rect');
 
 describe('Area shapes', () => {
@@ -18,6 +20,7 @@ describe('Area shapes', () => {
     end: { x: 500, y: 0 },
   });
   AreaShapeFactory.coordinate = rectCoord;
+  AreaShapeFactory.theme = Theme.area;
 
   const element = new Element({
     shapeType: 'area',
@@ -43,6 +46,24 @@ describe('Area shapes', () => {
       y0: 0.5,
     };
     expect(AreaShapeFactory.getDefaultPoints(pointInfo2)).toEqual([{ x: 1, y: 0.5 }, { x: 1, y: 1 }]);
+  });
+
+  it('getMarker()', () => {
+    const areaMarker = AreaShapeFactory.getMarker('area', 'red', false);
+    expect(areaMarker.fill).toBe('red');
+    expect(areaMarker.symbol).toBeFunction();
+
+    const lineMarker = AreaShapeFactory.getMarker('line', 'red', false);
+    expect(lineMarker.stroke).toBe('red');
+    expect(lineMarker.symbol).toBeFunction();
+
+    const smoothMarker = AreaShapeFactory.getMarker('smooth', 'red', false);
+    expect(smoothMarker.fill).toBe('red');
+    expect(smoothMarker.symbol).toBeFunction();
+
+    const smoothLineMarker = AreaShapeFactory.getMarker('smoothLine', 'red', false);
+    expect(smoothLineMarker.stroke).toBe('red');
+    expect(smoothLineMarker.symbol).toBeFunction();
   });
 
   describe('area', () => {

--- a/tests/unit/geometry/shape/area-spec.ts
+++ b/tests/unit/geometry/shape/area-spec.ts
@@ -17,7 +17,7 @@ describe('Area shapes', () => {
     start: { x: 0, y: 500 },
     end: { x: 500, y: 0 },
   });
-  AreaShapeFactory.setCoordinate(rectCoord);
+  AreaShapeFactory.coordinate = rectCoord;
 
   const element = new Element({
     shapeType: 'area',

--- a/tests/unit/geometry/shape/base-spec.ts
+++ b/tests/unit/geometry/shape/base-spec.ts
@@ -72,10 +72,12 @@ describe('Shape', () => {
       });
 
       GeometryShape.registerShape('circleFactory', 'hollowCircle', {
-        // @ts-ignore
-        // mock
-        getMarker() {
-          return 'marker';
+        getMarker(color, isInPolar) {
+          return {
+            symbol: 'circle',
+            r: 5,
+            stroke: color,
+          };
         },
         draw() {
           // @ts-ignore
@@ -89,6 +91,7 @@ describe('Shape', () => {
             },
           });
         },
+        update() {},
       });
       const circleFactory = GeometryShape.getShapeFactory('circleFactory');
       expect(circleFactory.getShape('circle')).not.toBe(undefined);
@@ -164,9 +167,22 @@ describe('Shape', () => {
 
     it('getMarker()', () => {
       const circleFactory = GeometryShape.getShapeFactory('circleFactory');
+      circleFactory.theme = {
+        hollowCircle: {
+          default: {
+            stroke: '#333',
+            lineWidth: 1,
+          },
+        },
+      };
 
-      expect(circleFactory.getMarker('circle', {})).toBe(undefined);
-      expect(circleFactory.getMarker('hollowCircle', {})).toBe('marker');
+      expect(circleFactory.getMarker('circle', 'red', false)).toBe(undefined);
+      expect(circleFactory.getMarker('hollowCircle', 'red', false)).toEqual({
+        symbol: 'circle',
+        r: 5,
+        stroke: 'red',
+        lineWidth: 1,
+      });
     });
 
     it('drawShape()', () => {

--- a/tests/unit/geometry/shape/base-spec.ts
+++ b/tests/unit/geometry/shape/base-spec.ts
@@ -99,7 +99,7 @@ describe('Shape', () => {
   describe('ShapeFactory', () => {
     it('getShape()', () => {
       const circleFactory = GeometryShape.getShapeFactory('circleFactory');
-      circleFactory.setCoordinate(coordinate);
+      circleFactory.coordinate = coordinate;
 
       const shape = circleFactory.getShape('circle');
       expect(shape).toEqual(circleFactory[circleFactory.defaultShapeType]);
@@ -238,7 +238,8 @@ describe('Shape', () => {
         end: { x: 200, y: 200 },
       });
       const circleFactory = GeometryShape.getShapeFactory('circleFactory');
-      circleFactory.setCoordinate(polar);
+      circleFactory.coordinate = polar;
+
       const shape = circleFactory.getShape('circle');
       let path = [['M', 0, 0], ['L', 0, 1], ['L', 0.5, 1]];
       let toPath = shape.parsePath(path, true);

--- a/tests/unit/geometry/shape/interval-spec.ts
+++ b/tests/unit/geometry/shape/interval-spec.ts
@@ -65,7 +65,7 @@ describe('Interval shapes', () => {
   });
 
   describe('rect', () => {
-    IntervalShapeFactory.setCoordinate(rectCoord);
+    IntervalShapeFactory.coordinate = rectCoord;
     const element = new Element({
       shapeType: 'rect',
       shapeFactory: IntervalShapeFactory,
@@ -130,7 +130,8 @@ describe('Interval shapes', () => {
   });
 
   describe('hollowRect', () => {
-    IntervalShapeFactory.setCoordinate(rectCoord);
+    IntervalShapeFactory.coordinate = rectCoord;
+
     const element = new Element({
       shapeType: 'hollowRect',
       shapeFactory: IntervalShapeFactory,
@@ -201,7 +202,8 @@ describe('Interval shapes', () => {
   });
 
   describe('line', () => {
-    IntervalShapeFactory.setCoordinate(rectCoord);
+    IntervalShapeFactory.coordinate = rectCoord;
+
     const element = new Element({
       shapeType: 'line',
       shapeFactory: IntervalShapeFactory,
@@ -297,7 +299,8 @@ describe('Interval shapes', () => {
   });
 
   describe('tick', () => {
-    IntervalShapeFactory.setCoordinate(rectCoord);
+    IntervalShapeFactory.coordinate = rectCoord;
+
     const element = new Element({
       shapeType: 'tick',
       shapeFactory: IntervalShapeFactory,
@@ -405,7 +408,8 @@ describe('Interval shapes', () => {
   });
 
   describe('funnel', () => {
-    IntervalShapeFactory.setCoordinate(rectCoord);
+    IntervalShapeFactory.coordinate = rectCoord;
+
     const element = new Element({
       shapeType: 'funnel',
       shapeFactory: IntervalShapeFactory,
@@ -525,7 +529,8 @@ describe('Interval shapes', () => {
   });
 
   describe('pyramid', () => {
-    IntervalShapeFactory.setCoordinate(rectCoord);
+    IntervalShapeFactory.coordinate = rectCoord;
+
     const element = new Element({
       shapeType: 'pyramid',
       shapeFactory: IntervalShapeFactory,

--- a/tests/unit/geometry/shape/interval-spec.ts
+++ b/tests/unit/geometry/shape/interval-spec.ts
@@ -17,6 +17,7 @@ describe('Interval shapes', () => {
     start: { x: 0, y: 500 },
     end: { x: 500, y: 0 },
   });
+  IntervalShapeFactory.theme = Theme.interval;
 
   describe('IntervalShapeFactory', () => {
     it('defaultShapeType', () => {
@@ -127,6 +128,23 @@ describe('Interval shapes', () => {
       expect(shape.attr('path').length).toBe(6);
       expect(shape.getBBox().width).toBe(250);
     });
+    it('getMarker', () => {
+      const markerCfg = IntervalShapeFactory.getMarker('rect', 'red', false);
+      expect(markerCfg).toEqual({
+        ...Theme.interval.rect.default,
+        symbol: 'square',
+        r: 4,
+        fill: 'red',
+      });
+
+      const polaeMarkerCfg = IntervalShapeFactory.getMarker('rect', 'red', true);
+      expect(polaeMarkerCfg).toEqual({
+        ...Theme.interval.rect.default,
+        symbol: 'circle',
+        r: 4.5,
+        fill: 'red',
+      });
+    });
   });
 
   describe('hollowRect', () => {
@@ -198,6 +216,23 @@ describe('Interval shapes', () => {
       expect(shape.attr('path').length).toBe(6);
       // FIXME: 需要 G 修复 https://github.com/antvis/g/issues/252
       // expect(shape.getBBox().width).toBe(104);
+    });
+    it('getMarker', () => {
+      const markerCfg = IntervalShapeFactory.getMarker('hollowRect', 'red', false);
+      expect(markerCfg).toEqual({
+        ...Theme.interval.hollowRect.default,
+        symbol: 'square',
+        r: 4,
+        stroke: 'red',
+      });
+
+      const polaeMarkerCfg = IntervalShapeFactory.getMarker('hollowRect', 'red', true);
+      expect(polaeMarkerCfg).toEqual({
+        ...Theme.interval.hollowRect.default,
+        symbol: 'circle',
+        r: 4.5,
+        stroke: 'red',
+      });
     });
   });
 
@@ -296,6 +331,11 @@ describe('Interval shapes', () => {
       // expect(shape.getBBox().width).toBe(10);
       expect(path[0][2] - path[1][2]).toBe(125);
     });
+    it('getMarker', () => {
+      const markerCfg = IntervalShapeFactory.getMarker('line', 'red', false);
+      expect(markerCfg.stroke).toBe('red');
+      expect(markerCfg.symbol(10, 10, 5)).toEqual([['M', 10, 5], ['L', 10, 15]]);
+    });
   });
 
   describe('tick', () => {
@@ -376,7 +416,7 @@ describe('Interval shapes', () => {
       expect(path[0][2] - path[1][2]).toBe(250);
     });
 
-    it('draw', () => {
+    it('update', () => {
       const cfg = {
         x: 0.5,
         y: 0.5,
@@ -404,6 +444,18 @@ describe('Interval shapes', () => {
       expect(path.length).toBe(6);
       expect(path[3][1] - path[2][1]).toBe(500);
       expect(path[0][2] - path[1][2]).toBe(250);
+    });
+    it('getMarker', () => {
+      const markerCfg = IntervalShapeFactory.getMarker('tick', 'red', false);
+      expect(markerCfg.stroke).toBe('red');
+      expect(markerCfg.symbol(10, 10, 4)).toEqual([
+        ['M', 8, 6],
+        ['L', 12, 6],
+        ['M', 10, 6],
+        ['L', 10, 14],
+        ['M', 8, 14],
+        ['L', 12, 14],
+      ]);
     });
   });
 
@@ -526,6 +578,15 @@ describe('Interval shapes', () => {
       expect(shape.attr('fill')).toBe('yellow');
       expect(path).toEqual([['M', 125, 400], ['L', 125, 250], ['L', 225, 300], ['L', 225, 350], ['Z']]);
     });
+    it('getMarker', () => {
+      const markerCfg = IntervalShapeFactory.getMarker('funnel', 'red', false);
+      expect(markerCfg).toEqual({
+        ...Theme.interval.funnel.default,
+        symbol: 'square',
+        r: 4,
+        fill: 'red',
+      });
+    });
   });
 
   describe('pyramid', () => {
@@ -640,6 +701,15 @@ describe('Interval shapes', () => {
       const path = shape.attr('path');
       expect(shape.attr('fill')).toBe('red');
       expect(path).toEqual([['M', 100, 200], ['L', 100, 100], ['L', 225, 125], ['L', 225, 175], ['Z']]);
+    });
+    it('getMarker', () => {
+      const markerCfg = IntervalShapeFactory.getMarker('pyramid', 'red', false);
+      expect(markerCfg).toEqual({
+        ...Theme.interval.pyramid.default,
+        symbol: 'square',
+        r: 4,
+        fill: 'red',
+      });
     });
   });
 

--- a/tests/unit/geometry/shape/interval-spec.ts
+++ b/tests/unit/geometry/shape/interval-spec.ts
@@ -334,6 +334,7 @@ describe('Interval shapes', () => {
     it('getMarker', () => {
       const markerCfg = IntervalShapeFactory.getMarker('line', 'red', false);
       expect(markerCfg.stroke).toBe('red');
+      // @ts-ignore
       expect(markerCfg.symbol(10, 10, 5)).toEqual([['M', 10, 5], ['L', 10, 15]]);
     });
   });
@@ -448,6 +449,7 @@ describe('Interval shapes', () => {
     it('getMarker', () => {
       const markerCfg = IntervalShapeFactory.getMarker('tick', 'red', false);
       expect(markerCfg.stroke).toBe('red');
+      // @ts-ignore
       expect(markerCfg.symbol(10, 10, 4)).toEqual([
         ['M', 8, 6],
         ['L', 12, 6],

--- a/tests/unit/geometry/shape/line-spec.ts
+++ b/tests/unit/geometry/shape/line-spec.ts
@@ -1,3 +1,4 @@
+import { isGenericTypeAnnotation } from '@babel/types';
 import { getCoordinate } from '../../../../src/dependents';
 import Element from '../../../../src/geometry/element/index';
 import LineShapeFactory from '../../../../src/geometry/shape/line';
@@ -19,6 +20,7 @@ describe('Line shapes', () => {
     end: { x: 500, y: 0 },
   });
   LineShapeFactory.coordinate = rectCoord;
+  LineShapeFactory.theme = Theme.line;
 
   const element = new Element({
     shapeType: 'line',
@@ -29,6 +31,17 @@ describe('Line shapes', () => {
 
   it('defaultShapeType', () => {
     expect(LineShapeFactory.defaultShapeType).toBe('line');
+  });
+
+  it('getMarker', () => {
+    const dotMarker = LineShapeFactory.getMarker('dot', 'red', false);
+    expect(dotMarker.lineDash).toBe(Theme.line.dot.default.lineDash);
+    expect(dotMarker.stroke).toBe('red');
+    expect(dotMarker.symbol(10, 10, 5)).toEqual([['M', 5, 10], ['L', 15, 10]]);
+
+    const vhMarker = LineShapeFactory.getMarker('vh', 'red', false);
+    expect(vhMarker.stroke).toBe('red');
+    expect(vhMarker.symbol(10, 10, 5)).toEqual([['M', 4, 12.5], ['L', 10, 12.5], ['L', 10, 7.5], ['L', 16, 7.5]]);
   });
 
   describe('line', () => {
@@ -204,144 +217,144 @@ describe('Line shapes', () => {
       expect(shape.attr('path')[1].length).toBe(7);
       expect(shape.attr('path')[2].length).toBe(7);
     });
+  });
 
-    describe('hv', () => {
-      // @ts-ignore
-      element.shapeType = 'hv';
-      it('draw', () => {
-        const shape = LineShapeFactory.drawShape(
-          'hv',
-          {
-            x: 100,
-            y: 100,
-            points: [{ x: 100, y: 100 }, { x: 200, y: 200 }],
-            color: 'red',
-            style: {
-              ...Theme.line.hv.default,
-            },
+  describe('hv', () => {
+    // @ts-ignore
+    element.shapeType = 'hv';
+    it('draw', () => {
+      const shape = LineShapeFactory.drawShape(
+        'hv',
+        {
+          x: 100,
+          y: 100,
+          points: [{ x: 100, y: 100 }, { x: 200, y: 200 }],
+          color: 'red',
+          style: {
+            ...Theme.line.hv.default,
           },
-          element
-        );
-        expect(shape.attr('stroke')).toBe('red');
-        expect(shape.attr('path').length).toBe(3);
-        expect(shape.attr('path')[0]).toEqual(['M', 100, 100]);
-        expect(shape.attr('path')[1]).toEqual(['L', 200, 100]);
-        expect(shape.attr('path')[2]).toEqual(['L', 200, 200]);
-      });
+        },
+        element
+      );
+      expect(shape.attr('stroke')).toBe('red');
+      expect(shape.attr('path').length).toBe(3);
+      expect(shape.attr('path')[0]).toEqual(['M', 100, 100]);
+      expect(shape.attr('path')[1]).toEqual(['L', 200, 100]);
+      expect(shape.attr('path')[2]).toEqual(['L', 200, 200]);
     });
+  });
 
-    describe('vh', () => {
-      // @ts-ignore
-      element.shapeType = 'hv';
-      it('draw', () => {
-        const shape = LineShapeFactory.drawShape(
-          'vh',
-          {
-            x: 100,
-            y: 100,
-            points: [{ x: 100, y: 100 }, { x: 200, y: 200 }],
-            color: 'red',
-            style: {
-              ...Theme.line.vh.default,
-            },
+  describe('vh', () => {
+    // @ts-ignore
+    element.shapeType = 'hv';
+    it('draw', () => {
+      const shape = LineShapeFactory.drawShape(
+        'vh',
+        {
+          x: 100,
+          y: 100,
+          points: [{ x: 100, y: 100 }, { x: 200, y: 200 }],
+          color: 'red',
+          style: {
+            ...Theme.line.vh.default,
           },
-          element
-        );
+        },
+        element
+      );
 
-        expect(shape.attr('stroke')).toBe('red');
-        expect(shape.attr('path').length).toBe(3);
-        expect(shape.attr('path')[0]).toEqual(['M', 100, 100]);
-        expect(shape.attr('path')[1]).toEqual(['L', 100, 200]);
-        expect(shape.attr('path')[2]).toEqual(['L', 200, 200]);
-      });
+      expect(shape.attr('stroke')).toBe('red');
+      expect(shape.attr('path').length).toBe(3);
+      expect(shape.attr('path')[0]).toEqual(['M', 100, 100]);
+      expect(shape.attr('path')[1]).toEqual(['L', 100, 200]);
+      expect(shape.attr('path')[2]).toEqual(['L', 200, 200]);
     });
+  });
 
-    describe('hvh', () => {
-      // @ts-ignore
-      element.shapeType = 'hvh';
-      it('draw', () => {
-        const shape = LineShapeFactory.drawShape(
-          'hvh',
-          {
-            x: 100,
-            y: 100,
-            points: [{ x: 100, y: 100 }, { x: 200, y: 200 }],
-            color: 'red',
-            style: {
-              ...Theme.line.hvh.default,
-            },
+  describe('hvh', () => {
+    // @ts-ignore
+    element.shapeType = 'hvh';
+    it('draw', () => {
+      const shape = LineShapeFactory.drawShape(
+        'hvh',
+        {
+          x: 100,
+          y: 100,
+          points: [{ x: 100, y: 100 }, { x: 200, y: 200 }],
+          color: 'red',
+          style: {
+            ...Theme.line.hvh.default,
           },
-          element
-        );
+        },
+        element
+      );
 
-        expect(shape.attr('stroke')).toBe('red');
-        expect(shape.attr('path').length).toBe(4);
-        expect(shape.attr('path')[0]).toEqual(['M', 100, 100]);
-        expect(shape.attr('path')[1]).toEqual(['L', 150, 100]);
-        expect(shape.attr('path')[2]).toEqual(['L', 150, 200]);
-        expect(shape.attr('path')[3]).toEqual(['L', 200, 200]);
-      });
+      expect(shape.attr('stroke')).toBe('red');
+      expect(shape.attr('path').length).toBe(4);
+      expect(shape.attr('path')[0]).toEqual(['M', 100, 100]);
+      expect(shape.attr('path')[1]).toEqual(['L', 150, 100]);
+      expect(shape.attr('path')[2]).toEqual(['L', 150, 200]);
+      expect(shape.attr('path')[3]).toEqual(['L', 200, 200]);
     });
+  });
 
-    describe('vhv', () => {
-      // @ts-ignore
-      element.shapeType = 'vhv';
-      it('draw', () => {
-        const shape = LineShapeFactory.drawShape(
-          'vhv',
-          {
-            x: 100,
-            y: 100,
-            points: [{ x: 100, y: 100 }, { x: 200, y: 200 }],
-            color: 'red',
-            style: {
-              ...Theme.line.vhv.default,
-            },
+  describe('vhv', () => {
+    // @ts-ignore
+    element.shapeType = 'vhv';
+    it('draw', () => {
+      const shape = LineShapeFactory.drawShape(
+        'vhv',
+        {
+          x: 100,
+          y: 100,
+          points: [{ x: 100, y: 100 }, { x: 200, y: 200 }],
+          color: 'red',
+          style: {
+            ...Theme.line.vhv.default,
           },
-          element
-        );
-        expect(shape.attr('stroke')).toBe('red');
-        expect(shape.attr('path').length).toBe(4);
-        expect(shape.attr('path')[0].length).toBe(3);
-        expect(shape.attr('path')[1].length).toBe(3);
-        expect(shape.attr('path')[2].length).toBe(3);
-        expect(shape.attr('path')[3].length).toBe(3);
-      });
+        },
+        element
+      );
+      expect(shape.attr('stroke')).toBe('red');
+      expect(shape.attr('path').length).toBe(4);
+      expect(shape.attr('path')[0].length).toBe(3);
+      expect(shape.attr('path')[1].length).toBe(3);
+      expect(shape.attr('path')[2].length).toBe(3);
+      expect(shape.attr('path')[3].length).toBe(3);
     });
+  });
 
-    describe('polar coordinate', () => {
-      const polar = new Polar({
-        start: { x: 0, y: 500 },
-        end: { x: 500, y: 0 },
-      });
-      // @ts-ignore
-      element.shapeType = 'smooth';
-      LineShapeFactory.coordinate = polar;
-      it('draw smooth line', () => {
-        const shape = LineShapeFactory.drawShape(
-          'smooth',
-          {
-            x: 100,
-            y: 100,
-            points: [{ x: 20, y: 10 }, { x: 40, y: 10 }, { x: 60, y: 10 }, { x: 80, y: 10 }],
-            isInCircle: true,
-            color: '#1890ff',
-            style: {
-              ...Theme.line.smooth.default,
-            },
+  describe('polar coordinate', () => {
+    const polar = new Polar({
+      start: { x: 0, y: 500 },
+      end: { x: 500, y: 0 },
+    });
+    // @ts-ignore
+    element.shapeType = 'smooth';
+    LineShapeFactory.coordinate = polar;
+    it('draw smooth line', () => {
+      const shape = LineShapeFactory.drawShape(
+        'smooth',
+        {
+          x: 100,
+          y: 100,
+          points: [{ x: 20, y: 10 }, { x: 40, y: 10 }, { x: 60, y: 10 }, { x: 80, y: 10 }],
+          isInCircle: true,
+          color: '#1890ff',
+          style: {
+            ...Theme.line.smooth.default,
           },
-          element
-        );
+        },
+        element
+      );
 
-        expect(shape.attr('stroke')).toBe('#1890ff');
-        expect(shape.attr('path')).toEqual([
-          ['M', 20, 10],
-          ['C', 20, 10, 32, 10, 40, 10],
-          ['C', 48, 10, 52, 10, 60, 10],
-          ['C', 68, 10, 84, 10, 80, 10],
-          ['C', 68, 10, 20, 10, 20, 10],
-        ]);
-      });
+      expect(shape.attr('stroke')).toBe('#1890ff');
+      expect(shape.attr('path')).toEqual([
+        ['M', 20, 10],
+        ['C', 20, 10, 32, 10, 40, 10],
+        ['C', 48, 10, 52, 10, 60, 10],
+        ['C', 68, 10, 84, 10, 80, 10],
+        ['C', 68, 10, 20, 10, 20, 10],
+      ]);
     });
   });
 

--- a/tests/unit/geometry/shape/line-spec.ts
+++ b/tests/unit/geometry/shape/line-spec.ts
@@ -18,7 +18,7 @@ describe('Line shapes', () => {
     start: { x: 0, y: 500 },
     end: { x: 500, y: 0 },
   });
-  LineShapeFactory.setCoordinate(rectCoord);
+  LineShapeFactory.coordinate = rectCoord;
 
   const element = new Element({
     shapeType: 'line',
@@ -316,7 +316,7 @@ describe('Line shapes', () => {
       });
       // @ts-ignore
       element.shapeType = 'smooth';
-      LineShapeFactory.setCoordinate(polar);
+      LineShapeFactory.coordinate = polar;
       it('draw smooth line', () => {
         const shape = LineShapeFactory.drawShape(
           'smooth',

--- a/tests/unit/geometry/shape/line-spec.ts
+++ b/tests/unit/geometry/shape/line-spec.ts
@@ -37,10 +37,12 @@ describe('Line shapes', () => {
     const dotMarker = LineShapeFactory.getMarker('dot', 'red', false);
     expect(dotMarker.lineDash).toBe(Theme.line.dot.default.lineDash);
     expect(dotMarker.stroke).toBe('red');
+    // @ts-ignore
     expect(dotMarker.symbol(10, 10, 5)).toEqual([['M', 5, 10], ['L', 15, 10]]);
 
     const vhMarker = LineShapeFactory.getMarker('vh', 'red', false);
     expect(vhMarker.stroke).toBe('red');
+    // @ts-ignore
     expect(vhMarker.symbol(10, 10, 5)).toEqual([['M', 4, 12.5], ['L', 10, 12.5], ['L', 10, 7.5], ['L', 16, 7.5]]);
   });
 

--- a/tests/unit/geometry/shape/point-spec.ts
+++ b/tests/unit/geometry/shape/point-spec.ts
@@ -70,10 +70,12 @@ describe('Point shapes', () => {
     });
 
     const bowtieMarker = PointShapeFactory.getMarker('bowtie', 'red', false);
+    // @ts-ignore
     expect(bowtieMarker.symbol(11.5, 10, 3.5)).toEqual([['M', 8, 8], ['L', 15, 12], ['L', 15, 8], ['L', 8, 12], ['Z']]);
     expect(bowtieMarker.fill).toBe('red');
 
     const crossMarker = PointShapeFactory.getMarker('cross', 'red', false);
+    // @ts-ignore
     expect(crossMarker.symbol(10, 10, 5)).toEqual([['M', 5, 5], ['L', 15, 15], ['M', 15, 5], ['L', 5, 15]]);
     expect(crossMarker.stroke).toBe('red');
   });

--- a/tests/unit/geometry/shape/point-spec.ts
+++ b/tests/unit/geometry/shape/point-spec.ts
@@ -20,6 +20,7 @@ describe('Point shapes', () => {
     end: { x: 500, y: 0 },
   });
   PointShapeFactory.coordinate = rectCoord;
+  PointShapeFactory.theme = Theme.point;
 
   const element = new Element({
     shapeType: 'point',
@@ -49,6 +50,32 @@ describe('Point shapes', () => {
     });
     expect(point[0].x).toBe(0.4);
     expect(point[0].y).toBe(0.8);
+  });
+
+  it('getMarker', () => {
+    const circleMarker = PointShapeFactory.getMarker('circle', 'red', false);
+    expect(circleMarker).toEqual({
+      ...Theme.point.circle.default,
+      symbol: 'circle',
+      r: 4.5,
+      fill: 'red',
+    });
+
+    const hollowCircleMarker = PointShapeFactory.getMarker('hollowCircle', 'red', false);
+    expect(hollowCircleMarker).toEqual({
+      ...Theme.point.hollowCircle.default,
+      symbol: 'circle',
+      r: 4.5,
+      stroke: 'red',
+    });
+
+    const bowtieMarker = PointShapeFactory.getMarker('bowtie', 'red', false);
+    expect(bowtieMarker.symbol(11.5, 10, 3.5)).toEqual([['M', 8, 8], ['L', 15, 12], ['L', 15, 8], ['L', 8, 12], ['Z']]);
+    expect(bowtieMarker.fill).toBe('red');
+
+    const crossMarker = PointShapeFactory.getMarker('cross', 'red', false);
+    expect(crossMarker.symbol(10, 10, 5)).toEqual([['M', 5, 5], ['L', 15, 15], ['M', 15, 5], ['L', 5, 15]]);
+    expect(crossMarker.stroke).toBe('red');
   });
 
   it('draw shapes', () => {

--- a/tests/unit/geometry/shape/point-spec.ts
+++ b/tests/unit/geometry/shape/point-spec.ts
@@ -19,7 +19,7 @@ describe('Point shapes', () => {
     start: { x: 0, y: 500 },
     end: { x: 500, y: 0 },
   });
-  PointShapeFactory.setCoordinate(rectCoord);
+  PointShapeFactory.coordinate = rectCoord;
 
   const element = new Element({
     shapeType: 'point',

--- a/tests/unit/geometry/shape/util/path-spec.ts
+++ b/tests/unit/geometry/shape/util/path-spec.ts
@@ -1,4 +1,5 @@
 import { getCoordinate } from '@antv/coord';
+import { PathCommand } from '@antv/g-base/lib/types';
 import {
   convertNormalPath,
   convertPolarPath,
@@ -98,7 +99,7 @@ describe('PathUtil', () => {
       },
     });
 
-    const path = [['M', 0, 0], ['L', 1, 1]];
+    const path: PathCommand[] = [['M', 0, 0], ['L', 1, 1]];
     expect(convertNormalPath(coord, path)).toEqual([['M', 0, 0], ['L', 200, 200]]);
   });
 
@@ -113,7 +114,7 @@ describe('PathUtil', () => {
         y: 200,
       },
     });
-    const path = [['M', 0, 0], ['L', 0, 1], ['L', 0.25, 1]];
+    const path: PathCommand[] = [['M', 0, 0], ['L', 0, 1], ['L', 0.25, 1]];
     const toPath = convertPolarPath(coord, path);
     expect(toPath).toEqual([['M', 100, 100], ['L', 100, 0], ['A', 100, 100, 0, 0, 1, 200, 100]]);
   });


### PR DESCRIPTION
API：

```ts
const shapeFactory = geometry.getShapeFactory();
const marker = shapeFactory.getMarker(shapeType, color, isInPolar);
```

返回的结果类型见： https://github.com/antvis/g2/commit/06caa1301f83600b5a5550d8dc59684874ceb45e#diff-cfe98604c7d056c8adca06c7dfddd5cdR120

另外该分支引入了 g-base 的 PathCommand 类型定义，目前会报错，需要这个 PR 合并，G 发个版本方可。https://github.com/antvis/g/pull/258