### PR TITLE
[3.6.x] fix: 修复legend 无法翻页的问题

### DIFF
--- a/packages/component/src/legend/category/canvas.ts
+++ b/packages/component/src/legend/category/canvas.ts
@@ -54,13 +54,13 @@ export default class CanvasLegend extends CategoryBase {
     each(items, (item: LegendItem) => {
       this._addItem(item);
     });
-    if (this.get('autoWrap')) {
-      this._adjustItems();
-    } // 默认自动换行
     const { maxItemWidth, maxItemHeight } = this._getMaxItemSize();
     this.set('maxItemWidth', maxItemWidth);
     this.set('maxItemHeight', maxItemHeight);
     const needPageFlip = this.isNeedFlip();
+    if (this.get('autoWrap')) {
+      this._adjustItems();
+    } // 默认自动换行
     if (needPageFlip) {
       this.flipPage();
     }


### PR DESCRIPTION
修改 isNeedFlip 的逻辑正确后，正确的流程应该是：

1. 渲染所有的 items
2. 根据所有的 item 的 bbox 判断是否需要翻页
3. 调整 items 自动换行
4. 根据是否需要翻页，渲染翻页器

之前 2，3 反了