### PR TITLE
优化 Geometry 中数据相关的类型定义

### DIFF
--- a/src/chart/controller/tooltip.ts
+++ b/src/chart/controller/tooltip.ts
@@ -5,7 +5,7 @@ import Geometry from '../../geometry/base';
 import { registerInteraction } from '../../interaction';
 // 引入 Tooltip 交互行为
 import TooltipInteraction from '../../interaction/tooltip';
-import { Data, Point } from '../../interface';
+import { Data, MappingDatum, Point } from '../../interface';
 import { findDataByPoint, getTooltipItems } from '../../util/tooltip';
 import { TooltipOption } from '../interface';
 import View from '../view';
@@ -263,7 +263,7 @@ export default class Tooltip {
         const dataArray = geometry.dataArray;
         if (shared !== false) {
           // 用户未配置 share: false
-          _.each(dataArray, (data: Data) => {
+          _.each(dataArray, (data: MappingDatum[]) => {
             const record = findDataByPoint(point, data, geometry);
             if (record) {
               const tooltipItems = getTooltipItems(record, geometry);
@@ -274,14 +274,14 @@ export default class Tooltip {
           const container = geometry.container;
           const shape = container.getShape(point.x, point.y);
           if (shape && shape.get('visible') && shape.get('origin')) {
-            const origin = shape.get('origin').origin;
-            if (_.isArray(origin)) {
-              const record = findDataByPoint(point, origin, geometry);
+            const mappingData = shape.get('origin').mappingData;
+            if (_.isArray(mappingData)) {
+              const record = findDataByPoint(point, mappingData, geometry);
               if (record) {
                 items = items.concat(getTooltipItems(record, geometry));
               }
             } else {
-              items = items.concat(getTooltipItems(origin, geometry));
+              items = items.concat(getTooltipItems(mappingData, geometry));
             }
           }
         }

--- a/src/geometry/animate/index.ts
+++ b/src/geometry/animate/index.ts
@@ -142,14 +142,14 @@ export function getDefaultAnimateCfg(geometryType: string, animateType: string, 
  * @param [toAttrs] shape 最终状态的图形属性
  */
 export function doAnimate(shape: IGroup | IShape, cfg: ShapeDrawCFG, coordinate: Coordinate, toAttrs?: object) {
-  const { animate, data, origin } = cfg;
+  const { animate, data, mappingData } = cfg;
   const animation = animate.animation;
   const animateCfg = getAnimateConfig(animate, data);
   if (animation) {
     // 用户声明了动画执行函数
     const animateFunction = Action[animation];
     if (animateFunction) {
-      animateFunction(shape, animateCfg, coordinate, origin, toAttrs);
+      animateFunction(shape, animateCfg, coordinate, mappingData, toAttrs);
     }
   } else {
     // 没有声明，则根据 toAttrs 做差值动画

--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -195,9 +195,9 @@ export default class Geometry {
    * Configuring color mapping rules
    *
    * @example
-   * // data: [{ x: 'A', y: 10, color: 'red' }, { x: 'B', y: 30, color: 'yellow' }]
    *
-   * ```ts
+   * ```typescript
+   * // data: [{ x: 'A', y: 10, color: 'red' }, { x: 'B', y: 30, color: 'yellow' }]
    * color({
    *   fields: [ 'x' ],
    *   values: [ '#1890ff', '#5AD8A6' ],
@@ -209,9 +209,8 @@ export default class Geometry {
    */
   public color(field: AttributeOption): Geometry;
   /**
-   *
-   * * @example
-   * ```ts
+   * @example
+   * ```typescript
    * // data: [{ x: 'A', y: 10, color: 'red' }, { x: 'B', y: 30, color: 'yellow' }]
    *
    * // use '#1890ff' rendering
@@ -246,9 +245,9 @@ export default class Geometry {
    * Configuring shape mapping rules
    *
    * @example
-   * // data: [{ x: 'A', y: 10, color: 'red' }, { x: 'B', y: 30, color: 'yellow' }]
    *
-   * ```ts
+   * ```typescript
+   * // data: [{ x: 'A', y: 10, color: 'red' }, { x: 'B', y: 30, color: 'yellow' }]
    * shape({
    *   fields: [ 'x' ],
    * });
@@ -261,7 +260,7 @@ export default class Geometry {
   /**
    *
    * * @example
-   * ```ts
+   * ```typescript
    * // data: [{ x: 'A', y: 10, color: 'red' }, { x: 'B', y: 30, color: 'yellow' }]
    *
    * // use specified shape
@@ -296,9 +295,8 @@ export default class Geometry {
    * Configuring size mapping rules
    *
    * @example
+   * ```typescript
    * // data: [{ x: 'A', y: 10, color: 'red' }, { x: 'B', y: 30, color: 'yellow' }]
-   *
-   * ```ts
    * size({
    *   values: [ 10 ],
    * })
@@ -311,7 +309,7 @@ export default class Geometry {
   /**
    *
    * * @example
-   * ```ts
+   * ```typescript
    * // data: [{ x: 'A', y: 10, color: 'red' }, { x: 'B', y: 30, color: 'yellow' }]
    *
    * // use specified value, 10 means '10px'
@@ -351,23 +349,23 @@ export default class Geometry {
    *
    *
    * **Tip**
-   * * When you use 'dodge' type, the following configurations are possible:
-   * ```ts
+   * + When you use 'dodge' type, the following configurations are possible:
+   * ```typescript
    * adjust('dodge', {
    *   marginRatio: 0, // used to adjust the spacing of individual columns in a group
    *   dodgeBy: 'x', // declare which field to group by
    * });
    * ```
    *
-   * * When you use 'stack' type, the following configurations are possible:
-   * ```ts
+   * + When you use 'stack' type, the following configurations are possible:
+   * ```typescript
    * adjust('stack', {
    *   reverseOrder: false, // whether or not to reverse data
    * });
    * ```
    *
    * @example
-   * ```ts
+   * ```typescript
    * adjust('stack');
    *
    * adjust({
@@ -406,7 +404,7 @@ export default class Geometry {
    * Graphic style configuration
    *
    * @example
-   * ```ts
+   * ```typescript
    * // just configure graphics style
    * style({
    *   lineWidth: 2,
@@ -432,7 +430,7 @@ export default class Geometry {
   public style(field: StyleOption | LooseObject): Geometry;
   /**
    * @example
-   * ```ts
+   * ```typescript
    * style('x*y', (xVal, yVal) => {
    *   const style = { lineWidth: 2, stroke: '#1890ff' };
    *   if (xVal === 'a') {
@@ -477,7 +475,7 @@ export default class Geometry {
    * The tooltip of geometry is open by default. So we can use this method to configure tootlip's content.
    *
    * @example
-   * ```ts
+   * ```typescript
    * // data: [{x: 'a', y: 10}]
    * tooltip({
    *   fields: [ 'x' ];
@@ -485,7 +483,7 @@ export default class Geometry {
    * ```
    * ![](https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*268uQ50if60AAAAAAAAAAABkARQnAQ)
    *
-   * ```ts
+   * ```typescript
    * tooltip({
    *   fields: [ 'x', 'y' ];
    * });
@@ -495,7 +493,7 @@ export default class Geometry {
    * The tooltip() method supports callbacks in the following way:
    *
    * @example
-   * ```ts
+   * ```typescript
    * chart.tooltip({
    *   itemTpl: '<li>{x}: {y}</li>',
    * });
@@ -521,7 +519,7 @@ export default class Geometry {
   public tooltip(field: TooltipOption | boolean): Geometry;
   /**
    * @example
-   * ```ts
+   * ```typescript
    * // data: [{x: 'a', y: 10}]
    *
    * // same with `tooltip({ fields: [ 'x' ] });`
@@ -570,7 +568,7 @@ export default class Geometry {
    * 3. leave
    *
    * @example
-   * ```ts
+   * ```typescript
    * animate({
    *   enter: {
    *     duration: 1000, // enter animation execution time
@@ -796,7 +794,7 @@ export default class Geometry {
   /**
    * get elements which meet the user's condition
    *
-   * ```ts
+   * ```typescript
    * getElementsBy((element) => {
    *   const data = element.getData();
    *

--- a/src/geometry/interval.ts
+++ b/src/geometry/interval.ts
@@ -1,5 +1,5 @@
 import * as _ from '@antv/util';
-import { LooseObject } from '../interface';
+import { Datum } from '../interface';
 import { getXDimensionLength } from '../util/coordinate';
 import Geometry from './base';
 /** 引入对应的 ShapeFactory */
@@ -28,14 +28,19 @@ export default class Interval extends Geometry {
     this.adjustYScale();
   }
 
-  protected createShapePointsCfg(record: LooseObject) {
-    const cfg = super.createShapePointsCfg(record);
+  /**
+   * Creates shape points cfg
+   * @param obj 经过分组 -> 数字化 -> adjust 调整后的数据记录
+   * @returns
+   */
+  protected createShapePointsCfg(obj: Datum) {
+    const cfg = super.createShapePointsCfg(obj);
 
     // 计算每个 shape 的 size
     let size;
     const sizeAttr = this.getAttribute('size');
     if (sizeAttr) {
-      size = this.getAttrValues(sizeAttr, record)[0];
+      size = this.getAttributeValues(sizeAttr, obj)[0];
       // 归一化
       const coordinate = this.coordinate;
       const coordinateWidth = getXDimensionLength(coordinate);

--- a/src/geometry/path.ts
+++ b/src/geometry/path.ts
@@ -1,6 +1,6 @@
 import * as _ from '@antv/util';
 import { FIELD_ORIGIN } from '../constant';
-import { Data, Datum, Point, ShapeInfo } from '../interface';
+import { Data, Datum, MappingDatum, Point, RangePoint, ShapeInfo } from '../interface';
 import Geometry, { GeometryCfg } from './base';
 import Element from './element';
 /** 引入对应的 ShapeFactory */
@@ -24,11 +24,11 @@ export default class Path extends Geometry {
     this.connectNulls = connectNulls;
   }
 
-  protected createElements(mappedArray: Data): Element[] {
+  protected createElements(mappingData: MappingDatum[]): Element[] {
     // Path 的每个 element 对应一组数据
     const { lastElementsMap, elementsMap, elements, theme, elementsContainer } = this;
-    const elementId = this.getElementId(mappedArray[0]);
-    const shapeCfg = this.getDrawCfg(mappedArray);
+    const elementId = this.getElementId(mappingData[0]);
+    const shapeCfg = this.getShapeInfo(mappingData);
 
     let result = lastElementsMap[elementId];
     if (!result) {
@@ -60,21 +60,8 @@ export default class Path extends Geometry {
     return elements;
   }
 
-  protected getDrawCfg(mappedArray: Data): ShapeInfo {
-    const shapeCfg = super.getDrawCfg(mappedArray[0]);
-
-    return {
-      ...shapeCfg,
-      origin: mappedArray,
-      isStack: !!this.getAdjust('adjust'),
-      points: this.getPoints(mappedArray),
-      data: this.getData(mappedArray),
-      connectNulls: this.connectNulls,
-    };
-  }
-
-  protected getPoints(mappedArray: Data): Point[] {
-    return mappedArray.map((obj: Datum) => {
+  protected getPoints(mappingData: MappingDatum[]): Point[] | RangePoint[] {
+    return mappingData.map((obj: MappingDatum) => {
       return {
         x: obj.x,
         y: obj.y,
@@ -82,8 +69,21 @@ export default class Path extends Geometry {
     });
   }
 
-  private getData(mappedArray: Data): Data {
-    return mappedArray.map((obj: Datum) => {
+  private getShapeInfo(mappingData: MappingDatum[]): ShapeInfo {
+    const shapeCfg = this.getDrawCfg(mappingData[0]);
+
+    return {
+      ...shapeCfg,
+      mappingData,
+      data: this.getData(mappingData),
+      isStack: !!this.getAdjust('adjust'),
+      points: this.getPoints(mappingData),
+      connectNulls: this.connectNulls,
+    };
+  }
+
+  private getData(mappingData: MappingDatum[]): Data {
+    return mappingData.map((obj: Datum) => {
       return obj[FIELD_ORIGIN];
     });
   }

--- a/src/geometry/point.ts
+++ b/src/geometry/point.ts
@@ -1,5 +1,5 @@
 import * as _ from '@antv/util';
-import { ShapeInfo } from '../interface';
+import { MappingDatum, ShapeInfo } from '../interface';
 import Geometry from './base';
 /** 引入 Point 对应的 ShapeFactory */
 import './shape/point';
@@ -9,8 +9,8 @@ export default class Point extends Geometry {
   public readonly shapeType: string = 'point';
   protected generatePoints: boolean = true;
 
-  protected getDrawCfg(obj): ShapeInfo {
-    const shapeCfg = super.getDrawCfg(obj);
+  protected getDrawCfg(mappingDatum: MappingDatum): ShapeInfo {
+    const shapeCfg = super.getDrawCfg(mappingDatum);
 
     return {
       ...shapeCfg,

--- a/src/geometry/polygon.ts
+++ b/src/geometry/polygon.ts
@@ -1,4 +1,5 @@
 import * as _ from '@antv/util';
+import { Datum } from '../interface';
 import Geometry from './base';
 /** 引入 Path 对应的 ShapeFactory */
 import './shape/polygon';
@@ -8,7 +9,7 @@ export default class Polygon extends Geometry {
   public readonly shapeType: string = 'polygon';
   protected generatePoints: boolean = true;
 
-  protected createShapePointsCfg(obj: object) {
+  protected createShapePointsCfg(obj: Datum) {
     const cfg: any = super.createShapePointsCfg(obj);
     let x = cfg.x;
     let y = cfg.y;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -67,10 +67,27 @@ export interface AnimateOption {
   leave?: AnimateCfg | false | null;
 }
 
+// 用户数据经过图形映射处理后的数据结构
+export interface MappingDatum {
+  /** raw data */
+  _origin: Datum;
+  /** the key points of the shape */
+  points?: ShapeVertices;
+  /** the key points of next shape */
+  nextPoints?: ShapeVertices;
+  /** value in the x direction */
+  x?: number[] | number;
+  /** value in the y direction */
+  y?: number[] | number;
+  color?: string;
+  shape?: string;
+  size?: number;
+}
+
 // 绘制 Shape 需要的图形、样式、关键点等信息
 export interface ShapeInfo {
   /** x 坐标 */
-  x: number;
+  x: number | number[];
   /** y 坐标 */
   y: number | number[];
   /** 映射的 shape 类型 */
@@ -85,8 +102,8 @@ export interface ShapeInfo {
   isInCircle?: boolean | undefined;
   /** 对应的原始数据记录 */
   data?: Datum | Data;
-  /** 进行图形映射后的数据记录 */
-  origin?: Datum;
+  /** 存储进行图形映射后的数据 */
+  mappingData?: MappingDatum | MappingDatum[];
   /** 构成 shape 的关键点  */
   points?: ShapeVertices;
   /** 下一个数据集对应的关键点 */

--- a/tests/unit/geometry/element/index-spec.ts
+++ b/tests/unit/geometry/element/index-spec.ts
@@ -141,7 +141,7 @@ describe('Element', () => {
           lineWidth: 20,
           fill: '#454545',
         },
-        origin: {
+        mappingData: {
           _origin: { x: 12 },
         },
         data: { x: 12 },
@@ -158,7 +158,7 @@ describe('Element', () => {
           lineWidth: 20,
           fill: '#454545',
         },
-        origin: {
+        mappingData: {
           _origin: { x: 12 },
         },
         data: { x: 12 },

--- a/tests/unit/util/tooltip-spec.ts
+++ b/tests/unit/util/tooltip-spec.ts
@@ -2,6 +2,7 @@ import { getCoordinate } from '@antv/coord';
 import Interval from '../../../src/geometry/interval';
 import Line from '../../../src/geometry/line';
 import Point from '../../../src/geometry/point';
+import { MappingDatum } from '../../../src/interface';
 import Theme from '../../../src/theme/antv';
 import { findDataByPoint, getTooltipItems } from '../../../src/util/tooltip';
 import { CITY_SALE, DIAMOND } from '../../util/data';
@@ -44,12 +45,12 @@ describe('Tooltip functions', () => {
 
       const point = { x: 100, y: 30 };
       const data = interval.dataArray[0];
-      const result = findDataByPoint(point, data, interval);
+      const result = findDataByPoint(point, data as MappingDatum[], interval);
       expect(result._origin).toEqual({ city: '上海', sale: 110, category: '电脑' });
     });
 
     it('getTooltipItems', () => {
-      const data = findDataByPoint({ x: 100, y: 30 }, interval.dataArray[0], interval);
+      const data = findDataByPoint({ x: 100, y: 30 }, interval.dataArray[0] as MappingDatum[], interval);
       const tooltipItems = getTooltipItems(data, interval);
       expect(tooltipItems.length).toBe(1);
 
@@ -77,7 +78,7 @@ describe('Tooltip functions', () => {
 
     it('findDataByPoint', () => {
       const data = point.dataArray[0];
-      const result = findDataByPoint({ x: 100, y: 90 }, data, point);
+      const result = findDataByPoint({ x: 100, y: 90 }, data as MappingDatum[], point);
       expect(result._origin.carat).toBe(1.5);
       expect(result._origin.price).toBe(9996);
       expect(result._origin.cut).toBe('Ideal');
@@ -110,12 +111,12 @@ describe('Tooltip functions', () => {
 
     it('findDataByPoint', () => {
       const data = line.dataArray[0];
-      const result = findDataByPoint({ x: 100, y: 90 }, data, line);
+      const result = findDataByPoint({ x: 100, y: 90 }, data as MappingDatum[], line);
       expect(result._origin).toEqual({ year: 1995, value: 17000 });
     });
 
     it('getTooltipItems', () => {
-      const data = findDataByPoint({ x: 100, y: 90 }, line.dataArray[0], line);
+      const data = findDataByPoint({ x: 100, y: 90 }, line.dataArray[0] as MappingDatum[], line);
       const tooltipItems = getTooltipItems(data, line);
       const { color, name, value, title, mappingData } = tooltipItems[0];
       expect(color).toBe('#1890FF');


### PR DESCRIPTION
Closed #1653 

## 主要更新点

* 保留 shape.get('origin')，`origin` 存储的是绘制 shape 的所有信息，即传入自定义 shape `draw(cfg, element)` 方法的第一个参数 cfg 的值
* `_orgin` 字段只在内部使用
* 外部用户通过获取  shape.get('origin') 的 `origin `属性中的 `mappingData` 和  `data` 来取得映射后的数据和原始数据。后面给用户的认知就是： mappingData 代表的是映射后的数据，`data` 代表的就是原始数据
* 优化 geometry 代码中关于数据的类型定义，让代码阅读者更好得理解数据流转过程