### PR TITLE
3.6.x: 组件绘制层级错误

### DIFF
--- a/packages/component/src/tooltip/crosshair.ts
+++ b/packages/component/src/tooltip/crosshair.ts
@@ -47,9 +47,6 @@ export default class Crosshair extends Guide<CrosshairCfg> {
   public _init_() {
     const plot = this.get('plot');
     const group = plot.addGroup();
-    if (this.get('type') === 'rect') { 
-      group.toBack();
-    }
     this.set('container', group);
   }
 

--- a/packages/component/src/tooltip/html.ts
+++ b/packages/component/src/tooltip/html.ts
@@ -71,7 +71,7 @@ export default class HtmlTooltip extends Tooltip<TooltipCfg> {
     // crosshair
     const crosshair = this.get('crosshairs');
     if (crosshair) {
-      const plot = this.get('frontgroundGroup');
+      const plot = crosshair.type === 'rect' ? this.get('backgroundGroup') : this.get('frontgroundGroup');
       const crosshairGroup = new Crosshair(
         Util.mix(
           {


### PR DESCRIPTION
- [x]  crosshair类型为rect时，应绘制在backgroundGroup上，此时不需要再对shape进行toBack()操作
