### PR TITLE
可『弯』可『直』的 tooltip 辅助线

### DIFF
--- a/examples/component/component/demo/meta.json
+++ b/examples/component/component/demo/meta.json
@@ -85,26 +85,26 @@
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*zo8yQp-k7hgAAAAAAAAAAABkARQnAQ"
     },
     {
-      "filename": "tooltip-customized.ts",
+      "filename": "tooltip-1.ts",
       "title": {
-        "zh": "自定义 tooltip",
-        "en": "customized tooltip"
+        "zh": "极坐标下的半径轴 crosshairs",
+        "en": ""
       },
-      "screenshot": "https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*kxObRLXxmccAAAAAAAAAAABkARQnAQ"
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*DrWlSqS1j4sAAAAAAAAAAABkARQnAQ"
     },
     {
-      "filename": "tooltip-fixed-position.ts",
+      "filename": "tooltip-2.ts",
       "title": {
-        "zh": "tooltip-固定位置",
-        "en": "fixed tooltip"
+        "zh": "极坐标下的 xy crosshairs",
+        "en": ""
       },
-      "screenshot": "https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*xNidQ7xZJd0AAAAAAAAAAABkARQnAQ"
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*DrWlSqS1j4sAAAAAAAAAAABkARQnAQ"
     },
     {
-      "filename": "tooltip-html-content.ts",
+      "filename": "tooltip-3.ts",
       "title": {
-        "zh": "tooltip-htmlContent",
-        "en": "customized html tooltip"
+        "zh": "xy crosshairs，带文本",
+        "en": ""
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*DrWlSqS1j4sAAAAAAAAAAABkARQnAQ"
     }

--- a/examples/component/component/demo/tooltip-1.ts
+++ b/examples/component/component/demo/tooltip-1.ts
@@ -1,0 +1,59 @@
+import { Chart } from '@antv/g2';
+
+// 构造数据
+const data = [
+  { year: '2001', population: 41.8 },
+  { year: '2002', population: 38 },
+  { year: '2003', population: 33.7 },
+  { year: '2004', population: 30.7 },
+  { year: '2005', population: 25.8 },
+  { year: '2006', population: 31.7 },
+  { year: '2007', population: 33 },
+  { year: '2008', population: 46 },
+  { year: '2009', population: 38.3 },
+  { year: '2010', population: 28 },
+  { year: '2011', population: 42.5 },
+  { year: '2012', population: 30.3 },
+];
+
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+  height: 500,
+  padding: 50,
+});
+
+chart.data(data);
+chart.scale('population', {
+  nice: true,
+});
+chart.coordinate('polar', {
+  innerRadius: 0.4,
+});
+chart.axis(false);
+chart.legend(false);
+chart.tooltip({
+  showCrosshairs: true,
+  crosshairs: {
+    line: {
+      style: {
+        lineDash: [2],
+      }
+    },
+    text: {
+      position: 'end',
+      offset: 5,
+      autoRotate: true,
+      style: {
+        fontSize: 14,
+      }
+    },
+    textBackground: {
+      style: {
+        fill: null
+      }
+    }
+  },
+});
+chart.interval().position('year*population').color('year').size(100);
+chart.render();

--- a/examples/component/component/demo/tooltip-2.ts
+++ b/examples/component/component/demo/tooltip-2.ts
@@ -35,6 +35,7 @@ chart.scale('score', {
 chart.coordinate('polar', {
   radius: 0.8,
 });
+chart.axis(false);
 chart.axis('item', {
   line: null,
   tickLine: null,
@@ -42,6 +43,7 @@ chart.axis('item', {
     line: {
       style: {
         lineDash: null,
+        strokeOpacity: 0.3
       },
     },
   },
@@ -54,10 +56,25 @@ chart.axis('score', {
       type: 'circle',
       style: {
         lineDash: null,
+        strokeOpacity: 0.3
       },
     },
-    alternateColor: 'rgba(0, 0, 0, 0.04)',
   },
+});
+
+chart.tooltip({
+  shared: true,
+  follow: true,
+  showCrosshairs: true,
+  crosshairs: {
+    type: 'xy',
+    line: {
+      style: {
+        stroke: '#565656',
+        lineDash: [4],
+      },
+    },
+  }
 });
 
 chart

--- a/examples/component/component/demo/tooltip-3.ts
+++ b/examples/component/component/demo/tooltip-3.ts
@@ -1,0 +1,83 @@
+import { Chart } from '@antv/g2';
+
+fetch('../data/scatter.json')
+  .then(res => res.json())
+  .then(data => {
+    const chart = new Chart({
+      container: 'container',
+      autoFit: true,
+      height: 500,
+      padding: [ 50, 70 ],
+      localRefresh: false,
+    });
+    // 数据格式： [{"gender":"female","height":161.2,"weight":51.6}]
+    chart.data(data);
+    chart.scale({
+      height: { nice: true },
+      weight: { nice: true },
+    });
+    chart.tooltip({
+      showTitle: false,
+      showCrosshairs: true,
+      crosshairs: {
+        type: 'xy',
+        text: (type, defaultText, items) => {
+          const color = items[0].color;
+          if (type === 'x') {
+            return {
+              offset: 5,
+              position: 'end',
+              content: defaultText + ' cm',
+              style: {
+                textAlign: 'center',
+                textBaseline: 'top',
+                fill: color,
+                fontSize: 14,
+                fontWeight: 'bold',
+                stroke: '#333',
+                lineWidth: 2,
+              },
+            };
+          } else {
+            return {
+              offset: 5,
+              content: defaultText + ' kg',
+              style: {
+                textAlign: 'end',
+                fill: color,
+                fontSize: 14,
+                fontWeight: 'bold',
+                stroke: '#333',
+                lineWidth: 2,
+              },
+            };
+          }
+        },
+        // FIXME: textBackground 应该可以支持关闭
+        textBackground: {
+          padding: 0,
+          style: {
+            fill: null,
+          }
+        }
+      },
+      itemTpl: '<li class="g2-tooltip-list-item" data-index={index} style="margin-bottom:4px;">'
+        + '<span style="background-color:{color};" class="g2-tooltip-marker"></span>'
+        + '{name}<br/>'
+        + '{value}'
+        + '</li>'
+    });
+    chart.point().position('height*weight')
+      .color('gender')
+      .shape('circle')
+      .tooltip('gender*height*weight', (gender, height, weight) => {
+        return {
+          name: gender,
+          value: height + '(cm), ' + weight + '(kg)'
+        };
+      })
+      .style({
+        opacity: 0.85,
+      });
+    chart.render();
+  });

--- a/src/chart/controller/tooltip.ts
+++ b/src/chart/controller/tooltip.ts
@@ -29,6 +29,7 @@ function uniq(items) {
 export default class Tooltip extends Controller<TooltipOption> {
   private tooltip;
 
+  private tooltipCfg;
   private isVisible: boolean = true;
   private markerGroup: IGroup;
   private items;
@@ -179,10 +180,11 @@ export default class Tooltip extends Controller<TooltipOption> {
    * override 不做任何事情
    */
   public clear() {
-    // do nothing
+    this.tooltipCfg = null;
   }
 
   public destroy() {
+    this.clear();
     const { tooltip, markerGroup } = this;
 
     if (tooltip) {
@@ -228,24 +230,27 @@ export default class Tooltip extends Controller<TooltipOption> {
   }
 
   private getTooltipCfg() {
-    const view = this.view;
-    const option = this.option;
-    const theme = view.getTheme();
-    const defaultCfg = get(theme, ['components', 'tooltip'], {});
-    const tooltipCfg = deepMix({}, defaultCfg, option);
+    if (!this.tooltipCfg) {
+      const view = this.view;
+      const option = this.option;
+      const theme = view.getTheme();
+      const defaultCfg = get(theme, ['components', 'tooltip'], {});
+      const tooltipCfg = deepMix({}, defaultCfg, option);
 
-    // set `crosshairs`
-    const coordinate = view.getCoordinate();
-    if (tooltipCfg.showCrosshairs && !tooltipCfg.crosshairs && coordinate.isRect) {
-      // 目前 Tooltip 辅助线只在直角坐标系下展示
-      tooltipCfg.crosshairs = !!coordinate.isTransposed ? 'y' : 'x';
+      // set `crosshairs`
+      const coordinate = view.getCoordinate();
+      if (tooltipCfg.showCrosshairs && !tooltipCfg.crosshairs && coordinate.isRect) {
+        // 目前 Tooltip 辅助线只在直角坐标系下展示
+        tooltipCfg.crosshairs = !!coordinate.isTransposed ? 'y' : 'x';
+      }
+
+      if (tooltipCfg.showCrosshairs === false) {
+        tooltipCfg.crosshairs = null;
+      }
+      this.tooltipCfg = tooltipCfg;
     }
 
-    if (tooltipCfg.showCrosshairs === false) {
-      tooltipCfg.crosshairs = null;
-    }
-
-    return tooltipCfg;
+    return this.tooltipCfg;
   }
 
   public getTooltipItems(point: Point) {

--- a/src/chart/controller/tooltip.ts
+++ b/src/chart/controller/tooltip.ts
@@ -1,6 +1,5 @@
-import * as TOOLTIP_CLASSNAMES from '@antv/component/lib/tooltip/css-const';
 import { vec2 } from '@antv/matrix-util';
-import { each, find, get, isArray, isEqual, isObject } from '@antv/util';
+import { deepMix, each, find, get, isArray, isEqual, isObject } from '@antv/util';
 import { HtmlTooltip, IGroup } from '../../dependents';
 import Geometry from '../../geometry/base';
 import { MappingDatum, Point } from '../../interface';
@@ -28,7 +27,6 @@ function uniq(items) {
 }
 
 export default class Tooltip extends Controller<TooltipOption> {
-  // public cfg;
   private tooltip;
 
   private isVisible: boolean = true;
@@ -75,7 +73,6 @@ export default class Tooltip extends Controller<TooltipOption> {
     });
 
     tooltip.render();
-    // tooltip.hide();
 
     this.tooltip = tooltip;
 
@@ -234,18 +231,9 @@ export default class Tooltip extends Controller<TooltipOption> {
     const view = this.view;
     const option = this.option;
     const theme = view.getTheme();
-
     const defaultCfg = get(theme, ['components', 'tooltip'], {});
-    let tooltipCfg = {
-      ...defaultCfg,
-    };
+    const tooltipCfg = deepMix({}, defaultCfg, option);
 
-    if (isObject(option)) {
-      tooltipCfg = {
-        ...defaultCfg,
-        ...option,
-      };
-    }
     // set `crosshairs`
     const coordinate = view.getCoordinate();
     if (tooltipCfg.showCrosshairs && !tooltipCfg.crosshairs && coordinate.isRect) {
@@ -256,14 +244,6 @@ export default class Tooltip extends Controller<TooltipOption> {
     if (tooltipCfg.showCrosshairs === false) {
       tooltipCfg.crosshairs = null;
     }
-
-    // set domStyles
-    tooltipCfg.domStyles = {};
-    each(TOOLTIP_CLASSNAMES, (classname) => {
-      if (tooltipCfg[classname]) {
-        tooltipCfg.domStyles[classname] = tooltipCfg[classname];
-      }
-    });
 
     return tooltipCfg;
   }

--- a/src/chart/interface.ts
+++ b/src/chart/interface.ts
@@ -9,6 +9,9 @@ import {
   ContinueLegendLabelCfg,
   ContinueLegendRailCfg,
   ContinueLegendTrackCfg,
+  CrosshairLineCfg,
+  CrosshairTextBackgroundCfg,
+  CrosshairTextCfg,
   GridLineCfg,
   GroupComponent,
   HtmlComponent,
@@ -20,6 +23,7 @@ import {
   LegendMarkerCfg,
   LegendTitleCfg,
   PathCommand,
+  Point,
 } from '../dependents';
 import {
   AdjustOption,
@@ -347,6 +351,21 @@ export interface LegendCfg {
   offsetY?: number;
 }
 
+interface TooltipCrosshairsText extends CrosshairTextCfg {
+  content?: string;
+}
+
+type TooltipCrosshairsTextCallback = (type: string, defaultContent: any, items: any[], currentPoint: Point) => TooltipCrosshairsText;
+export interface TooltipCrosshairs {
+  /**
+   * crosshairs 的类型
+   */
+  type?: 'x' | 'y' | 'xy';
+  line?: CrosshairLineCfg;
+  text?: TooltipCrosshairsText | TooltipCrosshairsTextCallback;
+  textBackground?: CrosshairTextBackgroundCfg;
+}
+
 export interface TooltipCfg {
   /** 设置 tooltip 是否跟随鼠标移动，默认为 false, 定位到数据点 */
   follow?: boolean;
@@ -361,16 +380,14 @@ export interface TooltipCfg {
   position?: 'top' | 'bottom' | 'left' | 'right';
   /** true 表示展示一组数据，false 表示展示单条数据 */
   shared?: boolean; // 是否只展示单条数据
+
+
   /** 是否展示 crosshairs */
   showCrosshairs?: boolean;
-  /**
-   * 设置 tooltip 辅助线的类型
-   * 'x' 水平辅助线
-   * 'y' 垂直辅助线
-   * 'xy' 十字辅助线
-   *
-   */
-  crosshairs?: 'x' | 'y' | 'xy';
+  /** 配置 tooltip 的 crosshairs */
+  crosshairs?: TooltipCrosshairs;
+
+
   /** 是否渲染 tooltipMarkers */
   showTooltipMarkers?: boolean;
   /** tooltipMarker 的样式 */

--- a/src/chart/interface.ts
+++ b/src/chart/interface.ts
@@ -355,14 +355,33 @@ interface TooltipCrosshairsText extends CrosshairTextCfg {
   content?: string;
 }
 
+/**
+ * 辅助线文本回调函数
+ * @param type 对应当前 crosshairs 的类型，值为 'x' 或者 'x'
+ * @param defaultContent 对应当前 crosshairs 默认的文本内容
+ * @param items 对应当前 tooltip 内容框中的数据
+ * @param currentPoint 对应当前坐标点
+ * @returns 返回当前 crosshairs 对应的辅助线文本配置
+ */
 type TooltipCrosshairsTextCallback = (type: string, defaultContent: any, items: any[], currentPoint: Point) => TooltipCrosshairsText;
 export interface TooltipCrosshairs {
   /**
-   * crosshairs 的类型
+   * crosshairs 的类型: `x` 表示 x 轴上的辅助线，`y` 表示 y 轴上的辅助项。
+   * 以下是在不同坐标系下，crosshairs 各个类型的表现
+   *
+   * 坐标系 | type = 'x' | type = 'xy' | type = 'y'
+   * ------------ | ------------- | -------------
+   * 直角坐标系  | ![image](https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*jmUBQ4nbtXsAAAAAAAAAAABkARQnAQ) | ![image](https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*RpWXT76ZSQgAAAAAAAAAAABkARQnAQ) | ![image](https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*Xjl8TLIJLuUAAAAAAAAAAABkARQnAQ)
+   * 极坐标 | ![image](https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*zbMVSoKTyFsAAAAAAAAAAABkARQnAQ) | ![image](https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*k5EYRJspET0AAAAAAAAAAABkARQnAQ) | ![image](https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*n_TKQpUaXWEAAAAAAAAAAABkARQnAQ)
    */
   type?: 'x' | 'y' | 'xy';
+  /** 辅助线的样式配置 */
   line?: CrosshairLineCfg;
+  /**
+   * 辅助线文本配置，支持回调
+   */
   text?: TooltipCrosshairsText | TooltipCrosshairsTextCallback;
+  /** 辅助线文本背景配置 */
   textBackground?: CrosshairTextBackgroundCfg;
 }
 
@@ -380,14 +399,10 @@ export interface TooltipCfg {
   position?: 'top' | 'bottom' | 'left' | 'right';
   /** true 表示展示一组数据，false 表示展示单条数据 */
   shared?: boolean; // 是否只展示单条数据
-
-
   /** 是否展示 crosshairs */
   showCrosshairs?: boolean;
   /** 配置 tooltip 的 crosshairs */
   crosshairs?: TooltipCrosshairs;
-
-
   /** 是否渲染 tooltipMarkers */
   showTooltipMarkers?: boolean;
   /** tooltipMarker 的样式 */

--- a/src/chart/interface.ts
+++ b/src/chart/interface.ts
@@ -348,13 +348,13 @@ export interface LegendCfg {
 }
 
 export interface TooltipCfg {
-  /** 是否展示 tooltip 标题 */
-  showTitle?: boolean;
   /** 设置 tooltip 是否跟随鼠标移动，默认为 false, 定位到数据点 */
   follow?: boolean;
+  /** 是否展示 tooltip 标题 */
+  showTitle?: boolean;
   /**
    * 设置 tooltip 的标题
-   * 如果值为数据字段名，则会展示数据中对应该字段的数值，如果数据中不存在该字段，则直接展示 title 值。
+   * 如果值为数据字段名，则会展示数据中对应该字段的数值，如果数据中不存在该字段，则直接展示 title 值
    */
   title?: string;
   /** 设置 tooltip 的固定展示位置，相对于数据点 */
@@ -371,8 +371,7 @@ export interface TooltipCfg {
    *
    */
   crosshairs?: 'x' | 'y' | 'xy';
-  // title?: string;
-  /** 是否自动渲染 tooltipMarkers，目前 line、area、path 会默认渲染 */
+  /** 是否渲染 tooltipMarkers */
   showTooltipMarkers?: boolean;
   /** tooltipMarker 的样式 */
   tooltipMarker?: object;
@@ -382,10 +381,6 @@ export interface TooltipCfg {
   containerTpl?: string;
   /** 每项记录的默认模板，自定义模板时必须包含各个 dom 节点的 class */
   itemTpl?: string;
-  /** 根据 x 定位的 crosshair 的模板 */
-  xCrosshairTpl?: string;
-  /** 根据 y 定位的 crosshair 的模板 */
-  yCrosshairTpl?: string;
   /** 传入各个 dom 的样式 */
   domStyles?: TooltipDomStyles;
   /** tooltip 偏移量 */

--- a/src/dependents.ts
+++ b/src/dependents.ts
@@ -22,7 +22,17 @@ export { getScale, registerScale, Scale, ScaleConfig } from '@antv/scale';
 export { Tick } from '@antv/scale/lib/types';
 
 // component
-import { Annotation, Axis, Component, Grid, GroupComponent, HtmlComponent, Legend, Tooltip } from '@antv/component';
+import {
+  Annotation,
+  Axis,
+  Component,
+  Crosshair,
+  Grid,
+  GroupComponent,
+  HtmlComponent,
+  Legend,
+  Tooltip,
+ } from '@antv/component';
 export { IComponent, IList } from '@antv/component/lib/interfaces';
 export {
   CategoryLegendCfg,
@@ -46,8 +56,11 @@ export {
   ContinueLegendRailCfg,
   ContinueLegendLabelCfg,
   ContinueLegendHandlerCfg,
+  CrosshairLineCfg,
+  CrosshairTextCfg,
+  CrosshairTextBackgroundCfg,
 } from '@antv/component/lib/types';
-export { HtmlComponent, GroupComponent, Component };
+export { HtmlComponent, GroupComponent, Component, Crosshair };
 export { Annotation };
 // axis
 const { Line: LineAxis, Circle: CircleAxis } = Axis;

--- a/src/theme/antv.ts
+++ b/src/theme/antv.ts
@@ -610,61 +610,65 @@ export default {
         lineWidth: 2,
         r: 4,
       },
-      // css style for tooltip
-      [`${TOOLTIP_CSS_CONST.CONTAINER_CLASS}`]: {
-        position: 'absolute',
-        visibility: 'hidden',
-        zIndex: 8,
-        transition:
-          'visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), ' +
-          'left 0.4s cubic-bezier(0.23, 1, 0.32, 1), ' +
-          'top 0.4s cubic-bezier(0.23, 1, 0.32, 1)',
-        backgroundColor: 'rgba(255, 255, 255, 0.9)',
-        boxShadow: '0px 0px 10px #aeaeae',
-        borderRadius: '3px',
-        color: 'rgb(87, 87, 87)',
-        fontSize: '12px',
-        fontFamily: FONT_FAMILY,
-        lineHeight: '20px',
-        padding: '10px 10px 6px 10px',
-      },
-      [`${TOOLTIP_CSS_CONST.TITLE_CLASS}`]: {
-        marginBottom: '4px',
-      },
-      [`${TOOLTIP_CSS_CONST.LIST_CLASS}`]: {
-        margin: 0,
-        listStyleType: 'none',
-        padding: 0,
-      },
-      [`${TOOLTIP_CSS_CONST.LIST_ITEM_CLASS}`]: {
-        listStyleType: 'none',
-        padding: 0,
-        marginBottom: '4px',
-        marginLeft: 0,
-        marginRight: 0,
-        marginTop: 0,
-      },
-      [`${TOOLTIP_CSS_CONST.MARKER_CLASS}`]: {
-        width: '8px',
-        height: '8px',
-        borderRadius: '50%',
-        display: 'inline-block',
-        marginRight: '8px',
-      },
-      [`${TOOLTIP_CSS_CONST.VALUE_CLASS}`]: {
-        display: 'inline-block',
-        float: 'right',
-        marginLeft: '30px',
-      },
-      [`${TOOLTIP_CSS_CONST.CROSSHAIR_X}`]: {
-        position: 'absolute',
-        width: '1px',
-        backgroundColor: 'rgba(0, 0, 0, 0.25)',
-      },
-      [`${TOOLTIP_CSS_CONST.CROSSHAIR_Y}`]: {
-        position: 'absolute',
-        height: '1px',
-        backgroundColor: 'rgba(0, 0, 0, 0.25)',
+      // tooltip dom 样式
+      domStyles: {
+        [`${TOOLTIP_CSS_CONST.CONTAINER_CLASS}`]: {
+          position: 'absolute',
+          visibility: 'hidden',
+          zIndex: 8,
+          transition:
+            'visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), ' +
+            'left 0.4s cubic-bezier(0.23, 1, 0.32, 1), ' +
+            'top 0.4s cubic-bezier(0.23, 1, 0.32, 1)',
+          backgroundColor: 'rgba(255, 255, 255, 0.9)',
+          boxShadow: '0px 0px 10px #aeaeae',
+          borderRadius: '3px',
+          color: 'rgb(87, 87, 87)',
+          fontSize: '12px',
+          fontFamily: FONT_FAMILY,
+          lineHeight: '20px',
+          padding: '10px 10px 6px 10px',
+        },
+        [`${TOOLTIP_CSS_CONST.TITLE_CLASS}`]: {
+          marginBottom: '4px',
+        },
+        [`${TOOLTIP_CSS_CONST.LIST_CLASS}`]: {
+          margin: 0,
+          listStyleType: 'none',
+          padding: 0,
+        },
+        [`${TOOLTIP_CSS_CONST.LIST_ITEM_CLASS}`]: {
+          listStyleType: 'none',
+          padding: 0,
+          marginBottom: '4px',
+          marginLeft: 0,
+          marginRight: 0,
+          marginTop: 0,
+        },
+        [`${TOOLTIP_CSS_CONST.MARKER_CLASS}`]: {
+          width: '8px',
+          height: '8px',
+          borderRadius: '50%',
+          display: 'inline-block',
+          marginRight: '8px',
+        },
+        [`${TOOLTIP_CSS_CONST.VALUE_CLASS}`]: {
+          display: 'inline-block',
+          float: 'right',
+          marginLeft: '30px',
+        },
+        // TODO: 移至 crosshairs 中
+        [`${TOOLTIP_CSS_CONST.CROSSHAIR_X}`]: {
+          position: 'absolute',
+          width: '1px',
+          backgroundColor: 'rgba(0, 0, 0, 0.25)',
+        },
+        // TODO: 移至 crosshairs 中
+        [`${TOOLTIP_CSS_CONST.CROSSHAIR_Y}`]: {
+          position: 'absolute',
+          height: '1px',
+          backgroundColor: 'rgba(0, 0, 0, 0.25)',
+        },
       },
     },
     annotation: {

--- a/src/theme/antv.ts
+++ b/src/theme/antv.ts
@@ -610,6 +610,23 @@ export default {
         lineWidth: 2,
         r: 4,
       },
+      crosshairs: {
+        line: {
+          style: {
+            stroke: '#BFBFBF',
+            lineWidth: 1,
+          },
+        },
+        text: null,
+        textBackground: {
+          padding: 2,
+          style: {
+            fill: 'rgba(0, 0, 0, 0.25)',
+            lineWidth: 0,
+            stroke: null,
+          },
+        },
+      },
       // tooltip dom 样式
       domStyles: {
         [`${TOOLTIP_CSS_CONST.CONTAINER_CLASS}`]: {
@@ -656,18 +673,6 @@ export default {
           display: 'inline-block',
           float: 'right',
           marginLeft: '30px',
-        },
-        // TODO: 移至 crosshairs 中
-        [`${TOOLTIP_CSS_CONST.CROSSHAIR_X}`]: {
-          position: 'absolute',
-          width: '1px',
-          backgroundColor: 'rgba(0, 0, 0, 0.25)',
-        },
-        // TODO: 移至 crosshairs 中
-        [`${TOOLTIP_CSS_CONST.CROSSHAIR_Y}`]: {
-          position: 'absolute',
-          height: '1px',
-          backgroundColor: 'rgba(0, 0, 0, 0.25)',
         },
       },
     },

--- a/tests/unit/chart/controller/tooltip-spec.ts
+++ b/tests/unit/chart/controller/tooltip-spec.ts
@@ -23,6 +23,12 @@ describe('Tooltip', () => {
     shared: true,
     showCrosshairs: true,
     showTooltipMarkers: true,
+    domStyles: {
+      'g2-tooltip': {
+        border: '1px solid #000',
+        boxShadow: null,
+      },
+    },
   });
   chart
     .interval()
@@ -30,6 +36,16 @@ describe('Tooltip', () => {
     .color('name')
     .adjust('dodge');
   chart.render();
+
+  it('tooltip config', () => {
+    const tooltipDom = container.getElementsByClassName('g2-tooltip')[0];
+    // @ts-ignore
+    expect(tooltipDom.style.border).toBe('1px solid rgb(0, 0, 0)');
+    // @ts-ignore
+    expect(tooltipDom.style.boxShadow).toBe('');
+    // @ts-ignore
+    expect(tooltipDom.style.backgroundColor).toBe(chart.getTheme().components.tooltip.domStyles['g2-tooltip'].backgroundColor);
+  });
 
   it('showTooltip', () => {
     let items;

--- a/tests/unit/chart/controller/tooltip-spec.ts
+++ b/tests/unit/chart/controller/tooltip-spec.ts
@@ -68,11 +68,11 @@ describe('Tooltip', () => {
     expect(tooltip.tooltip.get('y')).toBe(items[0].y);
 
     // @ts-ignore
-    const markerGroup = tooltip.markerGroup;
+    const markerGroup = tooltip.tooltipMarkersGroup;
     expect(markerGroup.getChildren().length).toBe(2);
 
-    const crosshairs = container.getElementsByClassName('g2-tooltip-crosshair-x');
-    expect(crosshairs.length).toBe(1);
+    // const crosshairs = container.getElementsByClassName('g2-tooltip-crosshair-x');
+    // expect(crosshairs.length).toBe(1);
 
     const foregroundGroup = chart.foregroundGroup;
     expect(foregroundGroup.getChildren().length).toBe(4);
@@ -90,12 +90,12 @@ describe('Tooltip', () => {
     expect(tooltip.tooltip.get('visible')).toBe(false);
 
     // @ts-ignore
-    const markerGroup = tooltip.markerGroup;
+    const markerGroup = tooltip.tooltipMarkersGroup;
     expect(markerGroup.get('visible')).toBe(false);
 
-    const crosshairs = container.getElementsByClassName('g2-tooltip-crosshair-x');
-    // @ts-ignore
-    expect(crosshairs[0].style.display).toBe('none');
+    // const crosshairs = container.getElementsByClassName('g2-tooltip-crosshair-x');
+    // // @ts-ignore
+    // expect(crosshairs[0].style.display).toBe('none');
   });
 
   it('getTooltipItems', () => {

--- a/tests/unit/component/tooltip-crosshairs-spec.ts
+++ b/tests/unit/component/tooltip-crosshairs-spec.ts
@@ -1,0 +1,353 @@
+import { Chart } from '../../../src';
+import { createDiv, removeDom } from '../../util/dom';
+
+describe('TooltipCrosshairs', () => {
+  const container = createDiv();
+  const data = [
+    { year: '1991', value: 3 },
+    { year: '1992', value: 4 },
+    { year: '1993', value: 3.5 },
+    { year: '1994', value: 5 },
+    { year: '1995', value: 4.9 },
+    { year: '1996', value: 6 },
+    { year: '1997', value: 7 },
+    { year: '1998', value: 9 },
+    { year: '1999', value: 13 }
+  ];
+  const chart = new Chart({
+    container,
+    autoFit: false,
+    width: 400,
+    height: 300,
+    padding: 50,
+  });
+  chart.animate(false);
+  chart.data(data);
+  chart.scale('year', {
+    range: [0, 1]
+  });
+  chart.scale('value', {
+    nice: true,
+  });
+  chart.line().position('year*value');
+  chart.point().position('year*value')
+    .shape('circle')
+    .style({
+      stroke: '#fff',
+      lineWidth: 1
+    });
+  chart.render();
+
+  it('default, crosshairs is closed', () => {
+    const point = chart.getXY({ year: '1994', value: 5 });
+    chart.showTooltip(point);
+    const tooltipController = chart.getController('tooltip');
+    // @ts-ignore
+    expect(tooltipController.guideGroup.getCount()).toBe(1);
+    // @ts-ignore
+    expect(tooltipController.yCrosshair).toBeUndefined();
+    // @ts-ignore
+    expect(tooltipController.xCrosshair).toBeUndefined();
+  });
+
+  it('show x crosshairs, but without text', () => {
+    chart.tooltip({
+      showCrosshairs: true,
+    });
+    chart.render(true);
+
+    const point = chart.getXY({ year: '1994', value: 5 });
+    chart.showTooltip(point);
+
+    const tooltipController = chart.getController('tooltip');
+    // @ts-ignore
+    expect(tooltipController.guideGroup.getCount()).toBe(2);
+    // @ts-ignore
+    expect(tooltipController.yCrosshair).toBeUndefined();
+    // @ts-ignore
+    const xCrosshair = tooltipController.xCrosshair;
+    expect(xCrosshair).toBeDefined();
+    expect(xCrosshair.get('start').x).toBe(point.x);
+    expect(xCrosshair.get('start').y).toBe(chart.getCoordinate().end.y);
+    expect(xCrosshair.get('end').x).toBe(point.x);
+    expect(xCrosshair.get('end').y).toBe(chart.getCoordinate().start.y);
+    expect(xCrosshair.get('text')).toBeNull();
+  });
+
+  it('show y crosshairs, but without text', () => {
+    chart.tooltip({
+      showCrosshairs: true,
+      crosshairs: {
+        type: 'y',
+        line: {
+          style: {
+            linDash: [ 2 ],
+          },
+        },
+      },
+    });
+    chart.render(true);
+
+    const point = chart.getXY({ year: '1994', value: 5 });
+    chart.showTooltip(point);
+
+    const tooltipController = chart.getController('tooltip');
+    // @ts-ignore
+    expect(tooltipController.guideGroup.getCount()).toBe(2);
+    // @ts-ignore
+    const yCrosshair = tooltipController.yCrosshair;
+    expect(yCrosshair).toBeDefined();
+    expect(yCrosshair.get('start').x).toBe(chart.getCoordinate().start.x);
+    expect(yCrosshair.get('start').y).toBe(point.y);
+    expect(yCrosshair.get('end').x).toBe(chart.getCoordinate().end.x);
+    expect(yCrosshair.get('end').y).toBe(point.y);
+    expect(yCrosshair.get('text')).toBeNull();
+    // @ts-ignore
+    const xCrosshair = tooltipController.xCrosshair;
+    expect(xCrosshair).toBeDefined();
+    expect(xCrosshair.get('visible')).toBeFalsy();
+  });
+
+  it('show x crosshairs, with text', () => {
+    chart.tooltip({
+      showCrosshairs: true,
+      crosshairs: {
+        text: {
+          style: {
+            textAlign: 'center'
+          }
+        },
+      }
+    });
+    chart.render(true);
+
+    const point = chart.getXY({ year: '1994', value: 5 });
+    chart.showTooltip(point);
+
+    const tooltipController = chart.getController('tooltip');
+    // @ts-ignore
+    expect(tooltipController.guideGroup.getCount()).toBe(2);
+    // @ts-ignore
+    const yCrosshair = tooltipController.yCrosshair;
+    expect(yCrosshair).toBeDefined();
+    expect(yCrosshair.get('visible')).toBeFalsy();
+
+    // @ts-ignore
+    const xCrosshair = tooltipController.xCrosshair;
+    expect(xCrosshair).toBeDefined();
+    expect(xCrosshair.get('visible')).toBeTruthy();
+    expect(xCrosshair.get('text')).not.toBeNull();
+    expect(xCrosshair.get('text').content).toBe('1994');
+  });
+
+  it('show y crosshairs, with text', () => {
+    chart.tooltip({
+      showCrosshairs: true,
+      crosshairs: {
+        type: 'y',
+        text: {
+          style: {
+            textAlign: 'right',
+            fill: 'red',
+          }
+        },
+      }
+    });
+    chart.render(true);
+
+    const point = chart.getXY({ year: '1994', value: 5 });
+    chart.showTooltip(point);
+
+    const tooltipController = chart.getController('tooltip');
+    // @ts-ignore
+    expect(tooltipController.guideGroup.getCount()).toBe(2);
+    // @ts-ignore
+    const yCrosshair = tooltipController.yCrosshair;
+    expect(yCrosshair).toBeDefined();
+    expect(yCrosshair.get('visible')).toBeTruthy();
+    expect(yCrosshair.get('text')).not.toBeNull();
+    expect(yCrosshair.get('text').content).toBe(5);
+    expect(yCrosshair.get('text').style.textAlign).toBe('right');
+    expect(yCrosshair.get('text').style.fill).toBe('red');
+
+    // @ts-ignore
+    const xCrosshair = tooltipController.xCrosshair;
+    expect(xCrosshair).toBeDefined();
+    expect(xCrosshair.get('visible')).toBeFalsy();
+  });
+
+  it('transpose coordinate', () => {
+    chart.coordinate('rect').transpose();
+    chart.tooltip({
+      showCrosshairs: true,
+      crosshairs: {
+        type: 'xy',
+        text: {
+          style: {
+            textAlign: 'right',
+            fill: 'red',
+          }
+        },
+      }
+    });
+    chart.render(true);
+
+    const point = chart.getXY({ year: '1994', value: 5 });
+    chart.showTooltip(point);
+
+    const tooltipController = chart.getController('tooltip');
+    // @ts-ignore
+    expect(tooltipController.guideGroup.getCount()).toBe(2);
+    // @ts-ignore
+    const yCrosshair = tooltipController.yCrosshair;
+    expect(yCrosshair).toBeDefined();
+    expect(yCrosshair.get('visible')).toBeTruthy();
+    expect(yCrosshair.get('text')).not.toBeNull();
+    expect(yCrosshair.get('text').content).toBe(5);
+    expect(yCrosshair.get('text').style.textAlign).toBe('right');
+    expect(yCrosshair.get('text').style.fill).toBe('red');
+    expect(yCrosshair.get('start').x).toBe(point.x);
+    expect(yCrosshair.get('start').y).toBe(chart.getCoordinate().end.y);
+    expect(yCrosshair.get('end').x).toBe(point.x);
+    expect(yCrosshair.get('end').y).toBe(chart.getCoordinate().start.y);
+
+    // @ts-ignore
+    const xCrosshair = tooltipController.xCrosshair;
+    expect(xCrosshair).toBeDefined();
+    expect(xCrosshair.get('visible')).toBeTruthy();
+    expect(xCrosshair.get('text')).not.toBeNull();
+    expect(xCrosshair.get('text').content).toBe('1994');
+    expect(xCrosshair.get('start').x).toBe(chart.getCoordinate().start.x);
+    expect(xCrosshair.get('start').y).toBe(point.y);
+    expect(xCrosshair.get('end').x).toBe(chart.getCoordinate().end.x);
+    expect(xCrosshair.get('end').y).toBe(point.y);
+  });
+
+  it('polar coordinate', () => {
+    chart.clear();
+    chart.coordinate('polar');
+    chart.axis('value', {
+      grid: null,
+    });
+    chart.data(data);
+    chart.scale('year', {
+      range: [0, 1]
+    });
+    chart.scale('value', {
+      nice: true,
+    });
+    chart.line().position('year*value');
+    chart.point().position('year*value')
+      .shape('circle')
+      .style({
+        stroke: '#fff',
+        lineWidth: 1
+      });
+    chart.render();
+
+    const point = chart.getXY({ year: '1994', value: 5 });
+    chart.showTooltip(point);
+
+    const tooltipController = chart.getController('tooltip');
+    // @ts-ignore
+    expect(tooltipController.guideGroup.getCount()).toBe(2);
+    // @ts-ignore
+    const yCrosshair = tooltipController.yCrosshair;
+    expect(yCrosshair).toBeDefined();
+    expect(yCrosshair.get('visible')).toBeTruthy();
+    expect(yCrosshair.get('text').content).toBe(5);
+    expect(yCrosshair.get('text').style.textAlign).toBe('right');
+    expect(yCrosshair.get('text').style.fill).toBe('red');
+    expect(yCrosshair.get('type')).toBe('circle');
+    expect(yCrosshair.get('radius')).toBeCloseTo(20);
+
+    // @ts-ignore
+    const xCrosshair = tooltipController.xCrosshair;
+    expect(xCrosshair).toBeDefined();
+    expect(xCrosshair.get('visible')).toBeTruthy();
+    expect(xCrosshair.get('text')).not.toBeNull();
+    expect(xCrosshair.get('text').content).toBe('1994');
+    expect(xCrosshair.get('start').x).toBe(chart.getCoordinate().getCenter().x);
+    expect(xCrosshair.get('start').y).toBe(chart.getCoordinate().getCenter().y);
+    expect(xCrosshair.get('end').x).toBeCloseTo(270.71067811865476);
+    expect(xCrosshair.get('end').y).toBeCloseTo(220.71067811865476);
+  });
+
+  it('follow cursor', () => {
+    chart.tooltip({
+      follow: true,
+      shared: true,
+      showCrosshairs: true,
+      crosshairs: {
+        type: 'xy',
+        text: (type, defaultValue, a, b) => {
+          if (type === 'x') {
+            return {
+              style: {
+                textAlign: 'center',
+                fill: 'red',
+              },
+              content: defaultValue,
+            }
+          }
+          return {
+            style: {
+              textAlign: 'center',
+              fill: 'red',
+            },
+            content: defaultValue.toFixed(0),
+          };
+        },
+      }
+    });
+    chart.render(true);
+
+    const point = chart.getXY({ year: '1994', value: 5 });
+    chart.showTooltip({
+      x: point.x,
+      y: (point.y - 8)
+    });
+
+    const tooltipController = chart.getController('tooltip');
+    // @ts-ignore
+    expect(tooltipController.guideGroup.getCount()).toBe(2);
+    // @ts-ignore
+    const yCrosshair = tooltipController.yCrosshair;
+    expect(yCrosshair).toBeDefined();
+    expect(yCrosshair.get('visible')).toBeTruthy();
+    expect(yCrosshair.get('text').content).toBe('5');
+    expect(yCrosshair.get('text').style.textAlign).toBe('center');
+    expect(yCrosshair.get('text').style.fill).toBe('red');
+    expect(yCrosshair.get('type')).toBe('circle');
+    expect(yCrosshair.get('radius')).toBeCloseTo(15.418360159897189);
+
+    // @ts-ignore
+    const xCrosshair = tooltipController.xCrosshair;
+    expect(xCrosshair).toBeDefined();
+    expect(xCrosshair.get('visible')).toBeTruthy();
+    expect(xCrosshair.get('text')).not.toBeNull();
+    expect(xCrosshair.get('text').content).toBe('1994');
+    expect(xCrosshair.get('start').x).toBe(chart.getCoordinate().getCenter().x);
+    expect(xCrosshair.get('start').y).toBe(chart.getCoordinate().getCenter().y);
+    expect(xCrosshair.get('end').x).toBeCloseTo(291.7226960394552);
+    expect(xCrosshair.get('end').y).toBeCloseTo(189.8365037528862);
+  });
+
+  it('destroy', () => {
+    const tooltipController = chart.getController('tooltip');
+    tooltipController.destroy();
+
+    // @ts-ignore
+    expect(tooltipController.guideGroup).toBeNull();
+    // @ts-ignore
+    expect(tooltipController.xCrosshair).toBeNull();
+    // @ts-ignore
+    expect(tooltipController.yCrosshair).toBeNull();
+  });
+
+  afterAll(() => {
+    chart.destroy();
+
+    removeDom(container);
+  });
+});


### PR DESCRIPTION
#### 改动
1. 移除当前 Tooltip  组件默认自带 html crosshairs，HTML 版本的 crosshairs 组件的支持需要将来 Component 将其从 Tooltip 组件中拆分出来，详见： https://github.com/antvis/component/issues/122

2. 接入 Crosshairs 组件，修改 G2 层 tooltip 的配置项，同时支持极坐标下的  crosshairs ~~~ 同时 crosshairs 可以带文本

####  配置项 

```ts
chart.tooltip({
  showCrosshairs: true,
  crosshairs: {
    type: 'xy',
    line: {
      style: {
        stroke: '#565656',
        lineDash: [4],
      },
    },
  }
});
```

#### demo

| **坐标系** | **type = 'x'** | **type = 'xy'** | **type = 'y'** |
| :---: | :---: | :---: | :---: |
| 直角坐标系 |  ![6](https://user-images.githubusercontent.com/6628666/72583993-53282580-3923-11ea-8373-dac583cab8c4.gif)  |  ![2](https://user-images.githubusercontent.com/6628666/72583996-57544300-3923-11ea-9488-ab42fde69307.gif) |   ![7](https://user-images.githubusercontent.com/6628666/72584000-5b806080-3923-11ea-8d99-d0a7da817ff6.gif)|
| 极坐标 | ![2222222](https://user-images.githubusercontent.com/6628666/72583970-43104600-3923-11ea-93ad-7395ada40b5c.gif) |   ![3](https://user-images.githubusercontent.com/6628666/72583975-4a375400-3923-11ea-8284-9b197bd16b5a.gif) |    ![4](https://user-images.githubusercontent.com/6628666/72583987-502d3500-3923-11ea-881e-376c6f6a6f3b.gif) |

