### PR TITLE
fix(layout): legend 布局上，需要和 coordinateBBox 对齐

### DIFF
--- a/src/chart/controller/legend.ts
+++ b/src/chart/controller/legend.ts
@@ -81,7 +81,20 @@ export default class Legend extends Controller<Option> {
       const bboxObject = component.getBBox();
       const bbox = new BBox(bboxObject.x, bboxObject.y, bboxObject.width, bboxObject.height);
 
-      const [x, y] = directionToPosition(this.view.viewBBox, bbox, direction);
+      const [x1, y1] = directionToPosition(this.view.coordinateBBox, bbox, direction);
+      const [x2, y2] = directionToPosition(this.view.viewBBox, bbox, direction);
+
+      let x = 0;
+      let y = 0;
+
+      // 因为 legend x y 要和 coordinateBBox 对齐，所以要做一个简单的判断
+      if (direction.startsWith('top') || direction.startsWith('bottom')) {
+        x = x1;
+        y = y2;
+      } else {
+        x = x2;
+        y = y1;
+      }
 
       component.update({
         x,

--- a/src/chart/layout/index.ts
+++ b/src/chart/layout/index.ts
@@ -79,4 +79,9 @@ export default function defaultLayout(view: View): void {
   if (annotation) {
     annotation.layout();
   }
+
+  // 因为 legend 的位置也和 coordinate 有关系（比如 right-bottom 的时候），所以在确定 coordinate 之后需要再次 layout
+  if (legend) {
+    legend.layout();
+  }
 }


### PR DESCRIPTION
 - [x] 修复图例和 coordinate BBox 没有对齐的 bug

![image](https://user-images.githubusercontent.com/7856674/71583038-b0606080-2b47-11ea-84eb-c22bc9582ac6.png)
