### PR TITLE
fix(event-rect): not remove event rect after clear

### DIFF
--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -219,9 +219,6 @@ export class View extends Base {
       component.destroy();
     });
 
-    // 4. clear eventCaptureRect
-    this.viewEventCaptureRect.remove(true);
-
     // 递归处理子 view
     each(this.views, (view: View) => {
       view.clear();
@@ -246,6 +243,7 @@ export class View extends Base {
       }
     });
     this.clear();
+    this.viewEventCaptureRect.remove(true);
     this.backgroundGroup.remove(true);
     this.middleGroup.remove(true);
     this.foregroundGroup.remove(true);
@@ -938,6 +936,9 @@ export class View extends Base {
     this.adjustCoordinate();
     // 8. 渲染几何标记
     this.paintGeometries();
+    // 9. 更新 viewEventCaptureRect 大小
+    const { x, y, width, height } = this.viewBBox;
+    this.viewEventCaptureRect.attr({ x, y, width, height });
   }
 
   /**
@@ -1009,7 +1010,7 @@ export class View extends Base {
         height,
         fill: 'rgba(255,255,255,0)',
       },
-    }) as any;
+    }) as IShape;
   }
 
   /**

--- a/tests/unit/chart/chart-spec.ts
+++ b/tests/unit/chart/chart-spec.ts
@@ -83,6 +83,27 @@ describe('Chart', () => {
     expect(chart.wrapperElement.style.display).toBe('none');
   });
 
+  it('changeSize', () => {
+    // @ts-ignore
+    let bbox = chart.viewEventCaptureRect.getBBox();
+    expect({ x: bbox.x, y: bbox.y, width: bbox.width, height: bbox.height }).toEqual({
+      x: 10,
+      y: 10,
+      width: 780,
+      height: 580,
+    });
+
+    chart.changeSize(700, 600);
+    // @ts-ignore
+    bbox = chart.viewEventCaptureRect.getBBox();
+    expect({ x: bbox.x, y: bbox.y, width: bbox.width, height: bbox.height }).toEqual({
+      x: 10,
+      y: 10,
+      width: 680,
+      height: 580,
+    });
+  });
+
   it('changeVisible', () => {
     chart.changeVisible(false);
     expect(chart.visible).toBe(false);
@@ -104,9 +125,12 @@ describe('Chart', () => {
     expect(chart.scales).toEqual({});
     expect(!!chart.getCoordinate()).toBe(false);
 
-    expect(chart.getLayer(LAYER.BG).get('children').length).toBe(0);
+    expect(chart.getLayer(LAYER.BG).get('children').length).toBe(1);
     expect(chart.getLayer(LAYER.MID).get('children').length).toBe(1);
     expect(chart.getLayer(LAYER.FORE).get('children').length).toBe(1);
+
+    // @ts-ignore
+    expect(chart.viewEventCaptureRect).not.toBeUndefined();
   });
 
   it('destroy', () => {
@@ -118,5 +142,8 @@ describe('Chart', () => {
 
     expect(chart.canvas.destroyed).toBe(true);
     expect(div.childNodes.length).toBe(0);
+
+    // @ts-ignore
+    expect(chart.viewEventCaptureRect.getParent()).toBeUndefined();
   });
 });


### PR DESCRIPTION
fixed #1773

 - [x] not remove event rect after clear
 - [x] remove event rect when destroy
 - [x] update x y width height when render