### PR TITLE
refactor(pie-label): 饼图label的调整，移动至layout中处理

### DIFF
--- a/examples/pie/basic/demo/labelline.ts
+++ b/examples/pie/basic/demo/labelline.ts
@@ -37,6 +37,7 @@ chart
   .position('percent')
   .color('item')
   .label('percent', {
+    layout: { type: 'distribute' },
     content: (data) => {
       return `${data.item}: ${data.percent * 100}%`;
     },

--- a/src/component/labels.ts
+++ b/src/component/labels.ts
@@ -56,7 +56,7 @@ export default class Labels {
         this.renderLabel(item, offscreenGroup);
       }
     }
-    this.adjustLabels(shapes); // 调整 labels
+    this.adjustLabels(shapes, items); // 调整 labels
 
     // 进行添加、更新、销毁操作
     const lastShapesMap = this.lastShapesMap;
@@ -155,8 +155,6 @@ export default class Labels {
       data,
       origin: mappingData,
       coordinate,
-      /** 把 labelItem 传递下去 */
-      labelItem: cfg,
     };
     const labelGroup = container.addGroup({
       name: 'label',
@@ -204,7 +202,7 @@ export default class Labels {
   }
 
   // 根据type对label布局
-  private adjustLabels(shapes) {
+  private adjustLabels(shapes, items: LabelItem[]) {
     if (this.layout) {
       const layouts = isArray(this.layout) ? this.layout : [this.layout];
       each(layouts, (layout: GeometryLabelLayoutCfg) => {
@@ -217,7 +215,7 @@ export default class Labels {
             geometryShapes.push(shapes[id]);
           });
 
-          layoutFn(labelShapes, geometryShapes, this.region, layout.cfg);
+          layoutFn(labelShapes, geometryShapes, items, this.region, layout.cfg);
         }
       });
     }

--- a/src/component/labels.ts
+++ b/src/component/labels.ts
@@ -149,12 +149,14 @@ export default class Labels {
   }
 
   private renderLabel(cfg: LabelItem, container: IGroup) {
-    const { id, data, mappingData, coordinate, animate, content } = cfg;
+    const { id, data, mappingData, coordinate, animate, content, offset } = cfg;
     const shapeAppendCfg = {
       id,
       data,
       origin: mappingData,
       coordinate,
+      /** 把 labelItem 传递下去 */
+      labelItem: cfg,
     };
     const labelGroup = container.addGroup({
       name: 'label',

--- a/src/geometry/label/index.ts
+++ b/src/geometry/label/index.ts
@@ -1,6 +1,7 @@
 import { BBox, IGroup, IShape } from '../../dependents';
 import { LooseObject } from '../../interface';
 import { GeometryLabelConstructor } from './base';
+import { LabelItem } from './interface';
 
 /**
  * label 布局函数定义
@@ -9,7 +10,7 @@ import { GeometryLabelConstructor } from './base';
  * @param region 画布区域
  * @param cfg 用于存储各个布局函数开放给用户的配置数据
  */
-type GeometryLabelsLayoutFn = (labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox, cfg?: LooseObject) => void;
+type GeometryLabelsLayoutFn = (labels: IGroup[], shapes: IShape[] | IGroup[], items: LabelItem[], region: BBox, cfg?: LooseObject) => void;
 
 const GEOMETRY_LABELS_MAP: Record<string, GeometryLabelConstructor> = {};
 const GEOMETRY_LABELS_LAYOUT_MAP: Record<string, GeometryLabelsLayoutFn>  = {};

--- a/src/geometry/label/layout/distribute.ts
+++ b/src/geometry/label/layout/distribute.ts
@@ -163,7 +163,7 @@ export function distribute(labels: IGroup[], shapes: IShape[] | IGroup[], region
         halves[1].push(label);
       }
     });
-
+    
     halves.forEach((half, index) => {
       // step 2: reduce labels
       const maxLabelsCountForOneSide = Math.floor(totalHeight / lineHeight);

--- a/src/geometry/label/layout/distribute.ts
+++ b/src/geometry/label/layout/distribute.ts
@@ -1,0 +1,192 @@
+import { find } from '@antv/util';
+import { BBox, IGroup, IShape } from '../../../dependents';
+
+/** label text和line距离 4px */
+const MARGIN = 4;
+
+function getEndPoint(center, angle, r) {
+  return {
+    x: center.x + r * Math.cos(angle),
+    y: center.y + r * Math.sin(angle),
+  };
+}
+
+function antiCollision(labelGroups: IGroup[], lineHeight, plotRange, center, isRight) {
+  const labels = labelGroups.map((labelShape) => labelShape.get('labelItem'));
+  // adjust y position of labels to avoid overlapping
+  let overlapping = true;
+  const start = plotRange.start;
+  const end = plotRange.end;
+  const startY = Math.min(start.y, end.y);
+  let totalHeight = Math.abs(start.y - end.y);
+  let i;
+
+  let maxY = 0;
+  let minY = Number.MIN_VALUE;
+  const boxes = labels.map((label) => {
+    if (label.y > maxY) {
+      maxY = label.y;
+    }
+    if (label.y < minY) {
+      minY = label.y;
+    }
+    return {
+      size: lineHeight,
+      targets: [label.y - startY],
+      pos: null,
+    };
+  });
+  minY -= startY;
+  if (maxY - startY > totalHeight) {
+    totalHeight = maxY - startY;
+  }
+
+  while (overlapping) {
+    /* eslint no-loop-func: 0 */
+    boxes.forEach((box) => {
+      const target = (Math.min.apply(minY, box.targets) + Math.max.apply(minY, box.targets)) / 2;
+      box.pos = Math.min(Math.max(minY, target - box.size / 2), totalHeight - box.size);
+      // box.pos = Math.max(0, target - box.size / 2);
+    });
+
+    // detect overlapping and join boxes
+    overlapping = false;
+    i = boxes.length;
+    while (i--) {
+      if (i > 0) {
+        const previousBox = boxes[i - 1];
+        const box = boxes[i];
+        if (previousBox.pos + previousBox.size > box.pos) {
+          // overlapping
+          previousBox.size += box.size;
+          previousBox.targets = previousBox.targets.concat(box.targets);
+
+          // overflow, shift up
+          if (previousBox.pos + previousBox.size > totalHeight) {
+            previousBox.pos = totalHeight - previousBox.size;
+          }
+          boxes.splice(i, 1); // removing box
+          overlapping = true;
+        }
+      }
+    }
+  }
+
+  i = 0;
+  // step 4: normalize y and adjust x
+  boxes.forEach((b) => {
+    let posInCompositeBox = startY + lineHeight / 2; // middle of the label
+    b.targets.forEach(() => {
+      labels[i].y = b.pos + posInCompositeBox;
+      posInCompositeBox += lineHeight;
+      i++;
+    });
+  });
+
+  // (x - cx)^2 + (y - cy)^2 = totalR^2
+  labels.forEach((label) => {
+    const rPow2 = label.r * label.r;
+    const dyPow2 = Math.pow(Math.abs(label.y - center.y), 2);
+    if (rPow2 < dyPow2) {
+      label.x = center.x;
+    } else {
+      const dx = Math.sqrt(rPow2 - dyPow2);
+      if (!isRight) {
+        // left
+        label.x = center.x - dx;
+      } else {
+        // right
+        label.x = center.x + dx;
+      }
+    }
+  });
+
+  labels.forEach((label) => {
+    const labelGroup = find(labelGroups, (group) => group.get('id') === label.id);
+    const coordinate = labelGroup.get('coordinate');
+    const coordRadius = coordinate.getRadius();
+    if (labelGroup) {
+      const labelShape = labelGroup.getChildren()[0];
+      const labelLineShape = labelGroup.getChildren()[1];
+      if (labelShape) {
+        labelShape.attr('x', label.x);
+        labelShape.attr('y', label.y);
+      }
+      if (labelLineShape) {
+        const distance = label.offset;
+        const angle = label.angle;
+        // 贴近圆周
+        const startPoint = getEndPoint(center, angle, coordRadius);
+        const inner = getEndPoint(center, angle, coordRadius + distance / 2);
+        const endPoint = {
+          x: label.x - Math.cos(angle) * MARGIN,
+          y: label.y - Math.sin(angle) * MARGIN,
+        };
+        labelLineShape.attr('path', [`M ${startPoint.x}`, `${startPoint.y} Q${inner.x}`, `${inner.y} ${endPoint.x}`, endPoint.y].join(','));
+      }
+    }
+  });
+}
+
+/**
+ * pie outer-label: distribute algorithm
+ */
+export function distribute(labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+  const offset = labels[0] ? labels[0].get('labelItem').offset : 0;
+  const lineHeight = labels[0] ? labels[0].get('labelItem').labelHeight : 14;
+  const coordinate = labels[0] ? labels[0].get('coordinate') : null;
+  if (coordinate && offset > 0) {
+    // @ts-ignore
+    const radius = coordinate.getRadius();
+    const center = coordinate.getCenter();
+    const totalR = radius + offset;
+    const totalHeight = totalR * 2 + lineHeight * 2;
+    const plotRange = {
+      start: coordinate.start,
+      end: coordinate.end,
+    };
+
+    // step 1: separate labels
+    const halves = [
+      [], // left
+      [], // right
+    ];
+    labels.forEach((label) => {
+      if (!label) {
+        return;
+      }
+      if (label.getChildren()[0].attr('textAlign') === 'right') {
+        // left
+        halves[0].push(label);
+      } else {
+        // right or center will be put on the right side
+        halves[1].push(label);
+      }
+    });
+
+    halves.forEach((half, index) => {
+      // step 2: reduce labels
+      const maxLabelsCountForOneSide = Math.floor(totalHeight / lineHeight);
+      if (half.length > maxLabelsCountForOneSide) {
+        half.sort((a, b) => {
+          // sort by percentage DESC
+          return b['..percent'] - a['..percent'];
+        });
+        half.forEach((label, idx) => {
+          if (idx >= maxLabelsCountForOneSide) {
+            label.remove(true); // 超出则不展示
+          }
+        });
+        // 同时移除
+        half.splice(maxLabelsCountForOneSide, half.length - maxLabelsCountForOneSide);
+      }
+
+      // step 3: distribute position (x and y)
+      half.sort((a, b) => {
+        // sort by y ASC
+        return a.get('labelItem').y - b.get('labelItem').y;
+      });
+      antiCollision(half, lineHeight, plotRange, center, index);
+    });
+  }
+}

--- a/src/geometry/label/layout/limit-in-canvas.ts
+++ b/src/geometry/label/layout/limit-in-canvas.ts
@@ -1,6 +1,7 @@
 import { each } from '@antv/util';
 import { BBox, IGroup, IShape } from '../../../dependents';
 import { translate } from '../../../util/transform';
+import { LabelItem } from '../interface';
 
 /**
  * @ignore
@@ -8,7 +9,7 @@ import { translate } from '../../../util/transform';
  * @param labels
  * @param cfg
  */
-export function limitInCanvas(labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+export function limitInCanvas(labels: IGroup[], shapes: IShape[] | IGroup[], items: LabelItem[], region: BBox) {
   each(labels, (label: IGroup) => {
     const { minX: regionMinX, minY: regionMinY, maxX: regionMaxX, maxY: regionMaxY } = region;
     const { minX, minY, maxX, maxY, x, y, width, height } = label.getCanvasBBox();

--- a/src/geometry/label/layout/limit-in-shape.ts
+++ b/src/geometry/label/layout/limit-in-shape.ts
@@ -5,7 +5,7 @@ import { BBox, IGroup, IShape } from '../../../dependents';
  * @ignore
  * 根据图形元素以及 label 的 bbox 进行调整，如果 label 超出了 shape 的 bbox 则不展示
  */
-export function limitInShape(labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+export function limitInShape(labels: IGroup[], shapes: IShape[] | IGroup[], items, region: BBox) {
   each(labels, (label, index) => {
     const labelBBox = label.getCanvasBBox(); // 文本有可能发生旋转
     const shapeBBox = shapes[index].getBBox();

--- a/src/geometry/label/layout/overlap.ts
+++ b/src/geometry/label/layout/overlap.ts
@@ -1,5 +1,6 @@
 import { each } from '@antv/util';
 import { BBox, IGroup, IShape } from '../../../dependents';
+import { LabelItem } from '../interface';
 
 const MAX_TIMES = 100;
 
@@ -211,7 +212,7 @@ function adjustLabelPosition(label: IShape, x: number, y: number, index: number)
  * 不同于 'overlap' 类型的布局，该布局不会对 label 的位置进行偏移调整。
  * @param labels 参与布局调整的 label 数组集合
  */
-export function fixedOverlap(labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+export function fixedOverlap(labels: IGroup[], shapes: IShape[] | IGroup[], items: LabelItem[], region: BBox) {
   const greedy = new Greedy();
   each(labels, (label: IGroup) => {
     const labelShape = label.find((shape) => shape.get('type') === 'text') as IShape;
@@ -227,7 +228,7 @@ export function fixedOverlap(labels: IGroup[], shapes: IShape[] | IGroup[], regi
  * label 防遮挡布局：为了防止 label 之间相互覆盖同时保证尽可能多 的 label 展示，通过尝试将 label 向**四周偏移**来剔除放不下的 label
  * @param labels 参与布局调整的 label 数组集合
  */
-export function overlap(labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+export function overlap(labels: IGroup[], shapes: IShape[] | IGroup[], items: LabelItem[], region: BBox) {
   const greedy = new Greedy();
   each(labels, (label: IGroup) => {
     const labelShape = label.find((shape) => shape.get('type') === 'text') as IShape;

--- a/src/geometry/label/pie.ts
+++ b/src/geometry/label/pie.ts
@@ -14,95 +14,6 @@ function getEndPoint(center, angle, r) {
   };
 }
 
-function antiCollision(labels, lineHeight, plotRange, center, isRight) {
-  // adjust y position of labels to avoid overlapping
-  let overlapping = true;
-  const start = plotRange.start;
-  const end = plotRange.end;
-  const startY = Math.min(start.y, end.y);
-  let totalHeight = Math.abs(start.y - end.y);
-  let i;
-
-  let maxY = 0;
-  let minY = Number.MIN_VALUE;
-  const boxes = labels.map((label) => {
-    if (label.y > maxY) {
-      maxY = label.y;
-    }
-    if (label.y < minY) {
-      minY = label.y;
-    }
-    return {
-      size: lineHeight,
-      targets: [label.y - startY],
-    };
-  });
-  minY -= startY;
-  if (maxY - startY > totalHeight) {
-    totalHeight = maxY - startY;
-  }
-
-  while (overlapping) {
-    /* eslint no-loop-func: 0 */
-    boxes.forEach((box) => {
-      const target = (Math.min.apply(minY, box.targets) + Math.max.apply(minY, box.targets)) / 2;
-      box.pos = Math.min(Math.max(minY, target - box.size / 2), totalHeight - box.size);
-      // box.pos = Math.max(0, target - box.size / 2);
-    });
-
-    // detect overlapping and join boxes
-    overlapping = false;
-    i = boxes.length;
-    while (i--) {
-      if (i > 0) {
-        const previousBox = boxes[i - 1];
-        const box = boxes[i];
-        if (previousBox.pos + previousBox.size > box.pos) {
-          // overlapping
-          previousBox.size += box.size;
-          previousBox.targets = previousBox.targets.concat(box.targets);
-
-          // overflow, shift up
-          if (previousBox.pos + previousBox.size > totalHeight) {
-            previousBox.pos = totalHeight - previousBox.size;
-          }
-          boxes.splice(i, 1); // removing box
-          overlapping = true;
-        }
-      }
-    }
-  }
-
-  i = 0;
-  // step 4: normalize y and adjust x
-  boxes.forEach((b) => {
-    let posInCompositeBox = startY + lineHeight / 2; // middle of the label
-    b.targets.forEach(() => {
-      labels[i].y = b.pos + posInCompositeBox;
-      posInCompositeBox += lineHeight;
-      i++;
-    });
-  });
-
-  // (x - cx)^2 + (y - cy)^2 = totalR^2
-  labels.forEach((label) => {
-    const rPow2 = label.r * label.r;
-    const dyPow2 = Math.pow(Math.abs(label.y - center.y), 2);
-    if (rPow2 < dyPow2) {
-      label.x = center.x;
-    } else {
-      const dx = Math.sqrt(rPow2 - dyPow2);
-      if (!isRight) {
-        // left
-        label.x = center.x - dx;
-      } else {
-        // right
-        label.x = center.x + dx;
-      }
-    }
-  });
-}
-
 /**
  * 饼图 label
  */
@@ -113,14 +24,6 @@ export default class PieLabel extends PolarLabel {
   }
   protected getDefaultOffset(offset) {
     return offset || 0;
-  }
-
-  protected adjustItems(items: LabelItem[]) {
-    const offset = items[0] ? items[0].offset : 0;
-    if (offset > 0) {
-      items = this.distribute(items, offset);
-    }
-    return super.adjustItems(items);
   }
 
   // 连接线
@@ -219,59 +122,5 @@ export default class PieLabel extends PolarLabel {
       angle,
       r,
     };
-  }
-
-  // distribute labels
-  private distribute(labels, offset) {
-    const coordinate = this.coordinate;
-    // @ts-ignore
-    const radius = coordinate.getRadius();
-    const lineHeight = get(this.geometry.theme, ['pieLabels', 'labelHeight'], 14);
-    const center = coordinate.getCenter();
-    const totalR = radius + offset;
-    const totalHeight = totalR * 2 + lineHeight * 2;
-    const plotRange = {
-      start: coordinate.start,
-      end: coordinate.end,
-    };
-
-    // step 1: separate labels
-    const halves = [
-      [], // left
-      [], // right
-    ];
-    labels.forEach((label) => {
-      if (!label) {
-        return;
-      }
-      if (label.textAlign === 'right') {
-        // left
-        halves[0].push(label);
-      } else {
-        // right or center will be put on the right side
-        halves[1].push(label);
-      }
-    });
-
-    halves.forEach((half, index) => {
-      // step 2: reduce labels
-      const maxLabelsCountForOneSide = totalHeight / lineHeight;
-      if (half.length > maxLabelsCountForOneSide) {
-        half.sort((a, b) => {
-          // sort by percentage DESC
-          return b['..percent'] - a['..percent'];
-        });
-        half.splice(maxLabelsCountForOneSide, half.length - maxLabelsCountForOneSide);
-      }
-
-      // step 3: distribute position (x and y)
-      half.sort((a, b) => {
-        // sort by y ASC
-        return a.y - b.y;
-      });
-      antiCollision(half, lineHeight, plotRange, center, index);
-    });
-
-    return halves[0].concat(halves[1]);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ registerGeometryLabel('polar', PolarLabel);
 
 // 注册 Geometry label 内置的布局函数
 import { registerGeometryLabelLayout } from './core';
+import { distribute } from './geometry/label/layout/distribute';
 import { limitInCanvas } from './geometry/label/layout/limit-in-canvas';
 import { limitInShape } from './geometry/label/layout/limit-in-shape';
 import { fixedOverlap, overlap } from './geometry/label/layout/overlap';
@@ -84,6 +85,7 @@ registerGeometryLabelLayout('overlap', overlap);
 registerGeometryLabelLayout('fixed-overlap', fixedOverlap);
 registerGeometryLabelLayout('limit-in-shape', limitInShape);
 registerGeometryLabelLayout('limit-in-canvas', limitInCanvas);
+registerGeometryLabelLayout('distribute', distribute);
 
 // 注册需要的动画执行函数
 import { fadeIn, fadeOut } from './animate/animation/fade';

--- a/tests/unit/geometry/label/labels-spec.ts
+++ b/tests/unit/geometry/label/labels-spec.ts
@@ -259,8 +259,8 @@ describe('LabelsRenderer', () => {
 
     const labelsContainer = interval.labelsContainer;
     expect(labelsContainer.getCount()).toBe(2);
-    const femaleLabel = labelsContainer.getChildren()[0];
-    const maleLabel = labelsContainer.getChildren()[1];
+    const femaleLabel = labelsContainer.getChildren()[1];
+    const maleLabel = labelsContainer.getChildren()[0];
     // @ts-ignore
     expect(femaleLabel.getFirst().get('type')).toBe('text');
     // @ts-ignore

--- a/tests/unit/geometry/label/layout/limit-in-canvas-spec.ts
+++ b/tests/unit/geometry/label/layout/limit-in-canvas-spec.ts
@@ -89,7 +89,7 @@ describe('GeometryLabel layout', () => {
     expect(canvas.getCanvasBBox().minX).toBeLessThan(0);
 
     // @ts-ignore
-    limitInCanvas(canvas.getChildren(), [], region);
+    limitInCanvas(canvas.getChildren(), [], [], region);
     canvas.draw();
     expect(canvas.getChildren().length).toBe(7);
     expect(canvas.getCanvasBBox().minX).toBe(0);

--- a/tests/unit/geometry/label/pie-spec.ts
+++ b/tests/unit/geometry/label/pie-spec.ts
@@ -180,20 +180,25 @@ describe('pie labels', () => {
     it('points', () => {
       const items = gLabels.getLabelItems(points);
       expect(items.length).toBe(points.length);
-      expect(items[0].x).toBe(230);
+      const center = { x: 250, y: 100 };
+      const radius = 50 + 10/** offset */;
+      const angle = Math.PI * 2 / 6;
+      const startAngle = angle / 2;
+      expect(items[0].r).toBe(radius);
+      expect(items[0].x).toBe(center.x + Math.sin(startAngle) * radius + 10/** offsetX */);
+      expect(items[0].y).toBe(center.y - Math.cos(startAngle) * radius - 10/** offsetY */);
       expect(items[0].labelLine).toBe(false);
-      expect(isNumberEqual(items[0].y, 48.03847577293368 - 10)).toBeTruthy();
 
-      expect(items[1].x).toBe(200);
+      expect(items[1].x).toBe(center.x + Math.sin(startAngle + angle) * radius + 10);
+      expect(items[1].y).toBe(center.y - Math.cos(startAngle + angle) * radius - 10/** offsetY */);
       expect(items[1].labelLine).toBe(false);
-      expect(isNumberEqual(items[1].y, 100 - 10)).toBeTruthy();
 
-      expect(items[2].x).toBe(230.00000000000006);
+      expect(items[2].x).toBeCloseTo(center.x + Math.sin(startAngle + angle * 2) * radius + 10);
+      expect(items[2].y).toBe(center.y - Math.cos(startAngle + angle * 2) * radius - 10/** offsetY */);
       expect(items[2].labelLine).toBe(false);
-      expect(isNumberEqual(items[2].y, 151.96152422706632 - 10)).toBeTruthy();
 
-      expect(items[5].x).toBe(290);
-      expect(isNumberEqual(items[5].y, 151.96152422706632 - 10)).toBeTruthy();
+      expect(items[5].x).toBeCloseTo(center.x + Math.sin(startAngle + angle * 5) * radius + 10);
+      expect(items[5].y).toBeCloseTo(center.y - Math.cos(startAngle + angle * 5) * radius - 10/** offsetY */);
     });
   });
 });


### PR DESCRIPTION
### about
将 pie-label 的 ajustItems 调整至layout处理，由于饼图label 布局中需要使用到 labelItem信息，因此需要将labelItem传递至layoutFn

- [x] 重构
- [x] 测例

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
