### PR TITLE
fix: 修复 package.json 中 main、module、types 的引用地址问题

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
       "@antv/g2": ["src"]
     }
   },
-  "include": ["src", "tests"],
+  "include": ["src"],
   "typedocOptions": {
     "mode": "file",
     "out": "docs/api",


### PR DESCRIPTION
由于 tsconfig.json 中 include 包含了 tests，因此编辑结果如下：

![image](https://user-images.githubusercontent.com/9314735/74673619-868ff580-51ea-11ea-88e4-6a087abc24ae.png)

这样导致 package.json 中 main、module、types 的引用地址出现错误，使用 npm 包时会使用 g.min.js，在 G2Plot 中不易调试 G2

test 文件由于已经使用了 ts-jest，理论上不需要在 build 阶段编译了，可以去除