### PR TITLE
Fix view render recursive

### DIFF
--- a/examples/relation/relation/demo/chord.ts
+++ b/examples/relation/relation/demo/chord.ts
@@ -67,5 +67,4 @@ fetch('../data/relationship-with-weight.json')
       });
 
     chart.render();
-    chart.render(); // FIXME: 初次加载时，scale 同步没有生效，调用两次 chart.render() 才生效
   });

--- a/examples/relation/relation/demo/sankey.ts
+++ b/examples/relation/relation/demo/sankey.ts
@@ -84,5 +84,4 @@ fetch('../data/energy.json')
         stroke: '#ccc'
       });
     chart.render();
-    chart.render();// FIXME: 初次加载时，scale 同步没有生效，调用两次 chart.render() 才生效
   });

--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -201,9 +201,7 @@ export class View extends Base {
   public render(isUpdate: boolean = false) {
     this.emit(VIEW_LIFE_CIRCLE.BEFORE_RENDER);
     // 递归渲染
-    this.renderDataRecursive(isUpdate);
-    this.renderLayoutRecursive(isUpdate);
-    this.renderPaintRecursive(isUpdate);
+    this.paint(isUpdate);
 
     this.emit(VIEW_LIFE_CIRCLE.AFTER_RENDER);
 
@@ -1006,10 +1004,9 @@ export class View extends Base {
     } else {
       this.adjustCoordinate();
     }
-    // 2. 初始化 Geometry
+    // 3. 初始化 Geometry
     this.initGeometries(isUpdate);
-
-    // 3. 处理分面逻辑，最终都是生成子 view 和 geometry
+    // 4. 处理分面逻辑，最终都是生成子 view 和 geometry
     this.renderFacet();
 
     // 同样递归处理子 views
@@ -1052,17 +1049,6 @@ export class View extends Base {
     // 2. 更新 viewEventCaptureRect 大小
     const { x, y, width, height } = this.viewBBox;
     this.viewEventCaptureRect.attr({ x, y, width, height });
-  }
-
-  /**
-   * 递归 render views
-   * 步骤非常繁琐，因为之间有一些数据依赖，所以执行流程上有先后关系
-   */
-  protected renderRecursive(isUpdate: boolean) {
-    // 子 view 大小相对 coordinateBBox，changeSize 的时候需要重新计算
-    this.calculateViewBBox();
-    // 数据到完整图表的绘制
-    this.paint(isUpdate);
 
     // 同样递归处理子 views
     each(this.views, (view: View) => {

--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -1396,10 +1396,10 @@ export class View extends Base {
    */
   private adjustScales() {
     // 调整目前包括：
-    // 分类 scale，调整 range 范围
-    this.adjustCategoryScaleRange();
     // 处理 sync scale 的逻辑
     this.syncScale();
+    // 分类 scale，调整 range 范围
+    this.adjustCategoryScaleRange();
   }
 
   /**


### PR DESCRIPTION
多 view 嵌套的时候，因为 view.render 的递归执行中，一个 view 完全渲染完成之后，才渲染另外一个。

导致先渲染的 view geometries 使用的 scale 不是完全同步完成的 scale，所以图形对不齐。

 - [x] 修改 view.render 为三个过程
      - renderDataRecursive
      - renderLayoutRecursive
      - renderUIRecursive
 - [x] 修复两个 demo #1905 
 - [x] 修复分类字段 scale 左右间距 range 调整在 sync 之后处理。
    
render 的三个步骤中，每个步骤都是执行完所有的嵌套 view，才执行下一步。