### PR TITLE
Feat component animate

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@antv/data-set": "^0.10.2",
-    "@antv/gatsby-theme-antv": "^0.10.0",
+    "@antv/gatsby-theme-antv": "^0.10.20",
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-angular": "^8.2.0",
     "@types/jest": "^24.0.18",

--- a/src/animate/animation/sector-path-update.ts
+++ b/src/animate/animation/sector-path-update.ts
@@ -1,39 +1,99 @@
 import getArcParams from '@antv/g-canvas/lib/util/arc-params';
-import { each } from '@antv/util';
-import { IShape } from '../../dependents';
-import { getSectorPath } from '../../util/graphics';
+import { isNumberEqual } from '@antv/util';
+import { IShape, PathCommand } from '../../dependents';
+import { getArcPath, getSectorPath } from '../../util/graphics';
 import { AnimateCfg, AnimateExtraCfg } from '../interface';
 
-function getAngle(path) {
-  let startPoint;
-  let arcPathCommand;
-  let index;
-  each(path, (command, idx) => {
-    if (command[0] === 'A' || command[0] === 'a') {
-      arcPathCommand = command;
-      index = idx;
-      return false;
-    }
-  });
+function getAngle(startPoint: number[], arcPath: PathCommand) {
+  let { startAngle, endAngle } = getArcParams(startPoint, arcPath);
 
-  startPoint = [path[index - 1][1], path[index - 1][2]];
-  let { startAngle, endAngle } = getArcParams(startPoint, arcPathCommand);
-
-  if (startAngle < -Math.PI * 0.5) {
+  if (!isNumberEqual(startAngle, -Math.PI * 0.5) && startAngle < -Math.PI * 0.5) {
     startAngle += Math.PI * 2;
   }
-  if (endAngle < -Math.PI * 0.5) {
+  if (!isNumberEqual(endAngle, -Math.PI * 0.5) && endAngle < -Math.PI * 0.5) {
     endAngle += Math.PI * 2;
   }
 
-  if (endAngle > startAngle) {
-    endAngle -= Math.PI * 2;
+  if (arcPath[5] === 0) {
+    // 逆时针，需要将 startAngle 和 endAngle 转置，因为 G2 极坐标系为顺时针方向
+    [startAngle, endAngle] = [endAngle, startAngle];
+  }
+
+  if (isNumberEqual(startAngle, Math.PI * 1.5)) {
+    startAngle = Math.PI * -0.5;
+  }
+
+  if (isNumberEqual(endAngle, Math.PI * -0.5)) {
+    endAngle = Math.PI * 1.5;
   }
 
   return {
-    startAngle: endAngle,
-    endAngle: startAngle,
-    radius: arcPathCommand[1],
+    startAngle,
+    endAngle,
+  };
+}
+
+function getArcStartPoint(path: PathCommand) {
+  let startPoint;
+  if (path[0] === 'M' || path[0] === 'L') {
+    startPoint = [path[1], path[2]];
+  } else if (path[0] === 'a' || path[0] === 'A') {
+    startPoint = [path[path.length - 2], path[path.length - 1]];
+  }
+
+  return startPoint;
+}
+
+/**
+ * path 存在以下情况
+ * 1. 饼图不为整圆的 path，命令为 M, L, A, L, Z
+ * 2. 饼图为整圆的 path，命令为 M, M, A, A, M, Z
+ * 3. 环图不为整圆的 path，命令为 M, A, L, A, L, Z
+ * 4. 环图为整圆的 path，命令为 M, A, A, M, A, A, M, Z
+ * 5. radial-line, 不为整圆时的 path, 命令为 M, A, A, Z
+ * 6. radial-line, 为整圆时的 path，命令为 M, A, A, A, A, Z
+ * @param path theta 坐标系下圆弧的 path 命令
+ */
+function getArcInfo(path: PathCommand[]) {
+  let startAngle;
+  let endAngle;
+
+  const arcPaths = path.filter((command) => {
+    return command[0] === 'A' || command[0] === 'a';
+  });
+
+  const firstArcPathCommand = arcPaths[0];
+  const lastArcPathCommand = arcPaths.length > 1 ? arcPaths[1] : arcPaths[0];
+  const firstIndex = path.indexOf(firstArcPathCommand);
+  const lastIndex = path.indexOf(lastArcPathCommand);
+  const firstStartPoint = getArcStartPoint(path[firstIndex - 1]);
+  const lastStartPoint = getArcStartPoint(path[lastIndex - 1]);
+
+  const { startAngle: firstStartAngle, endAngle: firstEndAngle } = getAngle(firstStartPoint, firstArcPathCommand);
+  const { startAngle: lastStartAngle, endAngle: lastEndAngle } = getAngle(lastStartPoint, lastArcPathCommand);
+
+  if (isNumberEqual(firstStartAngle, lastStartAngle) && isNumberEqual(firstEndAngle, lastEndAngle)) {
+    startAngle = firstStartAngle;
+    endAngle = firstEndAngle;
+  } else {
+    startAngle = Math.min(firstStartAngle, lastStartAngle);
+    endAngle = Math.max(firstEndAngle, lastEndAngle);
+  }
+
+  let radius = firstArcPathCommand[1];
+  let innerRadius = arcPaths[arcPaths.length - 1][1];
+
+  if (radius < innerRadius) {
+    [radius, innerRadius] = [innerRadius, radius];
+  } else if (radius === innerRadius) {
+    innerRadius = 0;
+  }
+
+  return {
+    startAngle,
+    endAngle,
+    radius,
+    innerRadius,
   };
 }
 
@@ -47,8 +107,9 @@ export function sectorPathUpdate(shape: IShape, animateCfg: AnimateCfg, cfg: Ani
   const { toAttrs, coordinate } = cfg;
   // @ts-ignore
   const path = toAttrs.path;
-  const { startAngle: curStartAngle, endAngle: curEndAngle, radius } = getAngle(path);
-  const { startAngle: preStartAngle, endAngle: preEndAngle } = getAngle(shape.attr('path'));
+
+  const { startAngle: curStartAngle, endAngle: curEndAngle, radius, innerRadius } = getArcInfo(path);
+  const { startAngle: preStartAngle, endAngle: preEndAngle } = getArcInfo(shape.attr('path'));
 
   const center = coordinate.getCenter();
   const diffStartAngle = curStartAngle - preStartAngle;
@@ -59,7 +120,11 @@ export function sectorPathUpdate(shape: IShape, animateCfg: AnimateCfg, cfg: Ani
     const onFrameEndAngle = preEndAngle + ratio * diffEndAngle;
     return {
       ...toAttrs,
-      path: getSectorPath(center.x, center.y, radius, onFrameStartAngle, onFrameEndAngle),
+      path:
+        // /examples/bar/basic/demo/radial-line.ts
+        path.length === 4 || shape.attr('path').length === 4
+          ? getArcPath(center.x, center.y, radius, onFrameStartAngle, onFrameEndAngle)
+          : getSectorPath(center.x, center.y, radius, onFrameStartAngle, onFrameEndAngle, innerRadius),
     };
   }, animateCfg);
 }

--- a/src/animate/index.ts
+++ b/src/animate/index.ts
@@ -5,7 +5,7 @@ import { getAnimation } from './animation';
 import { AnimateCfg as ParsedAnimateCfg, AnimateExtraCfg } from './interface';
 
 // 默认的动画参数配置
-const DEFAULT_ANIMATE_CFG = {
+export const DEFAULT_ANIMATE_CFG = {
   appear: {
     duration: 450,
     easing: 'easeQuadOut',

--- a/src/chart/controller/annotation.ts
+++ b/src/chart/controller/annotation.ts
@@ -1,16 +1,5 @@
-import {
-  deepMix,
-  each,
-  filter,
-  get,
-  isArray,
-  isFunction,
-  isNil,
-  isString,
-  isUndefined,
-  keys,
-  upperFirst,
-} from '@antv/util';
+import { deepMix, each, get, isArray, isFunction, isNil, isString, keys, upperFirst } from '@antv/util';
+import { DEFAULT_ANIMATE_CFG } from '../../animate/';
 import { COMPONENT_TYPE, DIRECTION, LAYER } from '../../constant';
 import { Annotation as AnnotationComponent, IGroup, Scale } from '../../dependents';
 import { Point } from '../../interface';
@@ -89,32 +78,12 @@ export interface TextOption {
   readonly animate?: boolean;
 }
 
-const default_animation_cfg = {
-  appear: {
-    duration: 450,
-    easing: 'easeQuadOut',
-  }, // 初始入场动画配置
-  update: {
-    duration: 400,
-    easing: 'easeQuadInOut',
-  }, // 更新时发生变更的动画配置
-  enter: {
-    duration: 400,
-    easing: 'easeQuadInOut',
-  }, // 更新时新增元素的入场动画配置
-  leave: {
-    duration: 350,
-    easing: 'easeQuadIn',
-  }, // 更新时销毁动画配置
-};
-
 /**
  * annotation controller, supply:
  * 1. API for creating annotation: line、text、arc ...
  * 2. life circle: init、layout、render、clear、destroy
  */
 export default class Annotation extends Controller<BaseOption[]> {
-  protected animate: boolean = true;
   private foregroundContainer: IGroup;
   private backgroundContainer: IGroup;
 
@@ -520,8 +489,8 @@ export default class Annotation extends Controller<BaseOption[]> {
     // 合并主题，用户配置优先级高于主题
     const cfg = deepMix({}, theme, { ...o });
     cfg.container = this.getComponentContainer(cfg);
-    cfg.animate = this.animate && cfg.animate && get(option, 'animate', cfg.animate);
-    cfg.animateOption = default_animation_cfg;
+    cfg.animate = cfg.animate && get(option, 'animate', cfg.animate);
+    cfg.animateOption = DEFAULT_ANIMATE_CFG;
 
     return cfg;
   }

--- a/src/chart/controller/axis.ts
+++ b/src/chart/controller/axis.ts
@@ -52,6 +52,8 @@ export default class Axis extends Controller<Option> {
   /** the draw group of axis */
   private axisContainer: IGroup;
   private gridContainer: IGroup;
+  /** 动画标识 */
+  private animate: boolean;
 
   /** 使用 object 存储组件 */
   private cache = new Map<string, ComponentOption>();

--- a/src/chart/controller/axis.ts
+++ b/src/chart/controller/axis.ts
@@ -25,7 +25,7 @@ function getAxisOption(axes: Record<string, AxisOption> | boolean, field: string
   }
 }
 
-const default_animate_cfg = {
+const DEFAULT_ANIMATE_CFG = {
   appear: null,
   update: {
     duration: 400,
@@ -707,7 +707,7 @@ export default class Axis extends Controller<Option> {
   private getAnimateCfg(cfg: object) {
     return {
       animate: this.animate && get(cfg, 'animate'),
-      animateOption: default_animate_cfg,
+      animateOption: DEFAULT_ANIMATE_CFG,
     };
   }
 }

--- a/src/chart/controller/base.ts
+++ b/src/chart/controller/base.ts
@@ -1,4 +1,4 @@
-import { each, find } from '@antv/util';
+import { each } from '@antv/util';
 import { ComponentOption } from '../interface';
 import View from '../view';
 
@@ -18,6 +18,7 @@ export abstract class Controller<O = unknown> {
   protected option: O;
   /** 所有的 component */
   protected components: ComponentOption[] = [];
+  protected animate: boolean = false;
 
   constructor(view: View) {
     this.view = view;

--- a/src/chart/controller/base.ts
+++ b/src/chart/controller/base.ts
@@ -18,7 +18,6 @@ export abstract class Controller<O = unknown> {
   protected option: O;
   /** 所有的 component */
   protected components: ComponentOption[] = [];
-  protected animate: boolean = false;
 
   constructor(view: View) {
     this.view = view;

--- a/src/chart/controller/legend.ts
+++ b/src/chart/controller/legend.ts
@@ -1,4 +1,5 @@
 import { deepMix, each, filter, find, get, head, isBoolean, last, map, uniq } from '@antv/util';
+import { DEFAULT_ANIMATE_CFG } from '../../animate';
 import { COMPONENT_MAX_VIEW_PERCENTAGE, COMPONENT_TYPE, DIRECTION, LAYER } from '../../constant';
 import { Attribute, CategoryLegend, ContinuousLegend, GroupComponent, IGroup, Scale, Tick } from '../../dependents';
 import Geometry from '../../geometry/base';
@@ -368,7 +369,9 @@ export default class Legend extends Controller<Option> {
   private mergeLegendCfg(baseCfg: object, legendOption: LegendOption, direction: DIRECTION) {
     const themeObject = get(this.view.getTheme(), ['components', 'legend', direction], {});
 
-    return deepMix({}, themeObject, baseCfg, legendOption);
+    return deepMix({}, themeObject, baseCfg, legendOption, {
+      animateOption: DEFAULT_ANIMATE_CFG,
+    });
   }
 
   /**

--- a/src/chart/controller/legend.ts
+++ b/src/chart/controller/legend.ts
@@ -1,4 +1,4 @@
-import { deepMix, each, filter, find, get, head, isBoolean, last, map, uniq } from '@antv/util';
+import { deepMix, each, find, get, head, isBoolean, last, map, uniq } from '@antv/util';
 import { DEFAULT_ANIMATE_CFG } from '../../animate';
 import { COMPONENT_MAX_VIEW_PERCENTAGE, COMPONENT_TYPE, DIRECTION, LAYER } from '../../constant';
 import { Attribute, CategoryLegend, ContinuousLegend, GroupComponent, IGroup, Scale, Tick } from '../../dependents';

--- a/src/chart/interface.ts
+++ b/src/chart/interface.ts
@@ -19,6 +19,7 @@ import {
   LegendItemValueCfg,
   LegendMarkerCfg,
   LegendTitleCfg,
+  PathCommand,
 } from '../dependents';
 import {
   AdjustOption,
@@ -436,7 +437,7 @@ type Marker =
   | 'plus'
   | 'hyphen'
   | 'line';
-type MarkerCallback = (x: number, y: number, r: number) => any[][];
+type MarkerCallback = (x: number, y: number, r: number) => PathCommand;
 export type TooltipOption = TooltipCfg | boolean;
 /* 筛选器函数类型定义 */
 export type FilterCondition = (value: any, datum: Datum) => boolean;

--- a/src/chart/interface.ts
+++ b/src/chart/interface.ts
@@ -1,6 +1,17 @@
 import { COMPONENT_TYPE, DIRECTION, LAYER } from '../constant';
-import { GroupComponent, HtmlComponent } from '../dependents';
-import { CategoryLegendCfg, CircleAxisCfg, ICanvas, IGroup, LineAxisCfg } from '../dependents';
+import {
+  AxisLabelCfg,
+  AxisLineCfg,
+  AxisSubTickLineCfg,
+  AxisTickLineCfg,
+  AxisTitleCfg,
+  CategoryLegendCfg,
+  GridLineCfg,
+  GroupComponent,
+  HtmlComponent,
+  ICanvas,
+  IGroup,
+} from '../dependents';
 import {
   AdjustOption,
   AttributeOption,
@@ -96,7 +107,6 @@ export interface ChartCfg {
   /** 图表高度 */
   readonly height?: number;
   /**
-   * TODO: 规则需要确认
    * 图表是否自适应容器宽高，默认为 false
    */
   readonly autoFit?: boolean;
@@ -235,6 +245,44 @@ export interface CoordinateCfg {
   center?: [number, number]; // 中心经纬度设置，比如 [ 120, 20 ]
 }
 
+export interface AxisGridCfg {
+  /**
+   * 线的样式
+   */
+  line?: GridLineCfg;
+  /**
+   * 两个栅格线间的填充色，必须是一个数组
+   */
+  alternateColor?: string | string[];
+}
+
+export interface AxisCfg {
+  /**
+   * 坐标轴线的配置项，null 表示不展示
+   */
+  line?: AxisLineCfg | null;
+  /**
+   * 坐标轴刻度线线的配置项，null 表示不展示
+   */
+  tickLine?: AxisTickLineCfg | null;
+  /**
+   * 坐标轴子刻度线的配置项，null 表示不展示
+   */
+  subTickLine?: AxisSubTickLineCfg | null;
+  /**
+   * 标题的配置项，null 表示不展示
+   */
+  title?: AxisTitleCfg | null;
+  /**
+   * 文本标签的配置项，null 表示不展示
+   */
+  label?: AxisLabelCfg | null;
+  /** 坐标轴网格线的配置项，null 表示不展示 */
+  grid?: AxisGridCfg | null;
+  /** 是否开启坐标轴动画，默认开启 */
+  animate?: boolean;
+}
+
 export interface Options {
   /** 数据源 */
   readonly data: Data;
@@ -269,5 +317,5 @@ export interface Options {
 export type TooltipOption = TooltipCfg | boolean;
 /* 筛选器函数类型定义 */
 export type FilterCondition = (value: any, datum: Datum) => boolean;
-export type AxisOption = Partial<LineAxisCfg> | Partial<CircleAxisCfg> | boolean;
+export type AxisOption = AxisCfg | boolean;
 export type LegendOption = LegendCfg | boolean;

--- a/src/chart/interface.ts
+++ b/src/chart/interface.ts
@@ -5,12 +5,20 @@ import {
   AxisSubTickLineCfg,
   AxisTickLineCfg,
   AxisTitleCfg,
-  CategoryLegendCfg,
+  ContinueLegendHandlerCfg,
+  ContinueLegendLabelCfg,
+  ContinueLegendRailCfg,
+  ContinueLegendTrackCfg,
   GridLineCfg,
   GroupComponent,
   HtmlComponent,
   ICanvas,
   IGroup,
+  LegendBackgroundCfg,
+  LegendItemNameCfg,
+  LegendItemValueCfg,
+  LegendMarkerCfg,
+  LegendTitleCfg,
 } from '../dependents';
 import {
   AdjustOption,
@@ -178,8 +186,109 @@ export interface ComponentOption {
   readonly extra?: any;
 }
 
-export interface LegendCfg extends Partial<CategoryLegendCfg> {
-  readonly position?: string;
+interface MarkerCfg extends LegendMarkerCfg {
+  symbol?: Marker | MarkerCallback; // marker 的形状
+}
+
+/**
+ * 图例项配置
+ */
+export interface LegendCfg {
+  /**
+   * 布局方式： horizontal，vertical
+   */
+  layout?: 'horizontal' | 'svertical';
+  /**
+   * 标题
+   */
+  title?: LegendTitleCfg;
+  /**
+   * 背景框配置项
+   */
+  background?: LegendBackgroundCfg;
+  /** 图例的位置 */
+  position?:
+    | 'top'
+    | 'top-left'
+    | 'top-right'
+    | 'right'
+    | 'right-top'
+    | 'right-bottom'
+    | 'left'
+    | 'left-top'
+    | 'left-bottom'
+    | 'bottom'
+    | 'bottom-left'
+    | 'bottom-right';
+  /** 动画配置 */
+  animate?: boolean;
+  /** 分类图例适用，图例项水平方向的间距 */
+  itemSpacing?: number;
+  /**
+   * 分类图例适用，图例项的宽度, 默认为 null，自动计算
+   */
+  itemWidth?: number;
+  /**
+   * 分类图例适用，图例的高度，默认为 null
+   */
+  itemHeight?: number;
+  /**
+   * 分类图例适用，图例项 name 文本的配置
+   */
+  itemName?: LegendItemNameCfg;
+  /**
+   * 分类图例适用，图例项 value 附加值的配置项
+   */
+  itemValue?: LegendItemValueCfg;
+  /**
+   * 分类图例适用，最大宽度
+   * @type {number}
+   */
+  maxWidth?: number;
+  /**
+   * 分类图例适用，最大高度
+   * @type {number}
+   */
+  maxHeight?: number;
+  /**
+   * 分类图例适用，图例项的 marker 图标的配置
+   */
+  marker?: MarkerCfg;
+  /** 适用于分类图例，当图例项过多时是否进行分页 */
+  flipPage?: boolean;
+
+  /**
+   * 连续图例适用，选择范围的最小值
+   */
+  min?: number;
+  /**
+   * 连续图例适用，选择范围的最大值
+   */
+  max?: number;
+  /**
+   * 连续图例适用，选择的值
+   */
+  value?: number[];
+  /**
+   * 连续图例适用，选择范围的色块配置项
+   */
+  track?: ContinueLegendTrackCfg;
+  /**
+   * 连续图例适用，图例滑轨（背景）的配置项
+   */
+  rail?: ContinueLegendRailCfg;
+  /**
+   * 连续图例适用，文本的配置项
+   */
+  label?: ContinueLegendLabelCfg;
+  /**
+   * 连续图例适用，滑块的配置项
+   */
+  handler?: ContinueLegendHandlerCfg;
+  /**
+   * 连续图例适用，是否可以滑动
+   */
+  slidable?: boolean;
 }
 
 export interface TooltipCfg {
@@ -314,6 +423,20 @@ export interface Options {
   readonly views?: ViewOption[];
 }
 
+type Marker =
+  | 'circle'
+  | 'square'
+  | 'diamond'
+  | 'triangle'
+  | 'triangleDown'
+  | 'hexagon'
+  | 'bowtie'
+  | 'cross'
+  | 'tick'
+  | 'plus'
+  | 'hyphen'
+  | 'line';
+type MarkerCallback = (x: number, y: number, r: number) => any[][];
 export type TooltipOption = TooltipCfg | boolean;
 /* 筛选器函数类型定义 */
 export type FilterCondition = (value: any, datum: Datum) => boolean;

--- a/src/dependents.ts
+++ b/src/dependents.ts
@@ -2,7 +2,7 @@
 
 // G
 export { ICanvas, IElement, IGroup, IShape } from '@antv/g-base/lib/interfaces';
-export { PathCommand, BBox, Point } from '@antv/g-base/lib/types';
+export { PathCommand, BBox, Point, ShapeAttrs } from '@antv/g-base/lib/types';
 export { Event } from '@antv/g-base';
 // 需要有 G-base 提供 g engine 类型定义
 export type IG = any;

--- a/src/dependents.ts
+++ b/src/dependents.ts
@@ -35,6 +35,16 @@ export {
   AxisTitleCfg,
   AxisLabelCfg,
   GridLineCfg,
+  LegendMarkerCfg,
+  LegendTitleCfg,
+  LegendBackgroundCfg,
+  LegendItemNameCfg,
+  LegendItemValueCfg,
+  ContinueLegendCfg,
+  ContinueLegendTrackCfg,
+  ContinueLegendRailCfg,
+  ContinueLegendLabelCfg,
+  ContinueLegendHandlerCfg,
 } from '@antv/component/lib/types';
 export { HtmlComponent, GroupComponent, Component };
 export { Annotation };

--- a/src/dependents.ts
+++ b/src/dependents.ts
@@ -23,7 +23,19 @@ export { Tick } from '@antv/scale/lib/base';
 // component
 import { Annotation, Axis, Component, Grid, GroupComponent, HtmlComponent, Legend, Tooltip } from '@antv/component';
 export { IComponent, IList } from '@antv/component/lib/interfaces';
-export { CategoryLegendCfg, CircleAxisCfg, LineAxisCfg, GroupComponentCfg, ListItem } from '@antv/component/lib/types';
+export {
+  CategoryLegendCfg,
+  CircleAxisCfg,
+  LineAxisCfg,
+  GroupComponentCfg,
+  ListItem,
+  AxisLineCfg,
+  AxisTickLineCfg,
+  AxisSubTickLineCfg,
+  AxisTitleCfg,
+  AxisLabelCfg,
+  GridLineCfg,
+} from '@antv/component/lib/types';
 export { HtmlComponent, GroupComponent, Component };
 export { Annotation };
 // axis

--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -1202,7 +1202,7 @@ export default class Geometry extends Base {
 
   // 创建图形属性相关的配置项
   private createAttrOption(attrName: string, field: AttributeOption | string | number, cfg?) {
-    if (!field || isObject(field)) {
+    if (isNil(field) || isObject(field)) {
       set(this.attributeOption, attrName, field);
     } else {
       const attrCfg: AttributeOption = {};

--- a/src/geometry/element/index.ts
+++ b/src/geometry/element/index.ts
@@ -94,6 +94,11 @@ export default class Element extends Base {
     if (!shape) {
       return;
     }
+
+    // 更新数据
+    this.model = model;
+    this.data = model.data;
+
     // step 1: 更新 shape 携带的信息
     const drawCfg = this.getShapeDrawCfg(model);
     this.setShapeInfo(shape, drawCfg);
@@ -104,10 +109,6 @@ export default class Element extends Base {
 
     // step 3: 同步 shape 样式
     this.syncShapeStyle(shape, newShape, '', this.getAnimateCfg('update'));
-
-    // 更新数据
-    this.model = model;
-    this.data = model.data;
 
     newShape.remove(true); // newShape 不在当前渲染树上，销毁，减少内存占用
   }
@@ -427,6 +428,7 @@ export default class Element extends Base {
         doAnimate(sourceShape, animateCfg, {
           coordinate: this.shapeFactory.coordinate,
           toAttrs: newAttrs,
+          shapeModel: this.model,
         });
       } else {
         sourceShape.attr(newAttrs);

--- a/src/geometry/element/index.ts
+++ b/src/geometry/element/index.ts
@@ -326,7 +326,12 @@ export default class Element extends Base {
     // 1. animate === false, 用户关闭动画
     // 2. 动画默认开启，用户没有对动画进行配置同时有没有内置的默认动画
     // 3. 用户关闭对应的动画  animate: { enter: false }
-    if (!animate || (animate === true && isEmpty(defaultCfg)) || animate[animateType] === false) {
+    if (
+      !animate ||
+      (animate === true && isEmpty(defaultCfg)) ||
+      animate[animateType] === false ||
+      animate[animateType] === null
+    ) {
       return null;
     }
 

--- a/src/geometry/shape/area.ts
+++ b/src/geometry/shape/area.ts
@@ -108,8 +108,10 @@ registerShape('area', 'area', {
       symbol: (x: number, y: number, r: number = 5.5) => {
         return [['M', x - r, y - 4], ['L', x + r, y - 4], ['L', x + r, y + 4], ['L', x - r, y + 4], ['Z']];
       },
-      r: 5,
-      fill: color,
+      style: {
+        r: 5,
+        fill: color,
+      },
     };
   },
 });
@@ -132,8 +134,10 @@ registerShape('area', 'line', {
       symbol: (x: number, y: number, r: number = 5.5) => {
         return [['M', x - r, y - 4], ['L', x + r, y - 4], ['L', x + r, y + 4], ['L', x - r, y + 4], ['Z']];
       },
-      r: 5,
-      stroke: color,
+      style: {
+        r: 5,
+        stroke: color,
+      },
     };
   },
 });
@@ -157,8 +161,10 @@ registerShape('area', 'smooth', {
       symbol: (x: number, y: number, r: number = 5.5) => {
         return [['M', x - r, y - 4], ['L', x + r, y - 4], ['L', x + r, y + 4], ['L', x - r, y + 4], ['Z']];
       },
-      r: 5,
-      fill: color,
+      style: {
+        r: 5,
+        fill: color,
+      },
     };
   },
 });
@@ -182,8 +188,10 @@ registerShape('area', 'smoothLine', {
       symbol: (x: number, y: number, r: number = 5.5) => {
         return [['M', x - r, y - 4], ['L', x + r, y - 4], ['L', x + r, y + 4], ['L', x - r, y + 4], ['Z']];
       },
-      r: 5,
-      stroke: color,
+      style: {
+        r: 5,
+        stroke: color,
+      },
     };
   },
 });

--- a/src/geometry/shape/base.ts
+++ b/src/geometry/shape/base.ts
@@ -1,6 +1,6 @@
 /** @module Shape */
 import { parsePathString } from '@antv/path-util';
-import { get, upperFirst } from '@antv/util';
+import { deepMix, get, mix, upperFirst } from '@antv/util';
 import { IGroup, IShape, PathCommand } from '../../dependents';
 import {
   Point,
@@ -73,10 +73,8 @@ const ShapeFactoryBase = {
     const theme = this.theme;
     const shapeStyle = get(theme, [shapeType, 'default'], {});
     const markerStyle = shape.getMarker(markerCfg);
-    return {
-      ...shapeStyle,
-      ...markerStyle,
-    };
+
+    return deepMix({}, { style: shapeStyle }, markerStyle);
   },
   /**
    * 绘制 shape

--- a/src/geometry/shape/interval.ts
+++ b/src/geometry/shape/interval.ts
@@ -192,15 +192,19 @@ registerShape('interval', 'rect', {
     if (isInPolar) {
       return {
         symbol: 'circle',
-        r: 4.5,
-        fill: color,
+        style: {
+          r: 4.5,
+          fill: color,
+        },
       };
     }
 
     return {
       symbol: 'square',
-      r: 4,
-      fill: color,
+      style: {
+        r: 4,
+        fill: color,
+      },
     };
   },
 });
@@ -225,15 +229,19 @@ registerShape('interval', 'hollowRect', {
     if (isInPolar) {
       return {
         symbol: 'circle',
-        r: 4.5,
-        stroke: color,
+        style: {
+          r: 4.5,
+          stroke: color,
+        },
       };
     }
 
     return {
       symbol: 'square',
-      r: 4,
-      stroke: color,
+      style: {
+        r: 4,
+        stroke: color,
+      },
     };
   },
 });
@@ -265,8 +273,10 @@ registerShape('interval', 'line', {
           ['L', x, y + r],
         ];
       },
-      r: 5,
-      stroke: color,
+      style: {
+        r: 5,
+        stroke: color,
+      },
     };
   },
 });
@@ -302,8 +312,10 @@ registerShape('interval', 'tick', {
           ['L', x + r / 2, y + r],
         ];
       },
-      r: 5,
-      stroke: color,
+      style: {
+        r: 5,
+        stroke: color,
+      },
     };
   },
 });
@@ -330,8 +342,10 @@ registerShape('interval', 'funnel', {
     const { color } = markerCfg;
     return {
       symbol: 'square',
-      r: 4,
-      fill: color,
+      style: {
+        r: 4,
+        fill: color,
+      },
     };
   },
 });
@@ -359,8 +373,10 @@ registerShape('interval', 'pyramid', {
     const { color } = markerCfg;
     return {
       symbol: 'square',
-      r: 4,
-      fill: color,
+      style: {
+        r: 4,
+        fill: color,
+      },
     };
   },
 });

--- a/src/geometry/shape/line.ts
+++ b/src/geometry/shape/line.ts
@@ -246,9 +246,11 @@ each(['line', 'dot', 'dash', 'smooth'], (shapeType) => {
       const { color } = markerCfg;
       return {
         symbol: LineSymbols[shapeType],
-        lineWidth: 2,
-        r: 6,
-        stroke: color,
+        style: {
+          lineWidth: 2,
+          r: 6,
+          stroke: color,
+        },
       };
     },
   });
@@ -271,9 +273,11 @@ each(['hv', 'vh', 'hvh', 'vhv'], (shapeType) => {
       const { color } = markerCfg;
       return {
         symbol: LineSymbols[shapeType],
-        lineWidth: 2,
-        r: 6,
-        stroke: color,
+        style: {
+          lineWidth: 2,
+          r: 6,
+          stroke: color,
+        },
       };
     },
   });

--- a/src/geometry/shape/point.ts
+++ b/src/geometry/shape/point.ts
@@ -99,8 +99,10 @@ each(SHAPES, (shapeName: string) => {
       const { color } = markerCfg;
       return {
         symbol: PointSymbols[shapeName] || shapeName,
-        r: 4.5,
-        fill: color,
+        style: {
+          r: 4.5,
+          fill: color,
+        },
       };
     },
   });
@@ -119,8 +121,10 @@ each(SHAPES, (shapeName: string) => {
       const { color } = markerCfg;
       return {
         symbol: PointSymbols[shapeName] || shapeName,
-        r: 4.5,
-        stroke: color,
+        style: {
+          r: 4.5,
+          stroke: color,
+        },
       };
     },
   });
@@ -142,8 +146,10 @@ each(HOLLOW_SHAPES, (shapeName: string) => {
       const { color } = markerCfg;
       return {
         symbol: PointSymbols[shapeName],
-        r: 4.5,
-        stroke: color,
+        style: {
+          r: 4.5,
+          stroke: color,
+        },
       };
     },
   });

--- a/src/geometry/shape/polygon.ts
+++ b/src/geometry/shape/polygon.ts
@@ -66,8 +66,10 @@ registerShape('polygon', 'polygon', {
     const { color } = markerCfg;
     return {
       symbol: 'square',
-      r: 4,
-      fill: color,
+      style: {
+        r: 4,
+        fill: color,
+      },
     };
   },
 });
@@ -90,8 +92,10 @@ registerShape('polygon', 'hollow', {
     const { color } = markerCfg;
     return {
       symbol: 'square',
-      r: 4,
-      stroke: color,
+      style: {
+        r: 4,
+        stroke: color,
+      },
     };
   },
 });

--- a/src/geometry/shape/schema.ts
+++ b/src/geometry/shape/schema.ts
@@ -173,10 +173,12 @@ registerShape('schema', 'candle', {
           ['L', points[7].x, points[7].y],
         ];
       },
-      lineWidth: 1,
-      stroke: color,
-      fill: color,
-      r: 6,
+      style: {
+        lineWidth: 1,
+        stroke: color,
+        fill: color,
+        r: 6,
+      },
     };
   },
 });
@@ -225,9 +227,11 @@ registerShape('schema', 'box', {
           ['L', points[13].x, points[13].y],
         ];
       },
-      r: 6,
-      lineWidth: 1,
-      stroke: color,
+      style: {
+        r: 6,
+        lineWidth: 1,
+        stroke: color,
+      },
     };
   },
 });

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,5 +1,5 @@
 import { View } from './chart';
-import { Coordinate, IGroup, IShape, PathCommand, ScaleConfig } from './dependents';
+import { Coordinate, IGroup, IShape, PathCommand, ScaleConfig, ShapeAttrs } from './dependents';
 
 /** G 的渲染类型 */
 export type Renderer = 'svg' | 'canvas';
@@ -143,13 +143,8 @@ export interface ShapeMarkerCfg {
 export interface ShapeMarkerAttrs {
   /** marker 的形状 */
   symbol: string | ShapeMarkerSymbol;
-  /** 描边的颜色 */
-  stroke?: string;
-  /** 填充的颜色 */
-  fill?: string;
-  /** marker 的大小 */
-  r: number;
-  [key: string]: any;
+  /** marker 的样式 */
+  style: ShapeAttrs;
 }
 
 /** 注册 ShapeFactory 需要实现的接口 */

--- a/src/theme/antv.ts
+++ b/src/theme/antv.ts
@@ -138,6 +138,7 @@ const AXIS_STYLE = {
     length: 5,
   },
   subTickLine: null,
+  animate: true,
 };
 
 const GRID_STYLE = {
@@ -164,6 +165,7 @@ const LEGEND_STYLE = {
       textBaseline: 'middle',
     },
   },
+  animate: false,
 };
 
 export default {
@@ -644,6 +646,7 @@ export default {
           lineDash: [2, 2],
           lineWidth: 1,
         },
+        animate: true,
       },
       line: {
         style: {
@@ -663,6 +666,7 @@ export default {
             textBaseline: 'bottom',
           },
         },
+        animate: true,
       },
       text: {
         style: {
@@ -672,6 +676,7 @@ export default {
           textAlign: 'start',
           fontFamily: FONT_FAMILY,
         },
+        animate: true,
       },
       region: {
         top: false,
@@ -680,6 +685,7 @@ export default {
           fill: '#000', // 辅助框填充的颜色
           fillOpacity: 0.04, // 辅助框的背景透明度
         }, // 辅助框的图形样式属性
+        animate: true,
       },
     },
   },

--- a/tests/unit/animate/charts-animate-spec.ts
+++ b/tests/unit/animate/charts-animate-spec.ts
@@ -534,32 +534,6 @@ describe('Test charts animate', () => {
       type: 'cat',
       values: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
     });
-
-    chart.axis('name', {
-      tickLine: null,
-      grid: {
-        align: 'center',
-        lineStyle: {
-          lineWidth: 1,
-          lineDash: null,
-          stroke: '#f0f0f0',
-        },
-      },
-    });
-
-    chart.axis('day', {
-      title: null,
-      grid: {
-        align: 'center',
-        lineStyle: {
-          lineWidth: 1,
-          lineDash: null,
-          stroke: '#f0f0f0',
-        },
-        showFirstLine: true,
-      },
-    });
-
     chart.coordinate('polar');
     chart
       .polygon()

--- a/tests/unit/chart/controller/annotation-update-spec.ts
+++ b/tests/unit/chart/controller/annotation-update-spec.ts
@@ -37,6 +37,8 @@ describe('annotation update', () => {
     let annotations = getAnnotations();
     expect(annotations.length).toBe(1);
     expect(annotations[0].component.get('type')).toBe('text');
+    expect(annotations[0].component.get('animate')).toBe(true);
+    expect(annotations[0].component.get('animateOption')).toBeDefined();
 
     const [text] = annotations;
 
@@ -45,6 +47,7 @@ describe('annotation update', () => {
     chart.annotation().line({
       start: { name: 'London', 月份: 'Jan.', 月均降雨量: 18.9 },
       end: { name: 'London', 月份: 'Mar.', 月均降雨量: 39.3 },
+      animate: false,
     });
     chart.render(true);
 
@@ -53,7 +56,10 @@ describe('annotation update', () => {
 
     // 更新逻辑保持引用
     expect(annotations[0]).toBe(text);
+    expect(annotations[0].component.get('animate')).toBe(true);
     expect(annotations[1].component.get('type')).toBe('line');
+    expect(annotations[1].component.get('animate')).toBe(false);
+    expect(annotations[1].component.get('animateOption')).toBeDefined();
   });
 
   it('legend update', async () => {

--- a/tests/unit/chart/controller/axis-spec.ts
+++ b/tests/unit/chart/controller/axis-spec.ts
@@ -44,5 +44,17 @@ describe('Axis', () => {
     expect(y.component.getBBox().minX).toBeWithin(-8 - GAP, -8 + GAP);
 
     expect(axes.length).toBe(2);
+
+    // 图表初始化加载的时候不做 axis 动画
+    expect(x.component.get('animate')).toBe(false);
+    expect(x.component.get('animateOption')).toBeDefined();
+    expect(y.component.get('animate')).toBe(false);
+    expect(y.component.get('animateOption')).toBeDefined();
+
+    // 默认 Y 轴生成 grid
+    const grids = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.GRID);
+    expect(grids.length).toBe(1);
+    expect(grids[0].component.get('animate')).toBe(false);
+    expect(grids[0].component.get('animateOption')).toBeDefined();
   });
 });

--- a/tests/unit/chart/controller/axis-update-spec.ts
+++ b/tests/unit/chart/controller/axis-update-spec.ts
@@ -5,7 +5,7 @@ import { delay } from '../../../util/delay';
 import { createDiv } from '../../../util/dom';
 
 // rect
-describe.skip('axis rect update', () => {
+describe('axis rect update', () => {
   const container = createDiv();
   const data = [
     { name: 'London', 月份: 'Jan.', 月均降雨量: 18.9 },
@@ -43,10 +43,17 @@ describe.skip('axis rect update', () => {
 
   it('axis update', async () => {
     let axes = getAxes();
+    let grids = getGrids();
+
     expect(axes.length).toBe(2);
+    expect(grids.length).toBe(1);
 
     const [x, y] = axes;
     expect(x.component.get('ticks').length).toBe(3);
+
+    expect(x.component.get('animate')).toBe(false);
+    expect(y.component.get('animate')).toBe(false);
+    expect(grids[0].component.get('animate')).toBe(false);
 
     await delay(100);
 
@@ -60,13 +67,18 @@ describe.skip('axis rect update', () => {
         autoRotate: true,
       },
     });
+    chart.axis('月均降雨量', {
+      animate: false, // 关闭该轴动画
+    });
 
     chart.changeData(data.slice(0, 2));
 
     chart.render(true);
 
     axes = getAxes();
+    grids = getGrids();
     expect(axes.length).toBe(2);
+    expect(grids.length).toBe(1);
 
     // 更新逻辑保持引用
     expect(axes[0]).toBe(x);
@@ -74,6 +86,11 @@ describe.skip('axis rect update', () => {
     // 修改配置生效
     expect(axes[0].component.get('title').style.fill).toBe('red');
     expect(axes[0].component.get('ticks').length).toBe(2);
+
+    // 更新时动画开启
+    expect(axes[0].component.get('animate')).toBe(true);
+    expect(axes[1].component.get('animate')).toBe(false);
+    expect(grids[0].component.get('animate')).toBe(false);
   });
 
   it('axis delete', async () => {
@@ -118,7 +135,9 @@ describe('axis polar update', () => {
   chart.data(data);
 
   const interval = chart
-    .interval()
+    .interval({
+      visible: false,
+    })
     .position('value')
     .color('type')
     .adjust('stack');
@@ -137,10 +156,16 @@ describe('axis polar update', () => {
 
   it('axis update', async () => {
     let axes = getAxes();
+    let grids = getGrids();
+
     expect(axes.length).toBe(1);
+    expect(grids.length).toBe(1);
 
     const [y] = axes;
     expect(y.component.get('ticks').length).toBe(5);
+    expect(y.component.get('animate')).toBe(false);
+    expect(grids[0].component.get('animate')).toBe(false);
+    expect(grids[0].component.get('animateOption')).toEqual(y.component.get('animateOption'));
 
     await delay(100);
 
@@ -153,18 +178,25 @@ describe('axis polar update', () => {
         offset: 0,
         autoRotate: true,
       },
+      animate: false, // 关闭动画
     });
 
     chart.render(true);
 
     axes = getAxes();
+    grids = getGrids();
     expect(axes.length).toBe(1);
+    expect(grids.length).toBe(1);
 
     // 更新逻辑保持引用
     expect(axes[0]).toBe(y);
     // 修改配置生效
     expect(axes[0].component.get('title').style.fill).toBe('red');
     expect(axes[0].component.get('title').style.text).toBe('value');
+
+    // y 轴动画被用户关闭
+    expect(axes[0].component.get('animate')).toBe(false);
+    expect(grids[0].component.get('animate')).toBe(false);
   });
 
   it('axis delete', async () => {

--- a/tests/unit/chart/controller/legend-spec.ts
+++ b/tests/unit/chart/controller/legend-spec.ts
@@ -35,6 +35,7 @@ describe('Legend', () => {
     expect(legends.length).toBe(1);
     // @ts-ignore
     expect(legends[0].component.getBBox().maxX).toBeLessThanOrEqual(chart.width);
+    expect(legends[0].component.get('animate')).toBe(false);
   });
 
   it('continuous color', () => {
@@ -65,6 +66,7 @@ describe('Legend', () => {
     expect(legends.length).toBe(1);
     // @ts-ignore
     expect(legends[0].component.getBBox().maxY).toBeLessThanOrEqual(chart.height);
+    expect(legends[0].component.get('animate')).toBe(false);
   });
 
   it('continuous size', () => {
@@ -86,6 +88,7 @@ describe('Legend', () => {
 
     chart.legend('月均降雨量', {
       position: 'top',
+      animate: true,
     });
 
     chart
@@ -99,5 +102,6 @@ describe('Legend', () => {
     expect(legends.length).toBe(1);
     // @ts-ignore
     expect(legends[0].component.getBBox().minX).toBeGreaterThanOrEqual(0);
+    expect(legends[0].component.get('animate')).toBe(true);
   });
 });

--- a/tests/unit/chart/multi-view-spec.ts
+++ b/tests/unit/chart/multi-view-spec.ts
@@ -25,7 +25,7 @@ const chart = new Chart({
 chart.data(data.slice(0, data.length - 2));
 
 chart.scale('city', { type: 'cat' });
-chart.axis('city', { type: 'category' });
+chart.axis('city', { title: null });
 chart.coordinate('rect').scale(1, -1);
 
 describe('chart multi view', () => {

--- a/tests/unit/component/legend-category-spec.ts
+++ b/tests/unit/component/legend-category-spec.ts
@@ -49,8 +49,8 @@ describe('Legend category', () => {
     // legend item style
     expect(items[0].name).toBe('电脑');
     expect(items[1].name).toBe('鼠标');
-    expect(items[0].marker.fill).toBe('#5B8FF9');
-    expect(items[1].marker.fill).toBe('#5AD8A6');
+    expect(items[0].marker.style.fill).toBe('#5B8FF9');
+    expect(items[1].marker.style.fill).toBe('#5AD8A6');
 
     // position
     // @ts-ignore

--- a/tests/unit/geometry/base-spec.ts
+++ b/tests/unit/geometry/base-spec.ts
@@ -158,6 +158,11 @@ describe('Geometry', () => {
       expect(geometry.attributeOption.size).toEqual({
         values: [3],
       });
+
+      geometry.size(0);
+      expect(geometry.attributeOption.size).toEqual({
+        values: [0],
+      });
     });
 
     it('label()', () => {
@@ -308,7 +313,7 @@ describe('Geometry', () => {
 
     it('getScaleFields', () => {
       const fields = geometry.getScaleFields();
-      expect(fields).toEqual(['month', 'temperature', 3]);
+      expect(fields).toEqual(['month', 'temperature', 0]);
     });
   });
 

--- a/tests/unit/geometry/base-spec.ts
+++ b/tests/unit/geometry/base-spec.ts
@@ -420,8 +420,10 @@ describe('Geometry', () => {
         getMarker(cfg) {
           return {
             symbol: 'rect',
-            fill: cfg.color,
-            r: 5,
+            style: {
+              fill: cfg.color,
+              r: 5,
+            },
           };
         },
       });
@@ -530,10 +532,12 @@ describe('Geometry', () => {
     it('getShapeMarker()', () => {
       const markerCfg = geometry.getShapeMarker('tick', { color: 'red', isInPolar: false });
       expect(markerCfg).toEqual({
-        fill: 'red',
         symbol: 'rect',
-        r: 5,
-        lineWidth: 10,
+        style: {
+          fill: 'red',
+          r: 5,
+          lineWidth: 10,
+        },
       });
     });
 

--- a/tests/unit/geometry/element/index-spec.ts
+++ b/tests/unit/geometry/element/index-spec.ts
@@ -269,6 +269,7 @@ describe('Element', () => {
           delay: 1000,
         },
         leave: false,
+        appear: null,
       };
       // @ts-ignore
       expect(element.getAnimateCfg('update')).toEqual({
@@ -279,6 +280,8 @@ describe('Element', () => {
       });
       // @ts-ignore
       expect(element.getAnimateCfg('leave')).toBe(null);
+      // @ts-ignore
+      expect(element.getAnimateCfg('appear')).toBe(null);
     });
 
     xit('event', () => {

--- a/tests/unit/geometry/shape/area-spec.ts
+++ b/tests/unit/geometry/shape/area-spec.ts
@@ -59,28 +59,28 @@ describe('Area shapes', () => {
       color: 'red',
       isInPolar: false,
     });
-    expect(areaMarker.fill).toBe('red');
+    expect(areaMarker.style.fill).toBe('red');
     expect(areaMarker.symbol).toBeFunction();
 
     const lineMarker = AreaShapeFactory.getMarker('line', {
       color: 'red',
       isInPolar: false,
     });
-    expect(lineMarker.stroke).toBe('red');
+    expect(lineMarker.style.stroke).toBe('red');
     expect(lineMarker.symbol).toBeFunction();
 
     const smoothMarker = AreaShapeFactory.getMarker('smooth', {
       color: 'red',
       isInPolar: false,
     });
-    expect(smoothMarker.fill).toBe('red');
+    expect(smoothMarker.style.fill).toBe('red');
     expect(smoothMarker.symbol).toBeFunction();
 
     const smoothLineMarker = AreaShapeFactory.getMarker('smoothLine', {
       color: 'red',
       isInPolar: false,
     });
-    expect(smoothLineMarker.stroke).toBe('red');
+    expect(smoothLineMarker.style.stroke).toBe('red');
     expect(smoothLineMarker.symbol).toBeFunction();
   });
 

--- a/tests/unit/geometry/shape/base-spec.ts
+++ b/tests/unit/geometry/shape/base-spec.ts
@@ -63,8 +63,10 @@ describe('Shape', () => {
         getMarker(markerCfg) {
           return {
             symbol: 'circle',
-            r: 5,
-            stroke: markerCfg.color,
+            style: {
+              r: 5,
+              stroke: markerCfg.color,
+            },
           };
         },
       });
@@ -168,14 +170,18 @@ describe('Shape', () => {
 
       expect(circleFactory.getMarker('circle', { color: 'red', isInPolar: false })).toEqual({
         symbol: 'circle',
-        r: 5,
-        stroke: 'red',
+        style: {
+          r: 5,
+          stroke: 'red',
+        },
       });
       expect(circleFactory.getMarker('hollowCircle', { color: 'red', isInPolar: false })).toEqual({
         symbol: 'circle',
-        r: 5,
-        stroke: 'red',
-        lineWidth: 1,
+        style: {
+          r: 5,
+          stroke: 'red',
+          lineWidth: 1,
+        },
       });
     });
 

--- a/tests/unit/geometry/shape/interval-spec.ts
+++ b/tests/unit/geometry/shape/interval-spec.ts
@@ -123,18 +123,22 @@ describe('Interval shapes', () => {
     it('getMarker', () => {
       const markerCfg = IntervalShapeFactory.getMarker('rect', { color: 'red', isInPolar: false });
       expect(markerCfg).toEqual({
-        ...Theme.geometries.interval.rect.default,
         symbol: 'square',
-        r: 4,
-        fill: 'red',
+        style: {
+          ...Theme.geometries.interval.rect.default,
+          r: 4,
+          fill: 'red',
+        },
       });
 
       const polaeMarkerCfg = IntervalShapeFactory.getMarker('rect', { color: 'red', isInPolar: true });
       expect(polaeMarkerCfg).toEqual({
-        ...Theme.geometries.interval.rect.default,
         symbol: 'circle',
-        r: 4.5,
-        fill: 'red',
+        style: {
+          ...Theme.geometries.interval.rect.default,
+          r: 4.5,
+          fill: 'red',
+        },
       });
     });
   });
@@ -178,18 +182,22 @@ describe('Interval shapes', () => {
     it('getMarker', () => {
       const markerCfg = IntervalShapeFactory.getMarker('hollowRect', { color: 'red', isInPolar: false });
       expect(markerCfg).toEqual({
-        ...Theme.geometries.interval.hollowRect.default,
         symbol: 'square',
-        r: 4,
-        stroke: 'red',
+        style: {
+          ...Theme.geometries.interval.hollowRect.default,
+          r: 4,
+          stroke: 'red',
+        },
       });
 
       const polaeMarkerCfg = IntervalShapeFactory.getMarker('hollowRect', { color: 'red', isInPolar: true });
       expect(polaeMarkerCfg).toEqual({
-        ...Theme.geometries.interval.hollowRect.default,
         symbol: 'circle',
-        r: 4.5,
-        stroke: 'red',
+        style: {
+          ...Theme.geometries.interval.hollowRect.default,
+          r: 4.5,
+          stroke: 'red',
+        },
       });
     });
   });
@@ -265,7 +273,7 @@ describe('Interval shapes', () => {
 
     it('getMarker', () => {
       const markerCfg = IntervalShapeFactory.getMarker('line', { color: 'red', isInPolar: false });
-      expect(markerCfg.stroke).toBe('red');
+      expect(markerCfg.style.stroke).toBe('red');
       // @ts-ignore
       expect(markerCfg.symbol(10, 10, 5)).toEqual([
         ['M', 10, 5],
@@ -352,7 +360,7 @@ describe('Interval shapes', () => {
 
     it('getMarker', () => {
       const markerCfg = IntervalShapeFactory.getMarker('tick', { color: 'red', isInPolar: false });
-      expect(markerCfg.stroke).toBe('red');
+      expect(markerCfg.style.stroke).toBe('red');
       // @ts-ignore
       expect(markerCfg.symbol(10, 10, 4)).toEqual([
         ['M', 8, 6],
@@ -457,10 +465,12 @@ describe('Interval shapes', () => {
     it('getMarker', () => {
       const markerCfg = IntervalShapeFactory.getMarker('funnel', { color: 'red', isInPolar: false });
       expect(markerCfg).toEqual({
-        ...Theme.geometries.interval.funnel.default,
         symbol: 'square',
-        r: 4,
-        fill: 'red',
+        style: {
+          ...Theme.geometries.interval.funnel.default,
+          r: 4,
+          fill: 'red',
+        },
       });
     });
   });
@@ -553,10 +563,12 @@ describe('Interval shapes', () => {
     it('getMarker', () => {
       const markerCfg = IntervalShapeFactory.getMarker('pyramid', { color: 'red', isInPolar: false });
       expect(markerCfg).toEqual({
-        ...Theme.geometries.interval.pyramid.default,
         symbol: 'square',
-        r: 4,
-        fill: 'red',
+        style: {
+          ...Theme.geometries.interval.pyramid.default,
+          r: 4,
+          fill: 'red',
+        },
       });
     });
   });

--- a/tests/unit/geometry/shape/line-spec.ts
+++ b/tests/unit/geometry/shape/line-spec.ts
@@ -35,8 +35,8 @@ describe('Line shapes', () => {
 
   it('getMarker', () => {
     const dotMarker = LineShapeFactory.getMarker('dot', { color: 'red', isInPolar: false });
-    expect(dotMarker.lineDash).toBe(Theme.geometries.line.dot.default.lineDash);
-    expect(dotMarker.stroke).toBe('red');
+    expect(dotMarker.style.lineDash).toEqual(Theme.geometries.line.dot.default.lineDash);
+    expect(dotMarker.style.stroke).toBe('red');
     // @ts-ignore
     expect(dotMarker.symbol(10, 10, 5)).toEqual([
       ['M', 5, 10],
@@ -44,7 +44,7 @@ describe('Line shapes', () => {
     ]);
 
     const vhMarker = LineShapeFactory.getMarker('vh', { color: 'red', isInPolar: false });
-    expect(vhMarker.stroke).toBe('red');
+    expect(vhMarker.style.stroke).toBe('red');
     // @ts-ignore
     expect(vhMarker.symbol(10, 10, 5)).toEqual([
       ['M', 4, 12.5],

--- a/tests/unit/geometry/shape/point-spec.ts
+++ b/tests/unit/geometry/shape/point-spec.ts
@@ -55,24 +55,28 @@ describe('Point shapes', () => {
   it('getMarker', () => {
     const circleMarker = PointShapeFactory.getMarker('circle', { color: 'red', isInPolar: false });
     expect(circleMarker).toEqual({
-      ...Theme.geometries.point.circle.default,
       symbol: 'circle',
-      r: 4.5,
-      fill: 'red',
+      style: {
+        ...Theme.geometries.point.circle.default,
+        r: 4.5,
+        fill: 'red',
+      },
     });
 
     const hollowCircleMarker = PointShapeFactory.getMarker('hollowCircle', { color: 'red', isInPolar: false });
     expect(hollowCircleMarker).toEqual({
-      ...Theme.geometries.point.hollowCircle.default,
       symbol: 'circle',
-      r: 4.5,
-      stroke: 'red',
+      style: {
+        ...Theme.geometries.point.hollowCircle.default,
+        r: 4.5,
+        stroke: 'red',
+      },
     });
 
     const bowtieMarker = PointShapeFactory.getMarker('bowtie', { color: 'red', isInPolar: false });
     // @ts-ignore
     expect(bowtieMarker.symbol(11.5, 10, 3.5)).toEqual([['M', 8, 8], ['L', 15, 12], ['L', 15, 8], ['L', 8, 12], ['Z']]);
-    expect(bowtieMarker.fill).toBe('red');
+    expect(bowtieMarker.style.fill).toBe('red');
 
     const crossMarker = PointShapeFactory.getMarker('cross', { color: 'red', isInPolar: false });
     // @ts-ignore
@@ -82,7 +86,7 @@ describe('Point shapes', () => {
       ['M', 15, 5],
       ['L', 5, 15],
     ]);
-    expect(crossMarker.stroke).toBe('red');
+    expect(crossMarker.style.stroke).toBe('red');
   });
 
   it('draw shapes', () => {

--- a/tests/unit/geometry/shape/polygon-spec.ts
+++ b/tests/unit/geometry/shape/polygon-spec.ts
@@ -79,10 +79,12 @@ describe('Point shapes', () => {
       const markerCfg = PolygonShapeFactory.getMarker('polygon', { color: 'red', isInPolar: false });
       expect(markerCfg).toEqual({
         symbol: 'square',
-        r: 4,
-        fill: 'red',
-        fillOpacity: 1,
-        lineWidth: 0,
+        style: {
+          r: 4,
+          fill: 'red',
+          fillOpacity: 1,
+          lineWidth: 0,
+        },
       });
     });
   });
@@ -124,11 +126,13 @@ describe('Point shapes', () => {
       const markerCfg = PolygonShapeFactory.getMarker('hollow', { color: 'red', isInPolar: false });
       expect(markerCfg).toEqual({
         symbol: 'square',
-        r: 4,
-        stroke: 'red',
-        fill: '#fff',
-        fillOpacity: 0,
-        lineWidth: 2,
+        style: {
+          r: 4,
+          stroke: 'red',
+          fill: '#fff',
+          fillOpacity: 0,
+          lineWidth: 2,
+        },
       });
     });
   });

--- a/tests/unit/geometry/shape/schema-spec.ts
+++ b/tests/unit/geometry/shape/schema-spec.ts
@@ -112,7 +112,7 @@ describe('Schema shapes', () => {
     it('getMarker', () => {
       const marker = SchemaShapeFactory.getMarker('box', { color: 'red', isInPolar: false });
       expect(marker.symbol).toBeInstanceOf(Function);
-      expect(marker.stroke).toBe('red');
+      expect(marker.style.stroke).toBe('red');
     });
   });
 
@@ -203,7 +203,7 @@ describe('Schema shapes', () => {
     it('getMarker', () => {
       const marker = SchemaShapeFactory.getMarker('candle', { color: 'red', isInPolar: false });
       expect(marker.symbol).toBeInstanceOf(Function);
-      expect(marker.fill).toBe('red');
+      expect(marker.style.fill).toBe('red');
     });
   });
 


### PR DESCRIPTION
## 说明
目前组件层只支持动画参数的配置，即具体的动画函数是内置的，所以在 G2 层只会开发 `animate: boolean` 开关操作。

即

```ts
chart.axis('x', {
  animate: boolean, // 开启或者关闭动画
});
```

目前 G2 层参与动画的组件为：
1. Axis
因为在 G2 中需要进行布局调整，所以图表初始化时，组件是先 render 后 update，所以如果开启了动画，那么初始化图表的时候坐标轴就会进行更新动画，与预期不符合，默认情况下，坐标轴在初始化的时候是不会参与动画的，只有发生了更新才会参与，所以 G2 在处理的时候，会在更新的时候将动画开启并将动画配置传入
2. Annotation
进行的动画：
	* appear
	* enter
	* update
	* leave
4. Legend
默认不开启动画

因为组件都是先渲染后 update 所以是没有 appear 动画的

动画优先级： Chart > View > Geometry(> label), Component

## TODOLIST
- [x] chart.axis() 配置项定义
- [x] axis 动画配置
- [x] Annotation 动画配置
- [x] legend 动画配置
- [x] chart.legend() 配置项定义
- [x] 图例更新动画 BUG
        详见： https://github.com/antvis/g/issues/332

周边问题：
- [x] https://github.com/antvis/component/issues/113

关联 component PR： https://github.com/antvis/component/pull/114