### PR TITLE
Feat category legend unchecked

### DIFF
--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -989,6 +989,33 @@ export class View extends Base {
     return components;
   }
 
+  /**
+   * 将 data 数据进行过滤
+   * @param data
+   * @returns 过滤之后的数据
+   */
+  public filterData(data: Data): Data {
+    const { filters } = this.options;
+    // 不存在 filters，则不需要进行数据过滤
+    if (size(filters) === 0) {
+      return data;
+    }
+
+    // 存在过滤器，则逐个执行过滤，过滤器之间是 与 的关系
+    return filter(data, (datum: Datum) => {
+      // 所有的 filter 字段
+      const fields = Object.keys(filters);
+
+      // 所有的条件都通过，才算通过
+      return fields.every((field: string) => {
+        const condition = filters[field];
+
+        // condition 返回 true，则保留
+        return condition(datum[field], datum);
+      });
+    });
+  }
+
   protected paint(isUpdate: boolean) {
     this.renderDataRecursive(isUpdate);
     this.renderLayoutRecursive(isUpdate);
@@ -1001,7 +1028,7 @@ export class View extends Base {
    */
   private renderDataRecursive(isUpdate: boolean) {
     // 1. 处理数据
-    this.filterData();
+    this.doFilterData();
     // 2. 创建实例
     this.createCoordinate();
     // 3. 初始化 Geometry
@@ -1251,27 +1278,9 @@ export class View extends Base {
    * 处理筛选器，筛选数据
    * @private
    */
-  private filterData() {
-    const { data, filters } = this.options;
-    // 不存在 filters，则不需要进行数据过滤
-    if (size(filters) === 0) {
-      this.filteredData = data;
-      return;
-    }
-
-    // 存在过滤器，则逐个执行过滤，过滤器之间是 与 的关系
-    this.filteredData = filter(data, (datum: Datum) => {
-      // 所有的 filter 字段
-      const fields = Object.keys(filters);
-
-      // 所有的条件都通过，才算通过
-      return fields.every((field: string) => {
-        const condition = filters[field];
-
-        // condition 返回 true，则保留
-        return condition(datum[field], datum);
-      });
-    });
+  private doFilterData() {
+    const { data } = this.options;
+    this.filteredData = this.filterData(data);
   }
 
   /**

--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -11,6 +11,7 @@ import {
   isNil,
   isObject,
   isString,
+  isUndefined,
   map,
   remove,
   set,
@@ -1014,6 +1015,22 @@ export class View extends Base {
         return condition(datum[field], datum);
       });
     });
+  }
+
+  /**
+   * 对某一个字段进行过滤
+   * @param field
+   * @param data
+   */
+  public filterFieldData(field: string, data: Data): Data {
+    const { filters } = this.options;
+    const condition = get(filters, field);
+
+    if (isUndefined(condition)) {
+      return data;
+    }
+
+    return filter(data, (datum: Datum) => condition(datum[field], datum));
   }
 
   protected paint(isUpdate: boolean) {

--- a/src/util/legend.ts
+++ b/src/util/legend.ts
@@ -1,4 +1,4 @@
-import { deepMix, map, get, isString } from '@antv/util';
+import { deepMix, isString, map, size } from '@antv/util';
 import { LegendItem } from '../chart/interface';
 import View from '../chart/view';
 import { DIRECTION } from '../constant';
@@ -34,12 +34,15 @@ export function getLegendItems(
 ): any[] {
   const scale = attr.getScale(attr.type);
   if (scale.isCategory) {
+    const field = scale.field;
+
     return map(scale.getTicks(), (tick: Tick): object => {
       const { text, value: scaleValue } = tick;
       const name = text;
       const value = scale.invert(scaleValue);
 
-      // const checked = filterVals ? self._isFiltered(scale, filterVals, scaleValue) : true;
+      // 通过过滤图例项的数据，来看是否乣 unchecked
+      const unchecked = !size(view.filterFieldData(field, [{ [field]: value }]));
 
       const colorAttr = geometry.getAttribute('color');
       const shapeAttr = geometry.getAttribute('shape');
@@ -59,7 +62,7 @@ export function getLegendItems(
         marker.symbol = MarkerSymbols[symbol];
       }
 
-      return { id: value, name, value, marker };
+      return { id: value, name, value, marker, unchecked };
     });
   }
   return [];

--- a/tests/unit/chart/view/index-spec.ts
+++ b/tests/unit/chart/view/index-spec.ts
@@ -123,7 +123,7 @@ describe('View', () => {
     expect(size(view.getOptions().filters)).toEqual(2);
 
     // @ts-ignore
-    view.filterData();
+    view.doFilterData();
 
     // @ts-ignore
     expect(view.filteredData).toEqual([
@@ -334,7 +334,12 @@ describe('View', () => {
 
     view1.data(data);
     view1.filter('category', (category: string) => category === '电脑');
-    view1.filter('city', (category: string) => category === '杭州');
+    view1.filter('city', (city: string) => city === '杭州');
+
+    // 测试 filterData API
+    expect(view1.filterData([{ city: '杭州', category: '电脑' }, { city: '杭州', category: 'xx' }])).toEqual(
+      [{ city: '杭州', category: '电脑' }]
+    );
 
     const geometry = view1
       .line()

--- a/tests/unit/chart/view/index-spec.ts
+++ b/tests/unit/chart/view/index-spec.ts
@@ -341,6 +341,10 @@ describe('View', () => {
       [{ city: '杭州', category: '电脑' }]
     );
 
+    expect(view1.filterFieldData('city', [{ city: '杭州' }])).toEqual(
+      [{ city: '杭州' }]
+    );
+
     const geometry = view1
       .line()
       .position('city*sale')

--- a/tests/unit/component/legend-unchecked-spec.ts
+++ b/tests/unit/component/legend-unchecked-spec.ts
@@ -1,0 +1,45 @@
+import { Chart } from '../../../src/';
+import { COMPONENT_TYPE } from '../../../src/constant';
+import { GroupComponent, GroupComponentCfg } from '../../../src/dependents';
+import { CITY_SALE, DIAMOND } from '../../util/data';
+import { createDiv } from '../../util/dom';
+
+describe('legend unchecked', () => {
+
+  it('category', () => {
+    const div = createDiv();
+
+    const chart = new Chart({
+      container: div,
+      width: 400,
+      height: 300,
+      autoFit: false,
+    });
+
+    chart.data(CITY_SALE);
+
+    chart
+      .interval()
+      .position('city*sale')
+      .color('category')
+      .adjust({ type: 'dodge' });
+
+
+    chart.filter('category', (v) => v === '电脑');
+    chart.interaction('legend-filter');
+
+    chart.render();
+
+    const legend = chart.getComponents().filter(co => co.type === COMPONENT_TYPE.LEGEND)[0].component;
+
+    const items = legend.get('items').map(item => ({
+      value: item.value,
+      unchecked: item.unchecked,
+    }));
+
+    expect(items).toEqual([
+      { value: '电脑', unchecked: false },
+      { value: '鼠标', unchecked: true },
+    ]);
+  });
+});


### PR DESCRIPTION
 - [x] view 增加 filterFieldData API 用于测试一个数据经过筛选之后的情况
 - [x] 通过图例项数据 经过 filterFieldData 来判断是否需要 unchecked 状态
 - [x] 单测

目前存在问题：交互上，可以将所有的图例项都 unchecked，然后控制台报错 @dxq613 ，大概是交互中无法通过 items.unchecked 获取 unchecked 状态。