### PR TITLE
refactor: view 的三层 group 不从父 view 的 middleGroup 中创建，而是从父 view 对应的层级中创建

### DIFF
--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -615,9 +615,9 @@ export class View extends EE {
       parent: this,
       canvas: this.canvas,
       // 子 view 共用三层 group
-      backgroundGroup: this.middleGroup.addGroup({ zIndex: GROUP_Z_INDEX.BG }),
+      backgroundGroup: this.backgroundGroup.addGroup({ zIndex: GROUP_Z_INDEX.BG }),
       middleGroup: this.middleGroup.addGroup({ zIndex: GROUP_Z_INDEX.MID }),
-      foregroundGroup: this.middleGroup.addGroup({ zIndex: GROUP_Z_INDEX.FORE }),
+      foregroundGroup: this.foregroundGroup.addGroup({ zIndex: GROUP_Z_INDEX.FORE }),
       theme: this.themeObject,
       ...cfg,
       options: {


### PR DESCRIPTION
解决 view 中各个 Geometry  label 遮挡的问题。 Geometry 的 label 将统一存储在 foregroundGroup 中。