### PR TITLE
fix(tooltip-style): replace visibility: hidden with display: node, av…

### DIFF
--- a/packages/component/__tests__/unit/tooltip/html-spec.js
+++ b/packages/component/__tests__/unit/tooltip/html-spec.js
@@ -43,9 +43,9 @@ describe('HtmlTooltip测试', () => {
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.show();
-    const visibility = tooltip.get('container').style.visibility;
+    const display = tooltip.get('container').style.display;
     expect(tooltip).be.an.instanceof(HtmlTooltip);
-    expect(visibility).to.equal('visible');
+    expect(display).to.equal('block');
     tooltip.destroy();
   });
   it('initialize,show, not show title', () => {
@@ -62,9 +62,9 @@ describe('HtmlTooltip测试', () => {
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.show();
-    const visibility = tooltip.get('container').style.visibility;
+    const display = tooltip.get('container').style.display;
     expect(tooltip).be.an.instanceof(HtmlTooltip);
-    expect(visibility).to.equal('visible');
+    expect(display).to.equal('block');
     tooltip.destroy();
   });
   it('initialize,show with no items', () => {
@@ -81,9 +81,9 @@ describe('HtmlTooltip测试', () => {
       frontgroundGroup: canvas.addGroup(),
     });
     tooltip.show();
-    const visibility = tooltip.get('container').style.visibility;
+    const display = tooltip.get('container').style.display;
     expect(tooltip).be.an.instanceof(HtmlTooltip);
-    expect(visibility).to.equal('visible');
+    expect(display).to.equal('block');
     tooltip.destroy();
   });
 
@@ -102,8 +102,8 @@ describe('HtmlTooltip测试', () => {
       crosshairs: { type: 'cross' },
     });
     tooltip.hide();
-    const visibility = tooltip.get('container').style.visibility;
-    expect(visibility).to.equal('hidden');
+    const display = tooltip.get('container').style.display;
+    expect(display).to.equal('none');
     tooltip.destroy();
   });
 
@@ -181,9 +181,10 @@ describe('HtmlTooltip测试', () => {
       frontgroundGroup: canvas.addGroup(),
       enterable: true,
     });
-    tooltip.setPosition(50, 10);
-    tooltip.setPosition(50, 10);
     tooltip.show();
+    tooltip.setPosition(50, 10);
+    tooltip.setPosition(50, 10);
+
     expect(tooltip.get('x')).to.equal(51);
     expect(tooltip.get('y')).to.equal(-46);
     tooltip.destroy();
@@ -204,8 +205,9 @@ describe('HtmlTooltip测试', () => {
       frontgroundGroup: canvas.addGroup(),
       inPanel: false,
     });
-    tooltip.setPosition(-100, 600);
     tooltip.show();
+    tooltip.setPosition(-100, 600);
+
     const height = tooltip.get('container').clientHeight;
     expect(tooltip.get('x')).to.equal(20); // gap
     expect(tooltip.get('y')).to.equal(600 - height - 20);
@@ -259,8 +261,9 @@ describe('HtmlTooltip测试', () => {
       panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
-    tooltip.setPosition(300, 20);
     tooltip.show();
+    tooltip.setPosition(300, 20);
+
     const width = tooltip.get('container').clientWidth;
     expect(tooltip.get('x')).to.equal(320 - width - 40);
     tooltip.destroy();
@@ -312,8 +315,9 @@ describe('HtmlTooltip测试', () => {
       panelGroup: canvas.addGroup(),
       frontgroundGroup: canvas.addGroup(),
     });
-    tooltip.setPosition(10, 300);
     tooltip.show();
+    tooltip.setPosition(10, 300);
+
     const height = tooltip.get('container').clientHeight;
     expect(tooltip.get('y')).to.equal(320 - height - 40);
     tooltip.destroy();

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/component",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "description": "Component for @antv.",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/packages/component/src/annotation/html.ts
+++ b/packages/component/src/annotation/html.ts
@@ -8,7 +8,10 @@ import Annotation, { AnnotationCfg, Point } from './base';
 export interface HtmlCfg extends AnnotationCfg {
   alignX: 'left' | 'middle' | 'right';
   alignY: 'top' | 'middle' | 'bottom';
-  html: ((xScales: Scale[] | Record<string, Scale>, yScales: Scale[] | Record<string, Scale>) => string) | string | HTMLElement;
+  html:
+    | ((xScales: Scale[] | Record<string, Scale>, yScales: Scale[] | Record<string, Scale>) => string)
+    | string
+    | HTMLElement;
   el: HTMLElement;
 }
 
@@ -93,7 +96,6 @@ export default class Html extends Annotation<HtmlCfg> {
     domUtil.modifyCSS(parentDom, {
       top: `${Math.round(position.y)}px`,
       left: `${Math.round(position.x)}px`,
-      visibility: 'visible',
       zIndex: this.get('zIndex'),
     });
   }

--- a/packages/component/src/tooltip/html.ts
+++ b/packages/component/src/tooltip/html.ts
@@ -159,7 +159,6 @@ export default class HtmlTooltip extends Tooltip<TooltipCfg> {
 
   public show() {
     const container = this.get('container');
-    container.style.visibility = 'visible';
     container.style.display = 'block';
     const crosshairGroup = this.get('crosshairGroup');
     if (crosshairGroup) {
@@ -175,7 +174,6 @@ export default class HtmlTooltip extends Tooltip<TooltipCfg> {
 
   public hide() {
     const container = this.get('container');
-    container.style.visibility = 'hidden';
     container.style.display = 'none';
     const crosshairGroup = this.get('crosshairGroup');
     if (crosshairGroup) {

--- a/packages/component/src/tooltip/theme.ts
+++ b/packages/component/src/tooltip/theme.ts
@@ -9,14 +9,15 @@ const TOOLTIP_MARKER_CLASS = 'g2-tooltip-marker';
 const TOOLTIP_VALUE_CLASS = 'g2-tooltip-value';
 
 export default {
-    // css style for tooltip
+  // css style for tooltip
   [`${TOOLTIP_CONTAINER_CLASS}`]: {
     position: 'absolute',
-    visibility: 'hidden',
-      // @2018-07-25 by blue.lb 这里去掉浮动，火狐上存在样式错位
-      // whiteSpace: 'nowrap',
+    display: 'none',
+    // @2018-07-25 by blue.lb 这里去掉浮动，火狐上存在样式错位
+    // whiteSpace: 'nowrap',
     zIndex: 8,
-    transition: 'visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), ' +
+    transition:
+      'visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), ' +
       'left 0.4s cubic-bezier(0.23, 1, 0.32, 1), ' +
       'top 0.4s cubic-bezier(0.23, 1, 0.32, 1)',
     backgroundColor: 'rgba(255, 255, 255, 0.9)',

--- a/packages/g2/package.json
+++ b/packages/g2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2",
-  "version": "3.6.0-beta.4",
+  "version": "3.6.0-beta.5",
   "description": "the Grammar of Graphics in Javascript",
   "main": "lib/index.js",
   "module": "esm/index.js",
@@ -34,7 +34,7 @@
   "dependencies": {
     "@antv/adjust": "~0.2.0",
     "@antv/attr": "~0.2.0",
-    "@antv/component": "~0.4.0-beta.2",
+    "@antv/component": "~0.4.0-beta.4",
     "@antv/coord": "~0.2.1",
     "@antv/dom-util": "^2.0.1",
     "@antv/event-emitter": "~0.1.0",

--- a/packages/g2/src/global.ts
+++ b/packages/g2/src/global.ts
@@ -6,7 +6,7 @@ import { DataPointType } from './interface';
 import { getTheme } from './theme';
 
 const Global = {
-  version: '3.6.0-beta.4',
+  version: '3.6.0-beta.5',
   renderer: 'canvas',
   width: 640,
   height: 480,

--- a/packages/g2/src/theme/default.ts
+++ b/packages/g2/src/theme/default.ts
@@ -420,7 +420,7 @@ const Theme = {
     // css style for tooltip
     [`${TOOLTIP_CONTAINER_CLASS}`]: {
       position: 'absolute',
-      visibility: 'hidden',
+      display: 'none',
       // @2018-07-25 by blue.lb 这里去掉浮动，火狐上存在样式错位
       // whiteSpace: 'nowrap',
       zIndex: 8,


### PR DESCRIPTION
1. 因为 dom visibility: hidden，还是会进行 dom 的渲染，以及撑开容器。
2. g2plot 通过 resize 兼容容器大小，自动重绘
3. tooltip 导致多次重绘

版本号已经升级，合并之后 build，然后发布版本，然后更新 g2plot 依赖。