### PR TITLE
优化 label 类以及修复相关 BUG

### DIFF
--- a/examples/pie/basic/demo/pie-texture.ts
+++ b/examples/pie/basic/demo/pie-texture.ts
@@ -8,6 +8,7 @@ const data = [
 const chart = new Chart({
   container: 'container',
   autoFit: true,
+  height: 500,
 });
 
 chart.data(data);

--- a/src/chart/controller/annotation.ts
+++ b/src/chart/controller/annotation.ts
@@ -23,7 +23,7 @@ import { COMPONENT_TYPE, DIRECTION, LAYER, VIEW_LIFE_CIRCLE } from '../../consta
 
 import Geometry from '../../geometry/base';
 import Element from '../../geometry/element';
-import { getDistanceToCenter, getPointAngle } from '../../util/coordinate';
+import { getAngleByPoint, getDistanceToCenter } from '../../util/coordinate';
 import { omit } from '../../util/helper';
 import View from '../view';
 import { Controller } from './base';
@@ -528,8 +528,8 @@ export default class Annotation extends Controller<BaseOption[]> {
       const { start, end } = option as ArcOption;
       const sp = this.parsePosition(start);
       const ep = this.parsePosition(end);
-      const startAngle = getPointAngle(coordinate, sp);
-      let endAngle = getPointAngle(coordinate, ep);
+      const startAngle = getAngleByPoint(coordinate, sp);
+      let endAngle = getAngleByPoint(coordinate, ep);
       if (startAngle > endAngle) {
         endAngle = Math.PI * 2 + endAngle;
       }

--- a/src/chart/controller/tooltip.ts
+++ b/src/chart/controller/tooltip.ts
@@ -2,7 +2,7 @@ import { deepMix, each, find, flatten, get, isArray, isEqual, isFunction, mix } 
 import { Crosshair, HtmlTooltip, IGroup } from '../../dependents';
 import Geometry from '../../geometry/base';
 import { MappingDatum, Point, TooltipOption } from '../../interface';
-import { getDistanceToCenter, getPointAngle, isPointInCoordinate } from '../../util/coordinate';
+import { getAngleByPoint, getDistanceToCenter, isPointInCoordinate } from '../../util/coordinate';
 import { polarToCartesian } from '../../util/graphics';
 import { findDataByPoint, getTooltipItems } from '../../util/tooltip';
 import { Controller } from './base';
@@ -397,7 +397,7 @@ export default class Tooltip extends Controller<TooltipOption> {
       }
     } else {
       // 极坐标下 x 轴上的 crosshairs 表现为半径
-      const angle = getPointAngle(coordinate, point);
+      const angle = getAngleByPoint(coordinate, point);
       const center = coordinate.getCenter();
       // @ts-ignore
       const radius = coordinate.getRadius();

--- a/src/component/labels.ts
+++ b/src/component/labels.ts
@@ -167,7 +167,7 @@ export default class Labels {
     if ((content.isGroup && content.isGroup()) || (content.isShape && content.isShape()))  {
       // 如果 content 是 Group 或者 Shape，根据 textAlign 调整位置后，直接将其加入 labelGroup
       const { width, height } = content.getCanvasBBox();
-      const textAlign = cfg.textAlign || 'left';
+      const textAlign = get(cfg, 'textAlign', 'left');
 
       let x = cfg.x;
       const y = cfg.y - (height / 2);
@@ -187,6 +187,7 @@ export default class Labels {
           x: cfg.x,
           y: cfg.y,
           textAlign: cfg.textAlign,
+          textBaseline: get(cfg, 'textBaseline', 'middle'),
           text: cfg.content,
           ...cfg.style,
         },

--- a/src/component/labels.ts
+++ b/src/component/labels.ts
@@ -188,7 +188,6 @@ export default class Labels {
 
       translate(content, x, y); // 将 label 平移至 x, y 指定的位置
       labelShape = content;
-      content.set('_name', 'labelContent');
       labelGroup.add(content);
     } else {
       labelShape = labelGroup.addShape('text', {
@@ -201,7 +200,6 @@ export default class Labels {
           ...cfg.style,
         },
         ...shapeAppendCfg,
-        _name: 'labelContent',
       });
     }
 
@@ -282,12 +280,14 @@ export default class Labels {
         const id = item.id;
         const labelGroup = this.shapesMap[id];
         if (!labelGroup.destroyed) {
-          const labelShape = labelGroup.find(ele => ele.get('_name') === 'labelContent');
-          if (item.offsetX) {
-            labelShape.attr('x', labelShape.attr('x') + item.offsetX);
-          }
-          if (item.offsetY) {
-            labelShape.attr('y', labelShape.attr('y') + item.offsetY);
+          const labelShape = labelGroup.find(ele => ele.get('type') === 'text');
+          if (labelShape) {
+            if (item.offsetX) {
+              labelShape.attr('x', labelShape.attr('x') + item.offsetX);
+            }
+            if (item.offsetY) {
+              labelShape.attr('y', labelShape.attr('y') + item.offsetY);
+            }
           }
         }
       }

--- a/src/geometry/label/base.ts
+++ b/src/geometry/label/base.ts
@@ -219,6 +219,7 @@ export default class GeometryLabel {
     }
 
     if (labelCfg.position) {
+      // 如果 label 支持 position 属性
       this.setLabelPosition(label, mappingData, index, labelCfg.position);
     }
     const offsetPoint = this.getLabelOffset(labelCfg, index, total);

--- a/src/geometry/label/base.ts
+++ b/src/geometry/label/base.ts
@@ -260,6 +260,10 @@ export default class GeometryLabel {
     return align;
   }
 
+  /**
+   * 获取每一个 label 的唯一 id
+   * @param mappingData label 对应的图形的绘制数据
+   */
   protected getLabelId(mappingData: MappingDatum) {
     const geometry = this.geometry;
     const type = geometry.type;

--- a/src/geometry/label/index.ts
+++ b/src/geometry/label/index.ts
@@ -1,15 +1,17 @@
 import { BBox, IGroup, IShape } from '../../dependents';
 import { LooseObject } from '../../interface';
 import { GeometryLabelConstructor } from './base';
+import { LabelItem } from './interface';
 
 /**
  * label 布局函数定义
+ * @param items 存储每个 label 的详细信息
  * @param labels 所有的 labels 图形实例
  * @param shapes 所有 label 对应的图形元素实例
  * @param region 画布区域
  * @param cfg 用于存储各个布局函数开放给用户的配置数据
  */
-type GeometryLabelsLayoutFn = (labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox, cfg?: LooseObject) => void;
+type GeometryLabelsLayoutFn = (items: LabelItem[], labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox, cfg?: LooseObject) => void;
 
 const GEOMETRY_LABELS_MAP: Record<string, GeometryLabelConstructor> = {};
 const GEOMETRY_LABELS_LAYOUT_MAP: Record<string, GeometryLabelsLayoutFn>  = {};

--- a/src/geometry/label/interface.ts
+++ b/src/geometry/label/interface.ts
@@ -17,6 +17,7 @@ export interface LabelPointCfg {
   color?: string;
   content?: any;
   textAlign?: TextAlign;
+  textBaseline?: string;
   rotate?: number;
   angle?: number;
   r?: number;
@@ -33,6 +34,7 @@ export interface LabelItem extends GeometryLabelCfg {
   color?: string;
   content?: any;
   textAlign?: TextAlign;
+  textBaseline?: string;
   rotate?: number;
   angle?: number;
   r?: number;

--- a/src/geometry/label/interval.ts
+++ b/src/geometry/label/interval.ts
@@ -1,3 +1,5 @@
+import { get } from '@antv/util';
+
 import { MappingDatum, Point } from '../../interface';
 import GeometryLabel from './base';
 import { LabelPointCfg } from './interface';
@@ -12,41 +14,36 @@ export default class IntervalLabel extends GeometryLabel {
     const shapePoints = mappingData.points as Point[];
     const point0 = coordinate.convert(shapePoints[0]);
     const point1 = coordinate.convert(shapePoints[2]);
-    const width = ((point0.x - point1.x) / 2) * (transposed ? -1 : 1);
-    const height = ((point0.y - point1.y) / 2) * (transposed ? -1 : 1);
+    const flag = transposed ? -1 : 1;
+    const width = ((point0.x - point1.x) / 2) * flag;
+    const height = ((point0.y - point1.y) / 2) * flag;
 
     switch (position) {
       case 'right':
-        if (transposed) {
+        if (!transposed) {
           labelPointCfg.x -= width;
           labelPointCfg.y += height;
-          labelPointCfg.textAlign = labelPointCfg.textAlign || 'center';
-        } else {
-          labelPointCfg.x -= width;
-          labelPointCfg.y += height;
-          labelPointCfg.textAlign = labelPointCfg.textAlign || 'left';
         }
+        labelPointCfg.textAlign = get(labelPointCfg, 'textAlign', 'left');
         break;
       case 'left':
         if (transposed) {
-          labelPointCfg.x -= width;
-          labelPointCfg.y -= height;
-          labelPointCfg.textAlign = labelPointCfg.textAlign || 'center';
+          labelPointCfg.x -= width * 2;
         } else {
           labelPointCfg.x += width;
           labelPointCfg.y += height;
-          labelPointCfg.textAlign = labelPointCfg.textAlign || 'right';
         }
+        labelPointCfg.textAlign = get(labelPointCfg, 'textAlign', 'right');
         break;
       case 'bottom':
         if (transposed) {
-          labelPointCfg.x -= width * 2;
-          labelPointCfg.textAlign = labelPointCfg.textAlign || 'left';
+          labelPointCfg.x -= width;
+          labelPointCfg.y -= height;
         } else {
           labelPointCfg.y += height * 2;
-          labelPointCfg.textAlign = labelPointCfg.textAlign || 'center';
         }
-
+        labelPointCfg.textAlign = get(labelPointCfg, 'textAlign', 'center');
+        labelPointCfg.textBaseline = get(labelPointCfg, 'textBaseline', 'top');
         break;
       case 'middle':
         if (transposed) {
@@ -54,14 +51,15 @@ export default class IntervalLabel extends GeometryLabel {
         } else {
           labelPointCfg.y += height;
         }
-        labelPointCfg.textAlign = labelPointCfg.textAlign || 'center';
+        labelPointCfg.textAlign = get(labelPointCfg, 'textAlign', 'center');
         break;
       case 'top':
         if (transposed) {
-          labelPointCfg.textAlign = labelPointCfg.textAlign || 'left';
-        } else {
-          labelPointCfg.textAlign = labelPointCfg.textAlign || 'center';
+          labelPointCfg.x -= width;
+          labelPointCfg.y += height;
         }
+        labelPointCfg.textAlign = get(labelPointCfg, 'textAlign', 'center');
+        labelPointCfg.textBaseline = get(labelPointCfg, 'textBaseline', 'bottom');
         break;
       default:
         break;

--- a/src/geometry/label/interval.ts
+++ b/src/geometry/label/interval.ts
@@ -8,8 +8,9 @@ import { LabelPointCfg } from './interface';
  * 柱状图 label
  */
 export default class IntervalLabel extends GeometryLabel {
+
   protected setLabelPosition(labelPointCfg: LabelPointCfg, mappingData: MappingDatum, index: number, position: string) {
-    const coordinate = this.coordinate;
+    const coordinate = this.getCoordinate();
     const transposed = coordinate.isTransposed;
     const shapePoints = mappingData.points as Point[];
     const point0 = coordinate.convert(shapePoints[0]);

--- a/src/geometry/label/layout/distribute.ts
+++ b/src/geometry/label/layout/distribute.ts
@@ -1,0 +1,188 @@
+import { isObject, each, get } from '@antv/util';
+
+import { BBox, IGroup, IShape  } from '../../../dependents';
+import { LabelItem } from '../interface';
+
+import { polarToCartesian } from '../../../util/graphics';
+
+/** label text和line距离 4px */
+const MARGIN = 4;
+
+function antiCollision(labelShapes, labels, lineHeight, plotRange, center, isRight) {
+  // adjust y position of labels to avoid overlapping
+  let overlapping = true;
+  const start = plotRange.start;
+  const end = plotRange.end;
+  const startY = Math.min(start.y, end.y);
+  let totalHeight = Math.abs(start.y - end.y);
+  let i;
+
+  let maxY = 0;
+  let minY = Number.MIN_VALUE;
+  const boxes = labels.map((label) => {
+    if (label.y > maxY) {
+      maxY = label.y;
+    }
+    if (label.y < minY) {
+      minY = label.y;
+    }
+    return {
+      size: lineHeight,
+      targets: [label.y - startY],
+    };
+  });
+  minY -= startY;
+  if (maxY - startY > totalHeight) {
+    totalHeight = maxY - startY;
+  }
+
+  while (overlapping) {
+    /* eslint no-loop-func: 0 */
+    boxes.forEach((box) => {
+      const target = (Math.min.apply(minY, box.targets) + Math.max.apply(minY, box.targets)) / 2;
+      box.pos = Math.min(Math.max(minY, target - box.size / 2), totalHeight - box.size);
+      // box.pos = Math.max(0, target - box.size / 2);
+    });
+
+    // detect overlapping and join boxes
+    overlapping = false;
+    i = boxes.length;
+    while (i--) {
+      if (i > 0) {
+        const previousBox = boxes[i - 1];
+        const box = boxes[i];
+        if (previousBox.pos + previousBox.size > box.pos) {
+          // overlapping
+          previousBox.size += box.size;
+          previousBox.targets = previousBox.targets.concat(box.targets);
+
+          // overflow, shift up
+          if (previousBox.pos + previousBox.size > totalHeight) {
+            previousBox.pos = totalHeight - previousBox.size;
+          }
+          boxes.splice(i, 1); // removing box
+          overlapping = true;
+        }
+      }
+    }
+  }
+
+  i = 0;
+  // step 4: normalize y and adjust x
+  boxes.forEach((b) => {
+    let posInCompositeBox = startY + lineHeight / 2; // middle of the label
+    b.targets.forEach(() => {
+      labels[i].y = b.pos + posInCompositeBox;
+      posInCompositeBox += lineHeight;
+      i++;
+    });
+  });
+
+  const labelsMap = {};
+  for (const labelShape of labelShapes) {
+    labelsMap[labelShape.get('id')] = labelShape;
+  }
+
+  // (x - cx)^2 + (y - cy)^2 = totalR^2
+  labels.forEach((label) => {
+    const rPow2 = label.r * label.r;
+    const dyPow2 = Math.pow(Math.abs(label.y - center.y), 2);
+    if (rPow2 < dyPow2) {
+      label.x = center.x;
+    } else {
+      const dx = Math.sqrt(rPow2 - dyPow2);
+      if (!isRight) {
+        // left
+        label.x = center.x - dx;
+      } else {
+        // right
+        label.x = center.x + dx;
+      }
+    }
+
+    // adjust labelShape
+    const labelShape = labelsMap[label.id];
+    labelShape.attr('x', label.x);
+    labelShape.attr('y', label.y);
+  });
+}
+
+export function distribute(items: LabelItem[], labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+  const offset = items[0] ? items[0].offset : 0;
+  const coordinate = labels[0].get('coordinate');
+  // @ts-ignore
+  const radius = coordinate.getRadius();
+  const center = coordinate.getCenter();
+
+  if (offset > 0) {
+    // const lineHeight = get(this.geometry.theme, ['pieLabels', 'labelHeight'], 14);
+    const lineHeight = 14; // TODO
+    const totalR = radius + offset;
+    const totalHeight = totalR * 2 + lineHeight * 2;
+    const plotRange = {
+      start: coordinate.start,
+      end: coordinate.end,
+    };
+
+    // step 1: separate labels
+    const halves = [
+      [], // left
+      [], // right
+    ];
+    items.forEach((labelItem) => {
+      if (!labelItem) {
+        return;
+      }
+      if (labelItem.textAlign === 'right') {
+        // left
+        halves[0].push(labelItem);
+      } else {
+        // right or center will be put on the right side
+        halves[1].push(labelItem);
+      }
+    });
+
+    halves.forEach((half, index) => {
+      // step 2: reduce labels
+      const maxLabelsCountForOneSide = totalHeight / lineHeight;
+      if (half.length > maxLabelsCountForOneSide) {
+        half.sort((a, b) => {
+          // sort by percentage DESC
+          return b['..percent'] - a['..percent'];
+        });
+        half.splice(maxLabelsCountForOneSide, half.length - maxLabelsCountForOneSide);
+      }
+
+      // step 3: distribute position (x and y)
+      half.sort((a, b) => {
+        // sort by y ASC
+        return a.y - b.y;
+      });
+
+
+      antiCollision(labels, half, lineHeight, plotRange, center, index);
+    });
+  }
+
+  // 配置 labelLine
+  each(items, item => {
+    if (item && item.labelLine) {
+      const distance = item.offset;
+      const angle = item.angle;
+      // 贴近圆周
+      const startPoint = polarToCartesian(center.x, center.y, radius, angle);
+      const innerPoint = polarToCartesian(center.x, center.y, radius + distance / 2, angle);
+      const itemX = item.x + get(item, 'offsetX', 0);
+      const itemY = item.y + get(item, 'offsetY', 0);
+      const endPoint = {
+        x: itemX - Math.cos(angle) * MARGIN,
+        y: itemY - Math.sin(angle) * MARGIN,
+      };
+      if (!isObject(item.labelLine)) {
+        // labelLine: true
+        item.labelLine = {};
+      }
+      item.labelLine.path = [`M ${startPoint.x}`, `${startPoint.y} Q${innerPoint.x}`, `${innerPoint.y} ${endPoint.x}`, endPoint.y].join(',');
+    }
+  });
+}

--- a/src/geometry/label/layout/limit-in-canvas.ts
+++ b/src/geometry/label/layout/limit-in-canvas.ts
@@ -1,6 +1,7 @@
 import { each } from '@antv/util';
 import { BBox, IGroup, IShape } from '../../../dependents';
 import { translate } from '../../../util/transform';
+import { LabelItem } from '../interface';
 
 /**
  * @ignore
@@ -8,7 +9,7 @@ import { translate } from '../../../util/transform';
  * @param labels
  * @param cfg
  */
-export function limitInCanvas(labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+export function limitInCanvas(items: LabelItem[], labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
   each(labels, (label: IGroup) => {
     const { minX: regionMinX, minY: regionMinY, maxX: regionMaxX, maxY: regionMaxY } = region;
     const { minX, minY, maxX, maxY, x, y, width, height } = label.getCanvasBBox();

--- a/src/geometry/label/layout/limit-in-shape.ts
+++ b/src/geometry/label/layout/limit-in-shape.ts
@@ -1,11 +1,12 @@
 import { each } from '@antv/util';
 import { BBox, IGroup, IShape } from '../../../dependents';
+import { LabelItem } from '../interface';
 
 /**
  * @ignore
  * 根据图形元素以及 label 的 bbox 进行调整，如果 label 超出了 shape 的 bbox 则不展示
  */
-export function limitInShape(labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+export function limitInShape(items: LabelItem[], labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
   each(labels, (label, index) => {
     const labelBBox = label.getCanvasBBox(); // 文本有可能发生旋转
     const shapeBBox = shapes[index].getBBox();

--- a/src/geometry/label/layout/overlap.ts
+++ b/src/geometry/label/layout/overlap.ts
@@ -1,5 +1,6 @@
 import { each } from '@antv/util';
 import { BBox, IGroup, IShape } from '../../../dependents';
+import { LabelItem } from '../interface';
 
 const MAX_TIMES = 100;
 
@@ -211,7 +212,7 @@ function adjustLabelPosition(label: IShape, x: number, y: number, index: number)
  * 不同于 'overlap' 类型的布局，该布局不会对 label 的位置进行偏移调整。
  * @param labels 参与布局调整的 label 数组集合
  */
-export function fixedOverlap(labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+export function fixedOverlap(items: LabelItem[], labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
   const greedy = new Greedy();
   each(labels, (label: IGroup) => {
     const labelShape = label.find((shape) => shape.get('type') === 'text') as IShape;
@@ -227,7 +228,7 @@ export function fixedOverlap(labels: IGroup[], shapes: IShape[] | IGroup[], regi
  * label 防遮挡布局：为了防止 label 之间相互覆盖同时保证尽可能多 的 label 展示，通过尝试将 label 向**四周偏移**来剔除放不下的 label
  * @param labels 参与布局调整的 label 数组集合
  */
-export function overlap(labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+export function overlap(items: LabelItem[], labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
   const greedy = new Greedy();
   each(labels, (label: IGroup) => {
     const labelShape = label.find((shape) => shape.get('type') === 'text') as IShape;

--- a/src/geometry/label/pie.ts
+++ b/src/geometry/label/pie.ts
@@ -1,18 +1,12 @@
 import { get, isArray, isObject } from '@antv/util';
 import { getAngleByPoint } from '../../util/coordinate';
+import { polarToCartesian } from '../../util/graphics';
 import Geometry from '../base';
 import { LabelItem } from './interface';
 import PolarLabel from './polar';
 
 /** label text和line距离 4px */
 const MARGIN = 4;
-
-function getEndPoint(center, angle, r) {
-  return {
-    x: center.x + r * Math.cos(angle),
-    y: center.y + r * Math.sin(angle),
-  };
-}
 
 function antiCollision(labels, lineHeight, plotRange, center, isRight) {
   // adjust y position of labels to avoid overlapping
@@ -132,8 +126,8 @@ export default class PieLabel extends PolarLabel {
     const angle = label.angle;
     const center = coordinate.getCenter();
     // 贴近圆周
-    const start = getEndPoint(center, angle, r);
-    const inner = getEndPoint(center, angle, r + distance / 2);
+    const start = polarToCartesian(center.x, center.y, r, angle);
+    const inner = polarToCartesian(center.x, center.y, r + distance / 2, angle);
     const end = {
       x: label.x - Math.cos(angle) * MARGIN,
       y: label.y - Math.sin(angle) * MARGIN,
@@ -209,13 +203,13 @@ export default class PieLabel extends PolarLabel {
     return angle;
   }
 
-  public getCirclePoint(angle, offset, p?) {
+  protected getCirclePoint(angle, offset, p?) {
     const coordinate = this.coordinate;
     const center = coordinate.getCenter();
     // @ts-ignore
     const r = coordinate.getRadius() + offset;
     return {
-      ...getEndPoint(center, angle, r),
+      ...polarToCartesian(center.x, center.y, r, angle),
       angle,
       r,
     };

--- a/src/geometry/label/pie.ts
+++ b/src/geometry/label/pie.ts
@@ -103,8 +103,12 @@ function antiCollision(labels, lineHeight, plotRange, center, isRight) {
 export default class PieLabel extends PolarLabel {
   constructor(geometry: Geometry) {
     super(geometry);
-    this.defaultLabelCfg = get(geometry.theme, 'pieLabels', {});
   }
+
+  protected getDefaultLabelCfg() {
+    return get(this.geometry.theme, 'pieLabels', {});
+  }
+
   protected getDefaultOffset(offset) {
     return offset || 0;
   }
@@ -119,7 +123,7 @@ export default class PieLabel extends PolarLabel {
 
   // 连接线
   protected lineToLabel(label: LabelItem) {
-    const coordinate = this.coordinate;
+    const coordinate = this.getCoordinate();
     // @ts-ignore
     const r = coordinate.getRadius();
     const distance = label.offset;
@@ -154,7 +158,7 @@ export default class PieLabel extends PolarLabel {
   }
 
   protected getLabelAlign(point: LabelItem) {
-    const coordinate = this.coordinate;
+    const coordinate = this.getCoordinate();
     const center = coordinate.getCenter();
 
     let align;
@@ -179,7 +183,7 @@ export default class PieLabel extends PolarLabel {
   }
 
   protected getPointAngle(point) {
-    const coordinate = this.coordinate;
+    const coordinate = this.getCoordinate();
     const startPoint = {
       x: isArray(point.x) ? point.x[0] : point.x,
       y: point.y[0],
@@ -204,7 +208,7 @@ export default class PieLabel extends PolarLabel {
   }
 
   protected getCirclePoint(angle, offset, p?) {
-    const coordinate = this.coordinate;
+    const coordinate = this.getCoordinate();
     const center = coordinate.getCenter();
     // @ts-ignore
     const r = coordinate.getRadius() + offset;
@@ -217,7 +221,7 @@ export default class PieLabel extends PolarLabel {
 
   // distribute labels
   private distribute(labels, offset) {
-    const coordinate = this.coordinate;
+    const coordinate = this.getCoordinate();
     // @ts-ignore
     const radius = coordinate.getRadius();
     const lineHeight = get(this.geometry.theme, ['pieLabels', 'labelHeight'], 14);

--- a/src/geometry/label/pie.ts
+++ b/src/geometry/label/pie.ts
@@ -1,106 +1,16 @@
-import { get, isArray, isObject } from '@antv/util';
+import { get, isArray } from '@antv/util';
 import { getAngleByPoint } from '../../util/coordinate';
 import { polarToCartesian } from '../../util/graphics';
 import Geometry from '../base';
 import { LabelItem } from './interface';
 import PolarLabel from './polar';
 
-/** label text和line距离 4px */
-const MARGIN = 4;
-
-function antiCollision(labels, lineHeight, plotRange, center, isRight) {
-  // adjust y position of labels to avoid overlapping
-  let overlapping = true;
-  const start = plotRange.start;
-  const end = plotRange.end;
-  const startY = Math.min(start.y, end.y);
-  let totalHeight = Math.abs(start.y - end.y);
-  let i;
-
-  let maxY = 0;
-  let minY = Number.MIN_VALUE;
-  const boxes = labels.map((label) => {
-    if (label.y > maxY) {
-      maxY = label.y;
-    }
-    if (label.y < minY) {
-      minY = label.y;
-    }
-    return {
-      size: lineHeight,
-      targets: [label.y - startY],
-    };
-  });
-  minY -= startY;
-  if (maxY - startY > totalHeight) {
-    totalHeight = maxY - startY;
-  }
-
-  while (overlapping) {
-    /* eslint no-loop-func: 0 */
-    boxes.forEach((box) => {
-      const target = (Math.min.apply(minY, box.targets) + Math.max.apply(minY, box.targets)) / 2;
-      box.pos = Math.min(Math.max(minY, target - box.size / 2), totalHeight - box.size);
-      // box.pos = Math.max(0, target - box.size / 2);
-    });
-
-    // detect overlapping and join boxes
-    overlapping = false;
-    i = boxes.length;
-    while (i--) {
-      if (i > 0) {
-        const previousBox = boxes[i - 1];
-        const box = boxes[i];
-        if (previousBox.pos + previousBox.size > box.pos) {
-          // overlapping
-          previousBox.size += box.size;
-          previousBox.targets = previousBox.targets.concat(box.targets);
-
-          // overflow, shift up
-          if (previousBox.pos + previousBox.size > totalHeight) {
-            previousBox.pos = totalHeight - previousBox.size;
-          }
-          boxes.splice(i, 1); // removing box
-          overlapping = true;
-        }
-      }
-    }
-  }
-
-  i = 0;
-  // step 4: normalize y and adjust x
-  boxes.forEach((b) => {
-    let posInCompositeBox = startY + lineHeight / 2; // middle of the label
-    b.targets.forEach(() => {
-      labels[i].y = b.pos + posInCompositeBox;
-      posInCompositeBox += lineHeight;
-      i++;
-    });
-  });
-
-  // (x - cx)^2 + (y - cy)^2 = totalR^2
-  labels.forEach((label) => {
-    const rPow2 = label.r * label.r;
-    const dyPow2 = Math.pow(Math.abs(label.y - center.y), 2);
-    if (rPow2 < dyPow2) {
-      label.x = center.x;
-    } else {
-      const dx = Math.sqrt(rPow2 - dyPow2);
-      if (!isRight) {
-        // left
-        label.x = center.x - dx;
-      } else {
-        // right
-        label.x = center.x + dx;
-      }
-    }
-  });
-}
-
 /**
  * 饼图 label
  */
 export default class PieLabel extends PolarLabel {
+  public defaultLayout = 'distribute';
+
   constructor(geometry: Geometry) {
     super(geometry);
   }
@@ -111,36 +21,6 @@ export default class PieLabel extends PolarLabel {
 
   protected getDefaultOffset(offset) {
     return offset || 0;
-  }
-
-  protected adjustItems(items: LabelItem[]) {
-    const offset = items[0] ? items[0].offset : 0;
-    if (offset > 0) {
-      items = this.distribute(items, offset);
-    }
-    return super.adjustItems(items);
-  }
-
-  // 连接线
-  protected lineToLabel(label: LabelItem) {
-    const coordinate = this.getCoordinate();
-    // @ts-ignore
-    const r = coordinate.getRadius();
-    const distance = label.offset;
-    const angle = label.angle;
-    const center = coordinate.getCenter();
-    // 贴近圆周
-    const start = polarToCartesian(center.x, center.y, r, angle);
-    const inner = polarToCartesian(center.x, center.y, r + distance / 2, angle);
-    const end = {
-      x: label.x - Math.cos(angle) * MARGIN,
-      y: label.y - Math.sin(angle) * MARGIN,
-    };
-    if (!isObject(label.labelLine)) {
-      // labelLine: true
-      label.labelLine = {};
-    }
-    label.labelLine.path = [`M ${start.x}`, `${start.y} Q${inner.x}`, `${inner.y} ${end.x}`, end.y].join(',');
   }
 
   protected getLabelRotate(angle: number, offset: number, isLabelLimit: boolean) {
@@ -217,59 +97,5 @@ export default class PieLabel extends PolarLabel {
       angle,
       r,
     };
-  }
-
-  // distribute labels
-  private distribute(labels, offset) {
-    const coordinate = this.getCoordinate();
-    // @ts-ignore
-    const radius = coordinate.getRadius();
-    const lineHeight = get(this.geometry.theme, ['pieLabels', 'labelHeight'], 14);
-    const center = coordinate.getCenter();
-    const totalR = radius + offset;
-    const totalHeight = totalR * 2 + lineHeight * 2;
-    const plotRange = {
-      start: coordinate.start,
-      end: coordinate.end,
-    };
-
-    // step 1: separate labels
-    const halves = [
-      [], // left
-      [], // right
-    ];
-    labels.forEach((label) => {
-      if (!label) {
-        return;
-      }
-      if (label.textAlign === 'right') {
-        // left
-        halves[0].push(label);
-      } else {
-        // right or center will be put on the right side
-        halves[1].push(label);
-      }
-    });
-
-    halves.forEach((half, index) => {
-      // step 2: reduce labels
-      const maxLabelsCountForOneSide = totalHeight / lineHeight;
-      if (half.length > maxLabelsCountForOneSide) {
-        half.sort((a, b) => {
-          // sort by percentage DESC
-          return b['..percent'] - a['..percent'];
-        });
-        half.splice(maxLabelsCountForOneSide, half.length - maxLabelsCountForOneSide);
-      }
-
-      // step 3: distribute position (x and y)
-      half.sort((a, b) => {
-        // sort by y ASC
-        return a.y - b.y;
-      });
-      antiCollision(half, lineHeight, plotRange, center, index);
-    });
-
-    return halves[0].concat(halves[1]);
   }
 }

--- a/src/geometry/label/pie.ts
+++ b/src/geometry/label/pie.ts
@@ -1,5 +1,5 @@
 import { get, isArray, isObject } from '@antv/util';
-import { getPointAngle } from '../../util/coordinate';
+import { getAngleByPoint } from '../../util/coordinate';
 import Geometry from '../base';
 import { LabelItem } from './interface';
 import PolarLabel from './polar';
@@ -195,11 +195,11 @@ export default class PieLabel extends PolarLabel {
       y: point.y[1],
     };
     let angle;
-    const startAngle = getPointAngle(coordinate, startPoint);
+    const startAngle = getAngleByPoint(coordinate, startPoint);
     if (point.points && point.points[0].y === point.points[1].y) {
       angle = startAngle;
     } else {
-      let endAngle = getPointAngle(coordinate, endPoint);
+      let endAngle = getAngleByPoint(coordinate, endPoint);
       if (startAngle >= endAngle) {
         // 100% pie slice
         endAngle = endAngle + Math.PI * 2;

--- a/src/geometry/label/polar.ts
+++ b/src/geometry/label/polar.ts
@@ -11,6 +11,11 @@ const HALF_PI = Math.PI / 2;
  * 极坐标下的图形 label
  */
 export default class PolarLabel extends GeometryLabel {
+  /**
+   * @override
+   * 获取文本的对齐方式
+   * @param point
+   */
   protected getLabelAlign(point: LabelItem) {
     const coordinate = this.coordinate;
     let align;
@@ -32,6 +37,13 @@ export default class PolarLabel extends GeometryLabel {
     return align;
   }
 
+  /**
+   * @override
+   * 获取 label 的位置
+   * @param labelCfg
+   * @param mappingData
+   * @param index
+   */
   protected getLabelPoint(labelCfg: LabelCfg, mappingData: MappingDatum, index: number): LabelPointCfg {
     let factor = 1;
     let arcPoint;
@@ -70,6 +82,9 @@ export default class PolarLabel extends GeometryLabel {
     return labelPositionCfg;
   }
 
+  /**
+   * 获取圆弧的位置
+   */
   protected getArcPoint(mappingData: MappingDatum, index: number = 0): Point {
     if (!isArray(mappingData.x) && !isArray(mappingData.y)) {
       return {
@@ -84,11 +99,21 @@ export default class PolarLabel extends GeometryLabel {
     };
   }
 
-  // 获取点所在的角度
+  /**
+   * 计算坐标线点在极坐标系下角度
+   * @param point
+   */
   protected getPointAngle(point: Point): number {
     return getAngleByPoint(this.coordinate, point);
   }
 
+  /**
+   * 获取坐标点与圆心形成的圆的位置信息
+   * @param angle
+   * @param offset
+   * @param point
+   * @param isLabelEmit
+   */
   protected getCirclePoint(angle: number, offset: number, point: Point, isLabelEmit: boolean) {
     const coordinate = this.coordinate;
     const center = coordinate.getCenter();
@@ -115,7 +140,12 @@ export default class PolarLabel extends GeometryLabel {
     };
   }
 
-  // angle 为弧度
+  /**
+   * 获取 label 的旋转角度
+   * @param angle
+   * @param offset
+   * @param isLabelEmit
+   */
   protected getLabelRotate(angle: number, offset: number, isLabelEmit: boolean) {
     let rotate = angle + HALF_PI;
     if (isLabelEmit) {

--- a/src/geometry/label/polar.ts
+++ b/src/geometry/label/polar.ts
@@ -17,7 +17,7 @@ export default class PolarLabel extends GeometryLabel {
    * @param point
    */
   protected getLabelAlign(point: LabelItem) {
-    const coordinate = this.coordinate;
+    const coordinate = this.getCoordinate();
     let align;
     if (point.labelEmit) {
       align = (point.angle <= Math.PI / 2 && point.angle > -Math.PI / 2) ? 'left' : 'right';
@@ -104,7 +104,7 @@ export default class PolarLabel extends GeometryLabel {
    * @param point
    */
   protected getPointAngle(point: Point): number {
-    return getAngleByPoint(this.coordinate, point);
+    return getAngleByPoint(this.getCoordinate(), point);
   }
 
   /**
@@ -115,7 +115,7 @@ export default class PolarLabel extends GeometryLabel {
    * @param isLabelEmit
    */
   protected getCirclePoint(angle: number, offset: number, point: Point, isLabelEmit: boolean) {
-    const coordinate = this.coordinate;
+    const coordinate = this.getCoordinate();
     const center = coordinate.getCenter();
     let r = getDistanceToCenter(coordinate, point);
     if (r === 0) {
@@ -163,7 +163,7 @@ export default class PolarLabel extends GeometryLabel {
 
   // 获取中心的位置
   private getMiddlePoint(points: Point[]) {
-    const coordinate = this.coordinate;
+    const coordinate = this.getCoordinate();
     const count = points.length;
     let middlePoint = {
       x: 0,

--- a/src/geometry/label/polar.ts
+++ b/src/geometry/label/polar.ts
@@ -20,7 +20,7 @@ export default class PolarLabel extends GeometryLabel {
     const coordinate = this.getCoordinate();
     let align;
     if (point.labelEmit) {
-      align = (point.angle <= Math.PI / 2 && point.angle > -Math.PI / 2) ? 'left' : 'right';
+      align = (point.angle <= Math.PI / 2 && point.angle >= -Math.PI / 2) ? 'left' : 'right';
     } else if (!coordinate.isTransposed) {
       align = 'center';
     } else {

--- a/src/geometry/label/polar.ts
+++ b/src/geometry/label/polar.ts
@@ -1,7 +1,7 @@
 import { each, isArray } from '@antv/util';
 import { MappingDatum, Point } from '../../interface';
 import { getDistanceToCenter } from '../../util/coordinate';
-import { getPointAngle } from '../../util/coordinate';
+import { getAngleByPoint } from '../../util/coordinate';
 import GeometryLabel from './base';
 import { LabelCfg, LabelItem, LabelPointCfg } from './interface';
 
@@ -15,11 +15,7 @@ export default class PolarLabel extends GeometryLabel {
     const coordinate = this.coordinate;
     let align;
     if (point.labelEmit) {
-      if (point.angle <= Math.PI / 2 && point.angle > -Math.PI / 2) {
-        align = 'left';
-      } else {
-        align = 'right';
-      }
+      align = (point.angle <= Math.PI / 2 && point.angle > -Math.PI / 2) ? 'left' : 'right';
     } else if (!coordinate.isTransposed) {
       align = 'center';
     } else {
@@ -28,17 +24,9 @@ export default class PolarLabel extends GeometryLabel {
       if (Math.abs(point.x - center.x) < 1) {
         align = 'center';
       } else if (point.angle > Math.PI || point.angle <= 0) {
-        if (offset > 0) {
-          align = 'left';
-        } else {
-          align = 'right';
-        }
+        align = offset > 0 ? 'left' : 'right';
       } else {
-        if (offset > 0) {
-          align = 'right';
-        } else {
-          align = 'left';
-        }
+        align = offset > 0 ? 'right' : 'left';
       }
     }
     return align;
@@ -83,25 +71,22 @@ export default class PolarLabel extends GeometryLabel {
   }
 
   protected getArcPoint(mappingData: MappingDatum, index: number = 0): Point {
-    let arcPoint;
     if (!isArray(mappingData.x) && !isArray(mappingData.y)) {
-      arcPoint = {
+      return {
         x: mappingData.x,
         y: mappingData.y,
       };
-    } else {
-      arcPoint = {
-        x: isArray(mappingData.x) ? mappingData.x[index] : mappingData.x,
-        y: isArray(mappingData.y) ? mappingData.y[index] : mappingData.y,
-      };
     }
 
-    return arcPoint;
+    return {
+      x: isArray(mappingData.x) ? mappingData.x[index] : mappingData.x,
+      y: isArray(mappingData.y) ? mappingData.y[index] : mappingData.y,
+    };
   }
 
   // 获取点所在的角度
   protected getPointAngle(point: Point): number {
-    return getPointAngle(this.coordinate, point);
+    return getAngleByPoint(this.coordinate, point);
   }
 
   protected getCirclePoint(angle: number, offset: number, point: Point, isLabelEmit: boolean) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,11 +76,13 @@ registerGeometryLabel('polar', PolarLabel);
 
 // 注册 Geometry label 内置的布局函数
 import { registerGeometryLabelLayout } from './core';
+import { distribute } from './geometry/label/layout/distribute';
 import { limitInCanvas } from './geometry/label/layout/limit-in-canvas';
 import { limitInShape } from './geometry/label/layout/limit-in-shape';
 import { fixedOverlap, overlap } from './geometry/label/layout/overlap';
 
 registerGeometryLabelLayout('overlap', overlap);
+registerGeometryLabelLayout('distribute', distribute);
 registerGeometryLabelLayout('fixed-overlap', fixedOverlap);
 registerGeometryLabelLayout('limit-in-shape', limitInShape);
 registerGeometryLabelLayout('limit-in-canvas', limitInCanvas);

--- a/src/interaction/action/element/state.ts
+++ b/src/interaction/action/element/state.ts
@@ -1,7 +1,7 @@
 import { each, isNil } from '@antv/util';
 import { ListItem } from '../../../dependents';
 import Element from '../../../geometry/element/';
-import { getCurrentElement, isElementChange, getDelegationObject, getElements, getElementValue, isList, getScaleByField} from '../util';
+import { getCurrentElement, getDelegationObject, getElements, getElementValue, getScaleByField, isElementChange, isList} from '../util';
 import StateBase from './state-base';
 
 function getItem(shape) {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -292,7 +292,7 @@ export interface StateOption {
 };
 
 /** interval label 的位置 */
-type IntervalGeometryLabelPosition = 'top' | 'bottom' | 'middle' | 'left' | 'right';
+export type IntervalGeometryLabelPosition = 'top' | 'bottom' | 'middle' | 'left' | 'right';
 /** G2 提供的 adjust 类型 */
 export type AdjustType = 'stack' | 'jitter' | 'dodge' | 'symmetric';
 /** geometry.color() 图形属性回调函数定义 */
@@ -398,7 +398,7 @@ export type ShapeMarkerSymbol = (x: number, y: number, r: number) => PathCommand
 
 // ============================ Annotation 类型定义 ============================
 /** Annotation position 回调函数 */
-type AnnotationPositionCallback = (
+export type AnnotationPositionCallback = (
   xScales: Scale[] | Record<string, Scale>,
   yScales: Scale[] | Record<string, Scale>
 ) => [number, number];
@@ -503,7 +503,7 @@ export interface RegionFilterOption extends RegionPositionBaseOption {
 
 // ============================ Chart && View 上的类型定义 ============================
 /** Tooltip 内容框的 css 样式定义 */
-interface TooltipDomStyles {
+export interface TooltipDomStyles {
   'g2-tooltip'?: LooseObject;
   'g2-tooltip-title'?: LooseObject;
   'g2-tooltip-list'?: LooseObject;
@@ -514,7 +514,7 @@ interface TooltipDomStyles {
 }
 
 /** 目前组件动画允许的参数配置 */
-interface ComponentAnimateCfg {
+export interface ComponentAnimateCfg {
   /** 动画执行时间 */
   readonly duration?: number;
   /** 动画缓动函数 */
@@ -523,7 +523,7 @@ interface ComponentAnimateCfg {
   readonly delay?: number;
 }
 /** 组件各个动画类型配置 */
-interface ComponentAnimateOption {
+export interface ComponentAnimateOption {
   /** 初入场动画配置 */
   appear?: ComponentAnimateCfg;
   /** 更新动画配置 */
@@ -759,7 +759,7 @@ export interface ComponentOption {
 }
 
 /** Legend marker 的配置结构 */
-interface MarkerCfg extends LegendMarkerCfg {
+export interface MarkerCfg extends LegendMarkerCfg {
   /** 配置图例 marker 的 symbol 形状。 */
   symbol?: Marker | MarkerCallback;
 }
@@ -902,7 +902,7 @@ export interface LegendCfg {
 /**
  * 配置属性详见 {@link https://github.com/antvis/component/blob/81890719a431b3f9088e0c31c4d5d382ef0089df/src/types.ts#L1154|CrosshairTextCfg}，Tooltip Crosshairs 的文本数据结构
  */
-interface TooltipCrosshairsText extends CrosshairTextCfg {
+export interface TooltipCrosshairsText extends CrosshairTextCfg {
   /** crosshairs 文本内容 */
   content?: string;
 }
@@ -915,7 +915,7 @@ interface TooltipCrosshairsText extends CrosshairTextCfg {
  * @param currentPoint 对应当前坐标点
  * @returns 返回当前 crosshairs 对应的辅助线文本配置
  */
-type TooltipCrosshairsTextCallback = (type: string, defaultContent: any, items: any[], currentPoint: Point) => TooltipCrosshairsText;
+export type TooltipCrosshairsTextCallback = (type: string, defaultContent: any, items: any[], currentPoint: Point) => TooltipCrosshairsText;
 /** Tooltip crosshairs 配置结构 */
 export interface TooltipCrosshairs {
   /**
@@ -1116,7 +1116,7 @@ export interface Options {
 }
 
 /** 支持的 Marker 类型 */
-type Marker =
+export type Marker =
   | 'circle'
   | 'square'
   | 'diamond'
@@ -1130,7 +1130,7 @@ type Marker =
   | 'hyphen'
   | 'line';
 /** 自定义 Marker 的回调函数定义 */
-type MarkerCallback = (x: number, y: number, r: number) => PathCommand;
+export type MarkerCallback = (x: number, y: number, r: number) => PathCommand;
 /** chart.tooltip() 参数类型 */
 export type TooltipOption = TooltipCfg | boolean;
 /* 筛选器函数类型定义 */
@@ -1152,10 +1152,10 @@ export type ScaleType =
   'quantize' |
   'quantile';
 
-type CoordinateRotate = ['rotate', number];
-type CoordinateReflect = ['reflect', 'x' | 'y'];
-type CoordinateScale = ['scale', number, number];
-type CoordinateTranspose = ['transpose'];
+export type CoordinateRotate = ['rotate', number];
+export type CoordinateReflect = ['reflect', 'x' | 'y'];
+export type CoordinateScale = ['scale', number, number];
+export type CoordinateTranspose = ['transpose'];
 /** 坐标系支持的 action 配置 */
 export type CoordinateActions = CoordinateRotate | CoordinateReflect | CoordinateScale | CoordinateTranspose;
 

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -1231,7 +1231,6 @@ export function getThemeByStylesheet(styleSheet: StyleSheet) {
       style: {
         fill: styleSheet.labelFillColor,
         fontSize: styleSheet.labelFontSize,
-        textBaseline: 'middle',
         fontFamily: styleSheet.fontFamily,
         stroke: styleSheet.labelBorderColor,
         lineWidth: styleSheet.labelBorder,
@@ -1242,7 +1241,6 @@ export function getThemeByStylesheet(styleSheet: StyleSheet) {
       style: {
         fill: styleSheet.innerLabelFillColor,
         fontSize: styleSheet.innerLabelFontSize,
-        textBaseline: 'middle',
         fontFamily: styleSheet.fontFamily,
         stroke: styleSheet.innerLabelBorderColor,
         lineWidth: styleSheet.innerLabelBorder,

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -1253,7 +1253,7 @@ export function getThemeByStylesheet(styleSheet: StyleSheet) {
       labelLine: {
         style: {
           lineWidth: styleSheet.labelLineBorder,
-          stroke: styleSheet.labelLineBorderColor,
+          // stroke: styleSheet.labelLineBorderColor,
         },
       },
       autoRotate: true,

--- a/src/util/coordinate.ts
+++ b/src/util/coordinate.ts
@@ -76,7 +76,7 @@ export function isPointInCoordinate(coordinate: Coordinate, point: Point) {
  * @ignore
  * 获取点到圆心的连线与水平方向的夹角
  */
-export function getPointAngle(coordinate: Coordinate, point: Point): number {
+export function getAngleByPoint(coordinate: Coordinate, point: Point): number {
   const center = coordinate.getCenter();
   return Math.atan2(point.y - center.y, point.x - center.x);
 }

--- a/tests/unit/geometry/label/base-spec.ts
+++ b/tests/unit/geometry/label/base-spec.ts
@@ -50,8 +50,14 @@ describe('GeometryLabel', () => {
     point.init();
 
     const geometryLabel = new GeometryLabel(point);
+    const labelsContainer = point.labelsContainer;
+
+    it('defaultLayout', () => {
+      expect(geometryLabel.defaultLayout).toBeUndefined();
+    });
 
     it('offset', () => {
+      // @ts-ignore
       const labelItems = geometryLabel.getLabelItems([
         { x: 100, y: 10, _origin: { x: 100, y: 10, z: '1' } },
         { x: 100, y: 20, _origin: { x: 100, y: 20, z: '2' } },
@@ -68,12 +74,15 @@ describe('GeometryLabel', () => {
         offsetX: 10,
         offsetY: 10,
       });
-      const labelItems = geometryLabel.getLabelItems([
+      geometryLabel.render([
         { x: 100, y: 10, _origin: { x: 100, y: 10, z: '1' } },
         { x: 100, y: 20, _origin: { x: 100, y: 20, z: '2' } },
-      ]);
-      expect(labelItems[0].x).toBe(110);
-      expect(labelItems[0].y).toBe(0);
+      ], false);
+
+      // @ts-ignore
+      const labelShape1 = labelsContainer.getChildren()[0].find(ele => ele.get('type') === 'text');
+      expect(labelShape1.attr('x')).toBe(110);
+      expect(labelShape1.attr('y')).toBe(0);
     });
 
     it('one point two labels', () => {
@@ -92,6 +101,7 @@ describe('GeometryLabel', () => {
         }
       );
 
+      // @ts-ignore
       const labelItems = geometryLabel.getLabelItems([
         { x: 100, y: [10, 20], _origin: { x: 100, y: [10, 20], z: ['1', '2'] } },
         { x: 100, y: [30, 40], _origin: { x: 100, y: [30, 40], z: ['3', '4'] } },
@@ -152,6 +162,7 @@ describe('GeometryLabel', () => {
         { x: 100, y: [30, 40], _origin: { x: 100, y: [30, 40], z: ['3', '4'] } },
       ]);
       expect(labelItems.length).toBe(4);
+      expect(labelItems[0].style.fill).toBe('#FFFFFF');
     });
 
     it('stack points', () => {

--- a/tests/unit/geometry/label/chart/funnel-spec.ts
+++ b/tests/unit/geometry/label/chart/funnel-spec.ts
@@ -1,0 +1,171 @@
+import { flatten } from '@antv/util';
+
+import { getCoordinate } from '@antv/coord';
+import { getScale } from '@antv/scale';
+import Interval from '../../../../../src/geometry/interval';
+import IntervalLabel from '../../../../../src/geometry/label/interval';
+import { getTheme } from '../../../../../src/theme/';
+import { createCanvas, createDiv } from '../../../../util/dom';
+import { createScale } from '../../../../util/scale';
+
+const Theme = getTheme('default');
+const CartesianCoordinate = getCoordinate('rect');
+const IdentityScale = getScale('identity');
+
+describe('Funnel chart label', () => {
+  const div = createDiv();
+  const canvas = createCanvas({
+    container: div,
+    width: 300,
+    height: 300,
+  });
+
+  const coord = new CartesianCoordinate({
+    start: { x: 0, y: 150 },
+    end: { x: 150, y: 0 },
+  });
+  coord.transpose().scale(1, -1);
+
+  const pyramidScale = new IdentityScale({
+    field: 'pyramid',
+    values: ['pyramid'],
+    range: [0, 1],
+  });
+  const funnelScale = new IdentityScale({
+    field: 'funnel',
+    values: ['funnel'],
+    range: [0, 1],
+  });
+
+  const data = [
+    { action: '浏览网站', pv: 50000 },
+    { action: '放入购物车', pv: 35000 },
+    { action: '生成订单', pv: 25000 },
+    { action: '支付订单', pv: 15000 },
+    { action: '完成交易', pv: 8000 },
+  ];
+
+  const scales = {
+    action: createScale('action', data),
+    pv: createScale('pv', data),
+    pyramid: pyramidScale,
+    funnel: funnelScale,
+  };
+
+  it('pyramid', () => {
+    const interval = new Interval({
+      data,
+      scales,
+      container: canvas.addGroup(),
+      labelsContainer: canvas.addGroup(),
+      theme: Theme,
+      coordinate: coord,
+    });
+    interval
+      .adjust('symmetric')
+      .position('action*pv')
+      .shape('pyramid')
+      .color('action', ['#0050B3', '#1890FF', '#40A9FF', '#69C0FF', '#BAE7FF'])
+      .label(
+        'action*pv',
+        (action, pv) => {
+          return {
+            content: `${action} ${pv}`,
+          };
+        },
+        {
+          offset: 35,
+          labelLine: {
+            style: {
+              lineWidth: 1,
+              stroke: 'rgba(0, 0, 0, 0.15)',
+            },
+          },
+        }
+      );
+    interval.init();
+    interval.paint();
+
+    // 生成映射数据
+    // @ts-ignore
+    const beforeMappingData = interval.beforeMappingData;
+    // @ts-ignore
+    const dataArray = interval.beforeMapping(beforeMappingData);
+
+    let mappingArray = [];
+    for (const eachGroup of dataArray) {
+      // @ts-ignore
+      const mappingData = interval.mapping(eachGroup);
+      mappingArray.push(mappingData);
+    }
+    mappingArray = flatten(mappingArray);
+
+    const gLabels = new IntervalLabel(interval);
+    const labelItems = gLabels.getLabelItems(mappingArray);
+
+    expect(labelItems[0].x).toBe(173.75);
+    expect(labelItems[0].y).toBe(3.75);
+    expect(labelItems[2].x).toBe(140);
+    expect(labelItems[2].y).toBe(78.75);
+    expect(labelItems[4].x).toBe(116);
+    expect(labelItems[4].y).toBe(150);
+  });
+
+  it('funnel', () => {
+    const interval = new Interval({
+      data,
+      scales,
+      container: canvas.addGroup(),
+      labelsContainer: canvas.addGroup(),
+      theme: Theme,
+      coordinate: coord,
+    });
+    interval
+      .adjust('symmetric')
+      .position('action*pv')
+      .shape('funnel')
+      .color('action', ['#0050B3', '#1890FF', '#40A9FF', '#69C0FF', '#BAE7FF'])
+      .label(
+        'action*pv',
+        (action, pv) => {
+          return {
+            content: `${action} ${pv}`,
+          };
+        },
+        {
+          offset: 35,
+          labelLine: {
+            style: {
+              lineWidth: 1,
+              stroke: 'rgba(0, 0, 0, 0.15)',
+            },
+          },
+        }
+      );
+    interval.init();
+    interval.paint();
+
+    // 生成映射数据
+    // @ts-ignore
+    const beforeMappingData = interval.beforeMappingData;
+    // @ts-ignore
+    const dataArray = interval.beforeMapping(beforeMappingData);
+
+    let mappingArray = [];
+    for (const eachGroup of dataArray) {
+      // @ts-ignore
+      const mappingData = interval.mapping(eachGroup);
+      mappingArray.push(mappingData);
+    }
+    mappingArray = flatten(mappingArray);
+
+    const gLabels = new IntervalLabel(interval);
+    const labelItems = gLabels.getLabelItems(mappingArray);
+    expect(labelItems[0].x).toBe(173.75);
+    expect(labelItems[0].y).toBe(3.75);
+    expect(labelItems[2].x).toBe(140);
+    expect(labelItems[2].y).toBe(78.75);
+    expect(labelItems[4].x).toBe(122);
+    expect(labelItems[4].y).toBe(150);
+  });
+});

--- a/tests/unit/geometry/label/chart/polar-interval-spec.ts
+++ b/tests/unit/geometry/label/chart/polar-interval-spec.ts
@@ -1,0 +1,88 @@
+import { flatten } from '@antv/util';
+
+import { getCoordinate } from '@antv/coord';
+import Interval from '../../../../../src/geometry/interval';
+import PolarLabel from '../../../../../src/geometry/label/polar';
+import { getTheme } from '../../../../../src/theme/';
+import { createCanvas, createDiv } from '../../../../util/dom';
+import { createScale } from '../../../../util/scale';
+
+const Theme = getTheme('default');
+const PolarCoord = getCoordinate('polar');
+
+describe('Interval label in Polar coordinate', () => {
+  const div = createDiv();
+  const canvas = createCanvas({
+    container: div,
+    width: 200,
+    height: 200,
+  });
+
+  const coord = new PolarCoord({
+    start: { x: 0, y: 100 },
+    end: { x: 100, y: 0 },
+  });
+
+  const data = [
+    { year: '1951 年', sales: 38 },
+    { year: '1952 年', sales: 52 },
+    { year: '1956 年', sales: 61 },
+    { year: '1957 年', sales: 145 },
+    { year: '1958 年', sales: 48 },
+    { year: '1959 年', sales: 38 },
+    { year: '1960 年', sales: 38 },
+    { year: '1962 年', sales: 38 },
+  ];
+  const scaleDefs = {
+    sales: {
+      nice: true,
+    },
+  };
+
+  const scales = {
+    year: createScale('year', data, scaleDefs),
+    sales: createScale('sales', data, scaleDefs),
+  };
+
+  const interval = new Interval({
+    data,
+    scales,
+    container: canvas.addGroup(),
+    labelsContainer: canvas.addGroup(),
+    theme: Theme,
+    coordinate: coord,
+    scaleDefs,
+  });
+  interval
+    .position('year*sales')
+    .label('sales', {
+      labelEmit: true,
+    });
+  interval.init();
+  interval.paint();
+
+  // 生成映射数据
+  // @ts-ignore
+  const beforeMappingData = interval.beforeMappingData;
+  // @ts-ignore
+  const dataArray = interval.beforeMapping(beforeMappingData);
+
+  let mappingArray = [];
+  for (const eachGroup of dataArray) {
+    // @ts-ignore
+    const mappingData = interval.mapping(eachGroup);
+    mappingArray.push(mappingData);
+  }
+  mappingArray = flatten(mappingArray);
+
+  it('labels', () => {
+    const gLabels = new PolarLabel(interval);
+    const labelItems = gLabels.getLabelItems(mappingArray);
+
+    expect(labelItems.length).toBe(data.length);
+    expect(labelItems[0].textAlign).toBe('left');
+    expect(labelItems[0].angle).toBeCloseTo(-1.5707963267948966);
+    expect(labelItems[3].angle).toBeCloseTo(1.1219973762820692);
+    expect(labelItems[5].angle).toBeCloseTo(2.9171931783333793);
+  });
+});

--- a/tests/unit/geometry/label/chart/polygon-spec.ts
+++ b/tests/unit/geometry/label/chart/polygon-spec.ts
@@ -1,0 +1,90 @@
+import { flatten } from '@antv/util';
+
+import { getCoordinate } from '@antv/coord';
+import IntervalLabel from '../../../../../src/geometry/label/interval';
+import Polygon from '../../../../../src/geometry/polygon';
+import { getTheme } from '../../../../../src/theme/';
+import { createCanvas, createDiv, removeDom } from '../../../../util/dom';
+
+import 'jest-extended';
+import { createScale } from '../../../../util/scale';
+
+const CartesianCoordinate = getCoordinate('rect');
+const Theme = getTheme('default');
+
+describe('Polygon', () => {
+  const div = createDiv();
+  const canvas = createCanvas({
+    container: div,
+    width: 300,
+    height: 300,
+  });
+  const rectCoord = new CartesianCoordinate({
+    start: { x: 0, y: 300 },
+    end: { x: 300, y: 0 },
+  });
+  const data = [
+    { city: '杭州', sale: 100, category: '电脑' },
+    { city: '广州', sale: 30, category: '电脑' },
+    { city: '上海', sale: 200, category: '鼠标' },
+    { city: '呼和浩特', sale: 10, category: '鼠标' },
+  ];
+
+  const scales = {
+    city: createScale('city', data, {
+      city: {
+        range: [0.125, 0.875],
+      },
+    }),
+    sale: createScale('sale', data),
+    category: createScale('category', data, {
+      category: {
+        range: [0.25, 0.75],
+      },
+    }),
+  };
+
+  const polygon = new Polygon({
+    data,
+    scales,
+    container: canvas.addGroup(),
+    labelsContainer: canvas.addGroup(),
+    theme: Theme,
+    coordinate: rectCoord,
+  });
+
+  polygon.position('city*category').color('sale').label('sale', {
+    offset: 0,
+  });
+  polygon.init();
+  polygon.paint();
+  // 生成映射数据
+  // @ts-ignore
+  const beforeMappingData = polygon.beforeMappingData;
+  // @ts-ignore
+  const dataArray = polygon.beforeMapping(beforeMappingData);
+
+  let mappingArray = [];
+  for (const eachGroup of dataArray) {
+    // @ts-ignore
+    const mappingData = polygon.mapping(eachGroup);
+    mappingArray.push(mappingData);
+  }
+  mappingArray = flatten(mappingArray);
+
+  it('labels', () => {
+    const gLabels = new IntervalLabel(polygon);
+    const labelItems = gLabels.getLabelItems(mappingArray);
+    expect(labelItems[0].x).toBe(37.5);
+    expect(labelItems[0].y).toBe(225);
+
+    expect(labelItems[1].x).toBe(112.5);
+    expect(labelItems[1].y).toBe(225);
+
+    expect(labelItems[2].x).toBe(187.5);
+    expect(labelItems[2].y).toBe(75);
+
+    expect(labelItems[3].x).toBe(262.5);
+    expect(labelItems[3].y).toBe(75);
+  });
+});

--- a/tests/unit/geometry/label/labels-spec.ts
+++ b/tests/unit/geometry/label/labels-spec.ts
@@ -259,8 +259,8 @@ describe('LabelsRenderer', () => {
 
     const labelsContainer = interval.labelsContainer;
     expect(labelsContainer.getCount()).toBe(2);
-    const femaleLabel = labelsContainer.getChildren()[0];
-    const maleLabel = labelsContainer.getChildren()[1];
+    const femaleLabel = labelsContainer.findById('1-女');
+    const maleLabel = labelsContainer.findById('1-男');
     // @ts-ignore
     expect(femaleLabel.getFirst().get('type')).toBe('text');
     // @ts-ignore

--- a/tests/unit/geometry/label/labels-spec.ts
+++ b/tests/unit/geometry/label/labels-spec.ts
@@ -82,7 +82,7 @@ describe('LabelsRenderer', () => {
     it('render', () => {
       expect(interval.labelsContainer.getCount()).toBe(3);
       // @ts-ignore
-      const labelsRenderer = interval.labelsRenderer;
+      const labelsRenderer = interval.geometryLabel.labelsRenderer;
       expect(labelsRenderer.container.getCount()).toBe(3);
       // @ts-ignore
       expect(labelsRenderer.container.getFirst().getCount()).toBe(2);
@@ -113,7 +113,7 @@ describe('LabelsRenderer', () => {
       interval.paint();
 
       // @ts-ignore
-      const labelsRenderer = interval.labelsRenderer;
+      const labelsRenderer = interval.geometryLabel.labelsRenderer;
       expect(labelsRenderer.container.getCount()).toBe(2);
       expect(labelsRenderer.container.find(ele => ele.get('type') === 'text').get('data')).toEqual({ a: '1', percent: 0.5 });
       expect(labelsRenderer.container.find(ele => ele.get('type') === 'text').get('animateCfg').update).toBe(false);
@@ -126,7 +126,7 @@ describe('LabelsRenderer', () => {
 
     it('clear', () => {
       // @ts-ignore
-      const labelsRenderer = interval.labelsRenderer;
+      const labelsRenderer = interval.geometryLabel.labelsRenderer;
       labelsRenderer.clear();
 
       expect(interval.labelsContainer.getCount()).toBe(0);
@@ -137,7 +137,7 @@ describe('LabelsRenderer', () => {
 
     it('destroy', () => {
       // @ts-ignore
-      const labelsRenderer = interval.labelsRenderer;
+      const labelsRenderer = interval.geometryLabel.labelsRenderer;
       labelsRenderer.destroy();
 
       expect(interval.labelsContainer.destroyed).toBe(true);

--- a/tests/unit/geometry/label/layout/limit-in-canvas-spec.ts
+++ b/tests/unit/geometry/label/layout/limit-in-canvas-spec.ts
@@ -89,7 +89,7 @@ describe('GeometryLabel layout', () => {
     expect(canvas.getCanvasBBox().minX).toBeLessThan(0);
 
     // @ts-ignore
-    limitInCanvas(canvas.getChildren(), [], region);
+    limitInCanvas([], canvas.getChildren(), [], region);
     canvas.draw();
     expect(canvas.getChildren().length).toBe(7);
     expect(canvas.getCanvasBBox().minX).toBe(0);

--- a/tests/unit/geometry/label/layout/limit-in-shape-spec.ts
+++ b/tests/unit/geometry/label/layout/limit-in-shape-spec.ts
@@ -23,7 +23,7 @@ describe('GeometryLabel layout', () => {
     ];
 
     // @ts-ignore
-    limitInShape(labels, shapes, {});
+    limitInShape([], labels, shapes, {});
 
     expect(removedCount).toBe(2);
   });

--- a/tests/unit/geometry/label/layout/overlap-spec.ts
+++ b/tests/unit/geometry/label/layout/overlap-spec.ts
@@ -29,7 +29,7 @@ describe('GeometryLabel layout', () => {
     expect(canvas.getChildren().length).toBe(20);
 
     // @ts-ignore
-    fixedOverlap(labels, [], {});
+    fixedOverlap([], labels, [], {});
     canvas.draw();
 
     expect(canvas.getChildren().length).toBeLessThan(20);
@@ -56,7 +56,7 @@ describe('GeometryLabel layout', () => {
     expect(canvas.getChildren().length).toBe(20);
 
     // @ts-ignore
-    overlap(labels, [], {});
+    overlap([], labels, [], {});
     canvas.draw();
 
     expect(canvas.getChildren().length).toBe(9);

--- a/tests/unit/geometry/label/pie-spec.ts
+++ b/tests/unit/geometry/label/pie-spec.ts
@@ -79,6 +79,10 @@ describe('pie labels', () => {
 
     let items;
 
+    it('defaultLayout', () => {
+      expect(gLabels.defaultLayout).toBe('distribute');
+    });
+
     it('get items', () => {
       items = gLabels.getLabelItems(points);
       expect(items.length).toBe(points.length);
@@ -177,23 +181,42 @@ describe('pie labels', () => {
 
     const gLabels = new PieLabel(pointGeom);
 
-    it('points', () => {
+    it('render', () => {
+      gLabels.render(points, false);
+
       const items = gLabels.getLabelItems(points);
-      expect(items.length).toBe(points.length);
-      expect(items[0].x).toBe(230);
+
+      const labels = gLabels.labelsRenderer.container.getChildren();
+      expect(labels.length).toBe(points.length);
+
+      // @ts-ignore
+      const labelText0 = labels[0].find(ele => ele.get('type') === 'text');
+      expect(labelText0.attr('x')).toBe(items[0].x + 10);
+      expect(labelText0.attr('y')).toBe(items[0].y - 10);
+      // @ts-ignore
+      expect(labels[0].getCount()).toBe(1);
       expect(items[0].labelLine).toBe(false);
-      expect(isNumberEqual(items[0].y, 48.03847577293368 - 10)).toBeTruthy();
 
-      expect(items[1].x).toBe(200);
+      // @ts-ignore
+      const labelText1 = labels[1].find(ele => ele.get('type') === 'text');
+      expect(labelText1.attr('x')).toBe(items[1].x + 10);
+      expect(labelText1.attr('y')).toBe(items[1].y - 10);
+      // @ts-ignore
+      expect(labels[1].getCount()).toBe(1);
       expect(items[1].labelLine).toBe(false);
-      expect(isNumberEqual(items[1].y, 100 - 10)).toBeTruthy();
 
-      expect(items[2].x).toBe(230.00000000000006);
+      // @ts-ignore
+      const labelText2 = labels[2].find(ele => ele.get('type') === 'text');
+      expect(labelText2.attr('x')).toBe(items[2].x + 10);
+      expect(labelText2.attr('y')).toBe(items[2].y - 10);
+      // @ts-ignore
+      expect(labels[2].getCount()).toBe(1);
       expect(items[2].labelLine).toBe(false);
-      expect(isNumberEqual(items[2].y, 151.96152422706632 - 10)).toBeTruthy();
 
-      expect(items[5].x).toBe(290);
-      expect(isNumberEqual(items[5].y, 151.96152422706632 - 10)).toBeTruthy();
+      // @ts-ignore
+      const labelText5 = labels[5].find(ele => ele.get('type') === 'text');
+      expect(labelText5.attr('x')).toBe(items[5].x + 10);
+      expect(labelText5.attr('y')).toBe(items[5].y - 10);
     });
   });
 });

--- a/tests/unit/util/coordinate-spec.ts
+++ b/tests/unit/util/coordinate-spec.ts
@@ -1,5 +1,5 @@
 import { getCoordinate } from '@antv/coord';
-import { getDistanceToCenter, getPointAngle, getXDimensionLength, isFullCircle } from '../../../src/util/coordinate';
+import { getAngleByPoint, getDistanceToCenter, getXDimensionLength, isFullCircle } from '../../../src/util/coordinate';
 
 const Polar = getCoordinate('polar');
 const Cartesian = getCoordinate('rect');
@@ -70,7 +70,7 @@ describe('CoordinateUtil', () => {
     ).toBe(100);
   });
 
-  it('getPointAngle()', () => {
+  it('getAngleByPoint()', () => {
     const coord = new Polar({
       start: {
         x: 0,
@@ -82,13 +82,13 @@ describe('CoordinateUtil', () => {
       },
     });
     expect(
-      getPointAngle(coord, {
+      getAngleByPoint(coord, {
         x: 100,
         y: 100,
       })
     ).toBe(0);
     expect(
-      getPointAngle(coord, {
+      getAngleByPoint(coord, {
         x: 0,
         y: 100,
       })


### PR DESCRIPTION
- [x] fix: Interval label 对于转置坐标系下 position 的位置计算错误

<img src="https://user-images.githubusercontent.com/6628666/76286606-99738280-62dd-11ea-8200-c582eaa5a08f.png" width=400>

<img src="https://user-images.githubusercontent.com/6628666/76286662-ad1ee900-62dd-11ea-8ca2-f0f9eda2fde5.png" width=400>

- [x] refactor: Pie label 的布局调整从 PieGeometryLabel 类逻辑中抽离，使用 label 布局函数实现

- [x] refactor: Label 基类添加 layout 默认布局
         将 LabelRender 的生成移至 GeometryLabel 的 render 方法中，由 GeometryLabel 统一负责生成 label 信息以及渲染图形。

- [x] 修复漏斗图相关 bug:
        * 更新时 label 位置错误
        * 尖底漏斗图最后一个图形 label 定位问题 Closed #1847 
- [x] 测试用例修改 + 补充