### PR TITLE
fix(legend): 分页图例设置 maxWidth、maxHeight 导致位置不正确

### DIFF
--- a/src/chart/controller/legend.ts
+++ b/src/chart/controller/legend.ts
@@ -104,17 +104,23 @@ export default class Legend extends Controller<Option> {
   public layout() {
     each(this.components, (co: ComponentOption) => {
       const { component, direction } = co;
-      const bboxObject = component.getLayoutBBox(); // 这里只需要他的 width、height 信息做位置调整
-      const bbox = new BBox(bboxObject.x, bboxObject.y, bboxObject.width, bboxObject.height);
-
-      const [x1, y1] = directionToPosition(this.view.coordinateBBox, bbox, direction);
-      const [x2, y2] = directionToPosition(this.view.viewBBox, bbox, direction);
-
       const layout = getLegendLayout(direction);
       const maxSize = this.getCategoryLegendSizeCfg(layout);
 
       const maxWidth = component.get('maxWidth');
       const maxHeight = component.get('maxHeight');
+
+      // 先更新 maxSize，更新 layoutBBox，以便计算正确的 x y
+      component.update({
+        maxWidth: Math.min(maxSize.maxWidth, maxWidth || 0),
+        maxHeight: Math.min(maxSize.maxHeight, maxHeight || 0),
+      });
+
+      const bboxObject = component.getLayoutBBox(); // 这里只需要他的 width、height 信息做位置调整
+      const bbox = new BBox(bboxObject.x, bboxObject.y, bboxObject.width, bboxObject.height);
+
+      const [x1, y1] = directionToPosition(this.view.coordinateBBox, bbox, direction);
+      const [x2, y2] = directionToPosition(this.view.viewBBox, bbox, direction);
 
       let x = 0;
       let y = 0;
@@ -128,11 +134,10 @@ export default class Legend extends Controller<Option> {
         y = y1;
       }
 
+      // 更新位置
       component.update({
         x,
         y,
-        maxWidth: Math.min(maxSize.maxWidth, maxWidth || 0),
-        maxHeight: Math.min(maxSize.maxHeight, maxHeight || 0),
       });
     });
   }

--- a/tests/unit/component/legend-category-spec.ts
+++ b/tests/unit/component/legend-category-spec.ts
@@ -150,6 +150,7 @@ describe('Legend Category Vertical', () => {
     const legend = legends[0].component as GroupComponent<GroupComponentCfg>;
 
     expect(legend.get('maxHeight')).toBe(80);
+    expect(legend.get('y')).toBeGreaterThan(0);
 
     const navigation = legend.getElementById(`${legendId}-legend-navigation-group`);
 


### PR DESCRIPTION
#2054

 - [x] 图例位置不正确， 导致没有和 coordinate 对齐
 - [x] 单测

另外还有一个

 - [ ] 因为 legend 直接将 maxWidth 作为 bbox.width，所以导致右侧空白很多。需要 component 修复，更新版本即可 @dxq613 