### PR TITLE
fix(coordinate): redo matrix actions when adjust coordinate start end

### DIFF
--- a/src/chart/controller/coordinate.ts
+++ b/src/chart/controller/coordinate.ts
@@ -1,4 +1,4 @@
-import { each, some } from '@antv/util';
+import { each, isNil, some } from '@antv/util';
 import { Coordinate, getCoordinate, Point } from '../../dependents';
 import { CoordinateOption } from '../../interface';
 
@@ -85,6 +85,12 @@ export default class {
       end,
     });
 
+    // 更新坐标系大小的时候，需要：
+    // 1. 重置 matrix
+    // 2. 重新执行作用于 matrix 的 action
+    this.coordinate.resetMatrix();
+    this.execActions(['scale', 'rotate', 'translate']);
+
     return this.coordinate;
   }
 
@@ -139,6 +145,13 @@ export default class {
   }
 
   /**
+   * 获得 coordinate 实例
+   */
+  public getCoordinate() {
+    return this.coordinate;
+  }
+
+  /**
    * 包装配置的默认值
    * @param option
    */
@@ -153,14 +166,19 @@ export default class {
 
   /**
    * coordinate 实例执行 actions
+   * @params includeActions 如果没有指定，则执行全部，否则，执行指定的 action
    */
-  private execActions() {
+  private execActions(includeActions?: string[]) {
     const { actions } = this.option;
 
     each(actions, action => {
       const [actionName, ...args] = action;
 
-      this.coordinate[actionName](...args);
+      const shouldExec = isNil(includeActions) ? true : includeActions.includes(actionName);
+
+      if (shouldExec) {
+        this.coordinate[actionName](...args);
+      }
     });
   }
 }

--- a/tests/bugs/2044-spec.ts
+++ b/tests/bugs/2044-spec.ts
@@ -1,0 +1,30 @@
+import CoordinateController from '../../src/chart/controller/coordinate';
+
+// 坐标系在 adjust 的时候，需要重新执行 matrix 相关 actions
+describe('#2044', () => {
+  it('Coordinate', () => {
+    const start = { x: 0, y: 0 };
+    const end = { x: 1, y: 1 };
+
+    const coordinateController = new CoordinateController();
+
+    // 设置配置
+    coordinateController.scale(1, -1);
+    coordinateController.rotate(Math.PI);
+
+    // 创建
+    coordinateController.create({ x: 0, y: 100 }, { x: 100, y: 0 });
+
+    const matrix1 = coordinateController.getCoordinate().matrix;
+
+    // 更新调整
+    coordinateController.adjust({ x: 0, y: 200 }, { x: 200, y: 0 });
+
+    const matrix2 = coordinateController.getCoordinate().matrix;
+
+    // 引用变化
+    expect(matrix1).not.toBe(matrix2);
+    // 因为 start end 变化，所以 matrix 也不相等
+    expect(matrix1).not.toEqual(matrix2);
+  });
+});

--- a/tests/bugs/active-region-spec.ts
+++ b/tests/bugs/active-region-spec.ts
@@ -237,7 +237,7 @@ describe('active-region', () => {
       return el.get('name') === 'active-region';
     })[0];
 
-    expect(regionShape.getBBox().minY).toBeCloseTo(203.23046875);
+    expect(regionShape.getBBox().minY).toBeCloseTo(169.23046875);
   });
 
   afterEach(() => {


### PR DESCRIPTION
Closed #2044

 - [x] coordinate.adjust 的时候，重新执行 matrix 相关 action
 - [x] 单测

等待 https://github.com/antvis/coord/pull/7 合并之后发版本，这边的 ci 才能通过。