### PR TITLE
fix: 极坐标下值坐标轴文本应该朝左放置

### DIFF
--- a/src/chart/component/axis.ts
+++ b/src/chart/component/axis.ts
@@ -259,9 +259,7 @@ export default class Axis extends Component<Option> {
    */
   private getLineAxisCfg(scale: Scale, axisOption: AxisOption, direction: DIRECTION): object {
     const container = this.container;
-
     const coordinate = this.view.getCoordinate();
-
     const region = getAxisRegion(coordinate, direction);
 
     const baseAxisCfg = {
@@ -271,7 +269,9 @@ export default class Axis extends Component<Option> {
       title: {
         text: getName(scale),
       },
-      verticalFactor: getAxisFactorByRegion(region, coordinate.getCenter()),
+      verticalFactor: coordinate.isPolar
+        ? getAxisFactorByRegion(region, coordinate.getCenter()) * -1
+        : getAxisFactorByRegion(region, coordinate.getCenter()),
     };
 
     const axisThemeCfg = getAxisThemeCfg(this.view.getTheme(), direction);

--- a/tests/unit/component/axis-circle-spec.ts
+++ b/tests/unit/component/axis-circle-spec.ts
@@ -81,7 +81,6 @@ describe('Component', () => {
       { x: 8, y: 0.6101 },
     ]);
     chart.coordinate('polar');
-    chart.axis('y', false); // 不显示 y 的坐标轴
     chart.axis('x', { grid: null });
     chart
       .line()
@@ -91,9 +90,11 @@ describe('Component', () => {
 
     chart.render();
     const axes = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.AXIS);
-    expect(axes.length).toBe(1);
+    expect(axes.length).toBe(2);
     // @ts-ignore
     expect(axes[0].component.cfg.ticks.length).toBe(4);
+    // @ts-ignore
+    expect(axes[1].component.cfg.verticalFactor).toBe(1);
   });
 
   afterAll(() => {


### PR DESCRIPTION
Fixed https://github.com/antvis/G2/issues/1715#issuecomment-563052470