### PR TITLE
修复 chart.annotation() 接口 animateOption 属性不生效的问题

### DIFF
--- a/src/chart/controller/annotation.ts
+++ b/src/chart/controller/annotation.ts
@@ -620,7 +620,7 @@ export default class Annotation extends Controller<BaseOption[]> {
         end: this.parsePosition(end),
       };
     }
-    // 合并主题，用户配置优先级高于主题
+    // 合并主题，用户配置优先级高于默认主题
     const cfg = deepMix({}, theme, {
       ...o,
       top: option.top,
@@ -630,7 +630,7 @@ export default class Annotation extends Controller<BaseOption[]> {
     });
     cfg.container = this.getComponentContainer(cfg);
     cfg.animate = this.view.getOptions().animate && cfg.animate && get(option, 'animate', cfg.animate); // 如果 view 关闭动画，则不执行
-    cfg.animateOption = deepMix({}, DEFAULT_ANIMATE_CFG, cfg.animateOption);
+    cfg.animateOption = deepMix({}, DEFAULT_ANIMATE_CFG, cfg.animateOption, option.animateOption);
 
     return cfg;
   }

--- a/src/chart/controller/axis.ts
+++ b/src/chart/controller/axis.ts
@@ -3,6 +3,8 @@ import { COMPONENT_TYPE, DIRECTION, LAYER } from '../../constant';
 import { CircleAxis, CircleGrid, IGroup, LineAxis, LineGrid, Scale } from '../../dependents';
 import { AxisCfg, AxisOption, ComponentOption } from '../../interface';
 
+import { DEFAULT_ANIMATE_CFG } from '../../animate/';
+
 import {
   getAxisDirection,
   getAxisFactorByRegion,
@@ -20,22 +22,6 @@ import { Controller } from './base';
 type Option = Record<string, AxisOption> | boolean;
 
 type Cache = Map<string, ComponentOption>;
-
-const DEFAULT_ANIMATE_CFG = {
-  appear: null,
-  update: {
-    duration: 400,
-    easing: 'easeQuadInOut',
-  }, // 更新时发生变更的动画配置
-  enter: {
-    duration: 400,
-    easing: 'easeQuadInOut',
-  }, // 更新时新增元素的入场动画配置
-  leave: {
-    duration: 300,
-    easing: 'easeQuadIn',
-  }, // 更新时销毁动画配置
-};
 
 // update 组件的时候，忽略的数据更新
 const OMIT_CFG = ['container'];
@@ -712,7 +698,9 @@ export default class Axis extends Controller<Option> {
   private getAnimateCfg(cfg: object) {
     return {
       animate: this.view.getOptions().animate && get(cfg, 'animate'), // 如果 view 关闭动画，则不执行动画
-      animateOption: deepMix({}, DEFAULT_ANIMATE_CFG, get(cfg, 'animateOption', {})),
+      animateOption: deepMix({}, DEFAULT_ANIMATE_CFG, {
+        appear: null, // 默认不做出场动画
+      }, get(cfg, 'animateOption', {})),
     };
   }
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -414,6 +414,8 @@ export interface AnnotationBaseOption {
   readonly style?: object;
   /** 是否进行动画 */
   readonly animate?: boolean;
+  /** 动画参数配置，当且仅当 `animate` 属性为 true，即动画开启时生效。 */
+  animateOption?: ComponentAnimateOption;
   /** x 方向的偏移量 */
   readonly offsetX?: number;
   /** y 方向的偏移量 */

--- a/tests/bugs/2146-spec.ts
+++ b/tests/bugs/2146-spec.ts
@@ -1,0 +1,88 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+
+describe('#2146', () => {
+  const data = [
+    { type: '未知', value: 654, percent: 0.02 },
+    { type: '17 岁以下', value: 654, percent: 0.02 },
+    { type: '18-24 岁', value: 4400, percent: 0.2 },
+    { type: '25-29 岁', value: 5300, percent: 0.24 },
+    { type: '30-39 岁', value: 6200, percent: 0.28 },
+    { type: '40-49 岁', value: 3300, percent: 0.14 },
+    { type: '50 岁以上', value: 1500, percent: 0.06 },
+  ];
+
+  const chart = new Chart({
+    container: createDiv(),
+    width: 400,
+    height: 300,
+    padding: 40
+  });
+  chart.data(data);
+  chart.legend({
+    animate: true,
+    animateOption: {
+      appear: {
+        delay: 1000,
+        duration: 1000,
+      },
+    },
+  });
+  chart.axis('value', {
+    grid: null,
+    animateOption: {
+      update: {
+        delay: 1000,
+        duration: 1000,
+      },
+    },
+  });
+  chart.axis('type', false);
+  chart.interval().position('type*value').color('type');
+  // 添加文本标注
+  chart
+    .annotation()
+    .text({
+      position: [data[0].type, data[0].value],
+      content: data[0].value,
+      style: {
+        textAlign: 'center',
+      },
+      offsetY: -30,
+      animateOption: {
+        appear: {
+          delay: 1000,
+          duration: 1000,
+        }
+      }
+    });
+  chart.render();
+
+  it('component animateOption', () => {
+    // 保证所有 animateOption
+    const components = chart.getComponents();
+    expect(components.length).toBe(3);
+    expect(components[0].component.get('animateOption')).toEqual({
+      appear: null,
+      update: { duration: 1000, easing: 'easeQuadInOut', delay: 1000 },
+      enter: { duration: 400, easing: 'easeQuadInOut' },
+      leave: { duration: 350, easing: 'easeQuadIn' },
+    });
+    expect(components[1].component.get('animateOption')).toEqual({
+      appear: { duration: 1000, easing: 'easeQuadOut', delay: 1000 },
+      update: { duration: 400, easing: 'easeQuadInOut' },
+      enter: { duration: 400, easing: 'easeQuadInOut' },
+      leave: { duration: 350, easing: 'easeQuadIn' },
+    });
+    expect(components[2].component.get('animateOption')).toEqual({
+      appear: { duration: 1000, easing: 'easeQuadOut', delay: 1000 },
+      update: { duration: 400, easing: 'easeQuadInOut' },
+      enter: { duration: 400, easing: 'easeQuadInOut' },
+      leave: { duration: 350, easing: 'easeQuadIn' },
+    });
+  });
+
+  afterAll(() => {
+    chart.destroy();
+  });
+});


### PR DESCRIPTION
Closed #2146.

BUG 原因：没有将用户配置的 `animateOption` 属性传入。