### PR TITLE
fix(legend): fix legend overlap

### DIFF
--- a/src/chart/controller/legend.ts
+++ b/src/chart/controller/legend.ts
@@ -108,6 +108,9 @@ export default class Legend extends Controller<Option> {
       const [x1, y1] = directionToPosition(this.view.coordinateBBox, bbox, direction);
       const [x2, y2] = directionToPosition(this.view.viewBBox, bbox, direction);
 
+      const layout = getLegendLayout(direction);
+      const maxSize = this.getCategoryLegendSizeCfg(layout);
+
       let x = 0;
       let y = 0;
 
@@ -123,6 +126,8 @@ export default class Legend extends Controller<Option> {
       component.update({
         x,
         y,
+        ...maxSize,
+        flipPage: true,
       });
     });
   }
@@ -556,15 +561,16 @@ export default class Legend extends Controller<Option> {
   }
 
   private getCategoryLegendSizeCfg(layout: 'horizontal' | 'vertical') {
-    const { width, height } = this.view.viewBBox;
+    const { width: vw, height: vh } = this.view.viewBBox;
+    const { width: cw, height: ch } = this.view.coordinateBBox;
     return layout === 'vertical'
       ? {
-          maxWidth: width * COMPONENT_MAX_VIEW_PERCENTAGE,
-          maxHeight: height,
+          maxWidth: vw * COMPONENT_MAX_VIEW_PERCENTAGE,
+          maxHeight: ch,
         }
       : {
-          maxWidth: width,
-          maxHeight: height * COMPONENT_MAX_VIEW_PERCENTAGE,
+          maxWidth: cw,
+          maxHeight: vh * COMPONENT_MAX_VIEW_PERCENTAGE,
         };
   }
 }

--- a/src/chart/controller/legend.ts
+++ b/src/chart/controller/legend.ts
@@ -111,6 +111,9 @@ export default class Legend extends Controller<Option> {
       const layout = getLegendLayout(direction);
       const maxSize = this.getCategoryLegendSizeCfg(layout);
 
+      const maxWidth = component.get('maxWidth');
+      const maxHeight = component.get('maxHeight');
+
       let x = 0;
       let y = 0;
 
@@ -126,8 +129,8 @@ export default class Legend extends Controller<Option> {
       component.update({
         x,
         y,
-        ...maxSize,
-        flipPage: true,
+        maxWidth: Math.min(maxSize.maxWidth, maxWidth || 0),
+        maxHeight: Math.min(maxSize.maxHeight, maxHeight || 0),
       });
     });
   }

--- a/src/theme/antv.ts
+++ b/src/theme/antv.ts
@@ -177,6 +177,7 @@ const LEGEND_STYLE = {
       textBaseline: 'middle',
     },
   },
+  flipPage: true,
   animate: false,
 };
 

--- a/tests/unit/chart/controller/legend-spec.ts
+++ b/tests/unit/chart/controller/legend-spec.ts
@@ -200,7 +200,7 @@ describe('Legend', () => {
     expect(legends[0].component.get('items')[1].marker.symbol).toBeInstanceOf(Function);
   });
 
-  it.only('legend maxWidth', () => {
+  it('legend maxWidth', () => {
     const data = [
       { genre: 'Sports', sold: 275 },
       { genre: 'Strategy', sold: 115 },
@@ -221,9 +221,19 @@ describe('Legend', () => {
       max: 3600,
       nice: false,
     });
-    // chart.coordinate().transpose();
+    chart.coordinate().transpose();
     chart.interval().position('genre*sold').color('genre').label('sold');
 
     chart.render();
+
+    const legend = chart.getComponents().filter(co => co.type === COMPONENT_TYPE.LEGEND)[0].component;
+
+    expect(legend.get('flipPage')).toBe(true);
+    expect(legend.totalPagesCnt).toBe(2);
+    expect(legend.pageHeight).toBe(20);
+  });
+
+  afterAll(() => {
+    chart.destroy();
   });
 });

--- a/tests/unit/chart/controller/legend-spec.ts
+++ b/tests/unit/chart/controller/legend-spec.ts
@@ -200,7 +200,30 @@ describe('Legend', () => {
     expect(legends[0].component.get('items')[1].marker.symbol).toBeInstanceOf(Function);
   });
 
-  afterEach(() => {
-    chart.destroy();
+  it.only('legend maxWidth', () => {
+    const data = [
+      { genre: 'Sports', sold: 275 },
+      { genre: 'Strategy', sold: 115 },
+      { genre: 'Action', sold: 120 },
+      { genre: 'Shooter', sold: 3500 },
+      { genre: 'Other', sold: 150 }
+    ];
+
+    chart = new Chart({
+      container: createDiv(),
+      autoFit: false,
+      width: 380,
+      height: 300,
+    });
+
+    chart.data(data);
+    chart.scale('sold', {
+      max: 3600,
+      nice: false,
+    });
+    // chart.coordinate().transpose();
+    chart.interval().position('genre*sold').color('genre').label('sold');
+
+    chart.render();
   });
 });

--- a/tests/unit/component/legend-category-spec.ts
+++ b/tests/unit/component/legend-category-spec.ts
@@ -62,7 +62,7 @@ describe('Legend category', () => {
   });
 });
 
-describe.skip('Legend category navigation', () => {
+describe('Legend category navigation', () => {
   const div = createDiv();
   const legendId = '';
 
@@ -120,7 +120,7 @@ describe.skip('Legend category navigation', () => {
   });
 });
 
-describe.skip('Legend Category Vertical', () => {
+describe('Legend Category Vertical', () => {
   const div = createDiv();
   const legendId = '';
 
@@ -128,8 +128,6 @@ describe.skip('Legend Category Vertical', () => {
     container: div,
     width: 400,
     height: 400,
-    padding: 16,
-    autoFit: false,
   });
 
   chart.data(DIAMOND);
@@ -146,10 +144,13 @@ describe.skip('Legend Category Vertical', () => {
       flipPage: true,
       maxHeight: 80,
     });
-    chart.render(true);
+    chart.render();
 
     const legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
     const legend = legends[0].component as GroupComponent<GroupComponentCfg>;
+
+    expect(legend.get('maxHeight')).toBe(80);
+
     const navigation = legend.getElementById(`${legendId}-legend-navigation-group`);
 
     const children = navigation ? navigation.getChildren() : [];

--- a/tests/unit/component/legend-category-spec.ts
+++ b/tests/unit/component/legend-category-spec.ts
@@ -11,9 +11,10 @@ describe('Legend category', () => {
     container: div,
     width: 800,
     height: 600,
-    padding: 16,
     autoFit: false,
   });
+
+  chart.animate(false);
 
   chart.data(CITY_SALE);
 
@@ -61,7 +62,7 @@ describe('Legend category', () => {
   });
 });
 
-describe('Legend category navigation', () => {
+describe.skip('Legend category navigation', () => {
   const div = createDiv();
   const legendId = '';
 
@@ -69,7 +70,6 @@ describe('Legend category navigation', () => {
     container: div,
     width: 400,
     height: 400,
-    padding: 16,
     autoFit: false,
   });
 
@@ -120,7 +120,7 @@ describe('Legend category navigation', () => {
   });
 });
 
-describe('Legend Category Vertical', () => {
+describe.skip('Legend Category Vertical', () => {
   const div = createDiv();
   const legendId = '';
 


### PR DESCRIPTION
ref #1715 
 - [x] 修复分类图例超长的时候，被画布裁剪，设置正确的 maxWidth, maxHeight
 - [x] 主题默认自动分页
