### PR TITLE
支持转置极坐标下坐标轴的渲染

### DIFF
--- a/examples/bar/basic/demo/radial-bar.ts
+++ b/examples/bar/basic/demo/radial-bar.ts
@@ -30,7 +30,16 @@ chart.tooltip({
 });
 
 chart.legend(false);
-chart.axis(false);
+chart.axis('question', {
+  grid: null,
+  tickLine: null,
+  line: null,
+  label: {
+    style: {
+      fill: '#595959'
+    }
+  }
+});
 
 chart.coordinate('polar', { innerRadius: 0.1 }).transpose();
 
@@ -45,22 +54,12 @@ chart
     };
   })
   .label('percent', {
-    offset: -5,
+    offset: -2,
     content: (data) => {
       return data.percent * 100 + '%';
     }
   });
 
-data.map((obj) => {
-  chart.annotation().text({
-    position: [obj.question, 0],
-    content: obj.question + ' ',
-    style: {
-      textAlign: 'right',
-    },
-  });
-  return null;
-});
 
 chart.interaction('element-active');
 

--- a/examples/bar/basic/demo/radial-line.ts
+++ b/examples/bar/basic/demo/radial-line.ts
@@ -27,7 +27,11 @@ chart.coordinate('theta', {
   endAngle: Math.PI,
 });
 
-chart.axis(false);
+chart.axis('term', {
+  tickLine: null,
+  grid: null,
+  line: null,
+});
 
 chart
   .interval()
@@ -41,17 +45,6 @@ chart
   .point()
   .position('term*count')
   .shape('circle');
-
-for (let i = 0, l = data.length; i < l; i++) {
-  const obj = data[i];
-  chart.annotation().text({
-    position: [obj.term, 0],
-    content: obj.term + ' ',
-    style: {
-      textAlign: 'right',
-    },
-  });
-}
 
 chart.annotation().text({
   position: ['50%', '50%'],

--- a/examples/bar/stack/demo/meta.json
+++ b/examples/bar/stack/demo/meta.json
@@ -13,6 +13,14 @@
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_f5c722/afts/img/A*okjvRJcWBBwAAAAAAAAAAABkARQnAQ"
     },
     {
+      "filename": "radial-stacked.ts",
+      "title": {
+        "en": "Radial stacked bar chart",
+        "zh": "径向堆叠条形图"
+      },
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_f5c722/afts/img/A*hpajTbogoeUAAAAAAAAAAABkARQnAQ"
+    },
+    {
       "filename": "bar-diverge.ts",
       "title": {
         "en": "stacked bar chart",

--- a/examples/bar/stack/demo/radial-stacked.ts
+++ b/examples/bar/stack/demo/radial-stacked.ts
@@ -26,20 +26,50 @@ const chart = new Chart({
   height: 500,
 });
 
-chart.coordinate().transpose();
+chart.coordinate('polar').transpose();
 
 chart.data(dv.rows);
-chart.scale('人口数量', { nice: true });
+chart.scale('人口数量', {
+  max: 200000,
+  tickCount: 10,
+});
 
 chart.axis('State', {
   label: {
     offset: 12,
   },
+  tickLine: {
+    alignTick: false,
+  },
+  grid: null,
+  line: {
+    style: {
+      stroke: '#595959'
+    }
+  }
+});
+chart.axis('人口数量', {
+  grid: {
+    line: {
+      style: {
+        lineDash: [ 4, 4 ]
+      }
+    }
+  }
 });
 
 chart.tooltip({
   shared: true,
   showMarkers: false,
+});
+
+chart.legend({
+  marker: {
+    symbol: 'square',
+    style: {
+      r: 5,
+    }
+  }
 });
 
 chart
@@ -48,6 +78,6 @@ chart
   .position('State*人口数量')
   .color('年龄段');
 
-chart.interaction('active-region');
+chart.interaction('element-highlight-by-x');
 
 chart.render();

--- a/src/util/grid.ts
+++ b/src/util/grid.ts
@@ -68,22 +68,40 @@ export function getLineGridItems(coordinate: Coordinate, scale: Scale, dim: stri
  * @param dim
  * @returns items
  */
-export function getCircleGridItems(coordinate: Coordinate, xScale: Scale, yScale: Scale, alignTick: boolean) {
+export function getCircleGridItems(coordinate: Coordinate, xScale: Scale, yScale: Scale, alignTick: boolean, dim: string) {
   const count = xScale.values.length;
   const items = [];
   const ticks = yScale.getTicks();
+
   ticks.reduce((preTick: Tick, currentTick: Tick) => {
     const preValue = preTick ? preTick.value : currentTick.value; // 只有一项数据时取当前值
     const currentValue = currentTick.value;
     const middleValue = (preValue + currentValue) / 2;
-    items.push({
-      points: map(Array(count + 1), (__: any, idx: number) => {
-        return coordinate.convert({
-          x: idx / count,
-          y: alignTick ? currentValue : middleValue,
-        });
-      }),
-    });
+    if (dim === 'x') {
+      // 如果是 x 轴作为半径轴，那么只需要取圆弧收尾两个即可
+      items.push({
+        points: [
+          coordinate.convert({
+            x: alignTick ? currentValue : middleValue,
+            y: 0,
+          }),
+          coordinate.convert({
+            x: alignTick ? currentValue : middleValue,
+            y: 1,
+          }),
+        ]
+      })
+    } else {
+      items.push({
+        points: map(Array(count + 1), (__: any, idx: number) => {
+          return coordinate.convert({
+            x: idx / count,
+            y: alignTick ? currentValue : middleValue,
+          });
+        }),
+      });
+    }
+
     return currentTick;
   }, ticks[0]);
   return items;

--- a/tests/bugs/1744-spec.ts
+++ b/tests/bugs/1744-spec.ts
@@ -1,0 +1,101 @@
+import { Chart } from '../../src';
+import { COMPONENT_TYPE } from '../../src/constant';
+import { createDiv } from '../util/dom';
+
+describe('1744', () => {
+  const data = [
+    { question: '问题 1', percent: 0.21 },
+    { question: '问题 2', percent: 0.4 },
+    { question: '问题 3', percent: 0.49 },
+    { question: '问题 4', percent: 0.52 },
+    { question: '问题 5', percent: 0.53 },
+    { question: '问题 6', percent: 0.84 },
+    { question: '问题 7', percent: 1.0 },
+    { question: '问题 8', percent: 1.2 },
+  ];
+
+  const chart = new Chart({
+    container: createDiv(),
+    width: 400,
+    height: 400,
+  });
+  chart.legend(false);
+  chart.axis(false);
+  chart.animate(false);
+  chart.data(data);
+  chart.scale('question', {
+    range: [0, 1]
+  });
+  chart.coordinate('polar').transpose();
+
+  chart
+    .interval()
+    .position('question*percent')
+    .color('percent', '#BAE7FF-#1890FF-#0050B3');
+  chart.render();
+
+  it('Not render by default', () => {
+    const axes = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.AXIS);
+    expect(axes.length).toBe(0);
+  });
+
+  it('After update, not render by default', () => {
+    chart.render(true);
+    const axes = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.AXIS);
+    expect(axes.length).toBe(0);
+
+    const grids = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.GRID);
+    expect(grids.length).toBe(0);
+  });
+
+  it('if update and axes are opened. should be render', () => {
+    chart.axis(true);
+    chart.render(true);
+    const axes = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.AXIS);
+    expect(axes.length).toBe(2);
+
+    const grids = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.GRID);
+    expect(grids.length).toBe(2);
+  });
+
+  it('But can be opened by chart.axis()', () => {
+    chart.clear();
+    chart.data(data);
+
+    chart.axis('percent', true);
+    chart.axis('question', {
+      grid: {
+        closed: false,
+      },
+    });
+
+    chart.coordinate('polar', {
+      innerRadius: 0.4,
+      endAngle: Math.PI / 2
+    }).transpose();
+
+    chart
+      .interval()
+      .position('question*percent')
+      .color('percent', '#BAE7FF-#1890FF-#0050B3');
+    chart.render();
+
+    expect(chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.AXIS).length).toBe(2);
+    const grids = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.GRID);
+    expect(grids.length).toBe(2);
+    expect(grids[0].component.get('items').length).toBe(8);
+    expect(grids[0].component.getBBox().width).toBeCloseTo(183.5000005594601);
+    expect(grids[0].component.getBBox().height).toBeCloseTo(366.5);
+  });
+
+  it('update', () => {
+    chart.changeSize(800, 800);
+
+    expect(chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.AXIS).length).toBe(2);
+    const grids = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.GRID);
+    expect(grids.length).toBe(2);
+    expect(grids[0].component.get('items').length).toBe(8);
+    expect(grids[0].component.getBBox().width).toBeCloseTo(383.5);
+    expect(grids[0].component.getBBox().height).toBeCloseTo(766.5);
+  });
+});

--- a/tests/unit/util/grid-spec.ts
+++ b/tests/unit/util/grid-spec.ts
@@ -67,8 +67,8 @@ describe('util grid', () => {
       max: 100,
     });
 
-    const items1 = getCircleGridItems(coordinate, xScale, yScale, false);
-    const items2 = getCircleGridItems(coordinate, xScale, yScale, true);
+    const items1 = getCircleGridItems(coordinate, xScale, yScale, false, 'y');
+    const items2 = getCircleGridItems(coordinate, xScale, yScale, true, 'y');
     expect(items1.length).toBe(xScale.values.length - 1);
     expect(items2.length).toBe(yScale.getTicks().length);
 


### PR DESCRIPTION
Closed #1744 

1. 默认在用户不配置的情况下不渲染。
2. 当用户通过配置可以开启

```ts
chart.axis(true);
chart.axis('x', true | {});
chart.axis('y', true | {});

```
3. 同 polar 不同的是，转置后，半径轴渲染的是直角坐标系下的 x 轴，圆弧轴渲染的是直角坐标系下的 y 轴

![下载](https://user-images.githubusercontent.com/6628666/77175281-55faee80-6afd-11ea-9703-4f501aec74dc.png)
