### PR TITLE
fix(data): 修复使用数据引用造成数据未更新的问题

### DIFF
--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -135,6 +135,8 @@ export class View extends Base {
   private isPreMouseInPlot: boolean = false;
   /** tooltip 是否被锁定 */
   private tooltipLocked: boolean;
+  /** 默认标识位，用于判定数据是否更新 */
+  private isDataChanged: boolean = false;
 
   constructor(props: ViewCfg) {
     super({ visible: props.visible });
@@ -229,6 +231,7 @@ export class View extends Base {
     this.scalePool.clear();
     this.filteredData = [];
     this.coordinateInstance = undefined;
+    this.isDataChanged = false; // 复位
 
     // 2. 清空 geometries
     each(this.geometries, (geometry: Geometry) => {
@@ -315,7 +318,7 @@ export class View extends Base {
    */
   public data(data: Data): View {
     set(this.options, 'data', data);
-
+    this.isDataChanged = true;
     return this;
   }
 
@@ -714,6 +717,7 @@ export class View extends Base {
    * @returns void
    */
   public changeData(data: Data) {
+    this.isDataChanged = true;
     this.emit(VIEW_LIFE_CIRCLE.BEFORE_CHANGE_DATA);
     // 1. 保存数据
     this.data(data);
@@ -1144,6 +1148,8 @@ export class View extends Base {
     this.emit(VIEW_LIFE_CIRCLE.AFTER_PAINT);
 
     this.renderPaintRecursive(isUpdate);
+
+    this.isDataChanged = false; // 渲染完毕复位
   }
 
   /**
@@ -1440,6 +1446,7 @@ export class View extends Base {
         scaleDefs: get(this.options, 'scales', {}),
         data: this.filteredData,
         theme: deepMix({}, this.themeObject, geometry.theme), // 支持 geometry 层级的主题设置
+        isDataChanged: this.isDataChanged,
       };
       if (isUpdate) {
         // 数据发生更新

--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -90,6 +90,8 @@ export interface InitCfg {
   theme?: LooseObject;
   /** 列定义 */
   scaleDefs?: Record<string, ScaleOption>;
+  /** 因为数据使用的引用，所以需要有一个标识位标识数据是否发生了更新 */
+  isDataChanged?: boolean;
 }
 
 /** Geometry 构造函数参数 */
@@ -786,16 +788,16 @@ export default class Geometry extends Base {
    * @param [cfg] 更新的配置
    */
   public update(cfg: InitCfg = {}) {
-    const { data } = cfg;
+    const { data, isDataChanged } = cfg;
     const { attributeOption, lastAttributeOption } = this;
 
     if (!isEqual(attributeOption, lastAttributeOption)) {
       // 映射发生改变，则重新创建图形属性
       this.init(cfg);
-    } else if (data && !isEqual(data, this.data)) {
-      // 数据或者 scale 发生变化
+    } else if (data && (isDataChanged || !isEqual(data, this.data))) {
+      // 数据发生变化
       this.setCfg(cfg);
-      this.processData(this.data); // 数据加工：分组 -> 数字化 -> adjust
+      this.processData(data); // 数据加工：分组 -> 数字化 -> adjust
     } else {
       // 有可能 coordinate 变化
       this.setCfg(cfg);

--- a/tests/bugs/2186-spec.ts
+++ b/tests/bugs/2186-spec.ts
@@ -1,0 +1,44 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+
+describe('#2186', () => {
+  const data = [
+    { year: '1991', value: 3 },
+    { year: '1992', value: 4 },
+    { year: '1993', value: 3.5 },
+    { year: '1994', value: 5 },
+    { year: '1995', value: 4.9 },
+    { year: '1996', value: 6 },
+    { year: '1997', value: 7 },
+    { year: '1998', value: 9 },
+    { year: '1999', value: 13 },
+  ];
+  const chart = new Chart({
+    container: createDiv(),
+    width: 400,
+    height: 300,
+  });
+
+  chart.data(data);
+  chart.scale('value', {
+    nice: true,
+  });
+  const line = chart.point().position('year*value');
+
+  chart.render();
+
+  it('changeData', () => {
+    data.push({ year: '2000', value: 13 });
+    chart.changeData(data);
+
+    expect(line.elements.length).toBe(10);
+  });
+
+  it('chart.render(true)', () => {
+    data.push({ year: '2001', value: 13 });
+
+    chart.data(data);
+    chart.render(true);
+    expect(line.elements.length).toBe(11);
+  });
+});

--- a/tests/bugs/candle-legend-spec.ts
+++ b/tests/bugs/candle-legend-spec.ts
@@ -90,7 +90,6 @@ const chart = new Chart({
   container: createDiv(),
   width: 500,
   height: 400,
-  //padding: [10, 40, 40, 40]
 });
 
 chart.data(data);

--- a/tests/unit/geometry/label/labels-spec.ts
+++ b/tests/unit/geometry/label/labels-spec.ts
@@ -115,8 +115,8 @@ describe('LabelsRenderer', () => {
       // @ts-ignore
       const labelsRenderer = interval.labelsRenderer;
       expect(labelsRenderer.container.getCount()).toBe(2);
-      expect(labelsRenderer.container.getFirst().get('data')).toEqual({ a: '1', percent: 0.5 });
-      expect(labelsRenderer.container.getFirst().get('animateCfg').update).toBe(false);
+      expect(labelsRenderer.container.find(ele => ele.get('type') === 'text').get('data')).toEqual({ a: '1', percent: 0.5 });
+      expect(labelsRenderer.container.find(ele => ele.get('type') === 'text').get('animateCfg').update).toBe(false);
 
       interval.animate(false).update();
       interval.paint();


### PR DESCRIPTION
Closed #2186 

**原因分析：**

因为 View 和 Geometry 的数据保持引用关系（除存在 chart.filter() 外），所以用户在外部通过 data.push() 等不改变引用却修改了内容的方式更新数据源的时候，https://github.com/antvis/G2/blob/master/src/geometry/base.ts#L795 

![image](https://user-images.githubusercontent.com/6628666/76940283-eafebb80-6934-11ea-8a6d-1a6b39cd52cd.png)
 Geometry 这里的代码判断数据是相等的（因为是引用关系，外部 data 改变了 geometry.data 也相应改变了），所以就会出现不更新的情况。