### PR TITLE
【G2 3.6.x】fix: 修复 legend 翻页判断问题

### DIFF
--- a/packages/component/src/legend/category/canvas.ts
+++ b/packages/component/src/legend/category/canvas.ts
@@ -70,15 +70,15 @@ export default class CanvasLegend extends CategoryBase {
 
   public isNeedFlip(): boolean {
     const maxWidth = this.get('maxWidth');
-    const maxItemHeight = this.get('maxItemHeight');
+    const maxHeight = this.get('maxHeight');
     const itemsBBox = this.get('itemsGroup').getBBox();
     const layout = this.get('layout');
     if (this.get('flipPage')) {
-      if (layout === 'vertical' && maxWidth < itemsBBox.width) {
+      if (layout === 'vertical' && maxHeight < itemsBBox.height) {
         return true;
       }
 
-      if (layout === 'horizontal' && maxItemHeight < itemsBBox.height) {
+      if (layout === 'horizontal' && maxWidth < itemsBBox.width) {
         return true;
       }
     }


### PR DESCRIPTION
原有判断逻辑存问题，应该是当前绘制区域宽/高与实际图例宽/高进行对比，会导致无需翻页器的场景计入翻页器高度，导致 padding 过多。例如：https://github.com/antvis/G2Plot/issues/617