### PR TITLE
fix(#2272): 当映射数据中不存在 x 和 y 时，不绘制 label

### DIFF
--- a/src/geometry/label/base.ts
+++ b/src/geometry/label/base.ts
@@ -42,7 +42,7 @@ export default class GeometryLabel {
     // 获取 label 相关的 x，y 的值，获取具体的 x, y，防止存在数组
     each(mapppingArray, (mappingData: MappingDatum, index: number) => {
       const labelCfg = labelCfgs[index];
-      if (!labelCfg) {
+      if (!labelCfg || isNil(mappingData.x) || isNil(mappingData.y)) {
         items.push(null);
         return;
       }

--- a/tests/bugs/2272-spec.ts
+++ b/tests/bugs/2272-spec.ts
@@ -1,0 +1,57 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+
+describe('#2272', () => {
+  it('#2272', () => {
+    const data = [
+      { type: '一线城市', value: 0.19 },
+      { type: '二线城市', value: 0.21 },
+      { type: '三线城市', value: 0.27 },
+      { type: '四线及以下', value: null },
+    ];
+    const chart = new Chart({
+      container: createDiv(),
+      width: 400,
+      height: 300,
+      localRefresh: false, // 暂时关闭
+    });
+    chart.data(data);
+    chart.coordinate('theta', {
+      radius: 0.75,
+      innerRadius: 0.4
+    });
+    chart.tooltip({
+      showMarkers: false
+    });
+
+    const interval = chart
+      .interval()
+      .adjust('stack')
+      .position('value')
+      .color('type', ['#063d8a', '#1770d6', '#47abfc', '#38c060'])
+      .label('type', (val) => {
+        const opacity = val === '四线及以下' ? 1 : 0.5;
+        return {
+          offset: -10,
+          style: {
+            opacity,
+            fill: 'white',
+            fontSize: 12,
+            shadowBlur: 2,
+            shadowColor: 'rgba(0, 0, 0, .45)',
+          },
+          content: (obj) => {
+            return obj.type + '\n' + obj.value + '%';
+          },
+        };
+      });
+
+    expect(() => {
+      chart.render();
+    }).not.toThrow();
+
+    expect(interval.elements.length).toBe(4);
+    // expect(interval.container.getBBox().width).not.toBe(Infinity);
+    // expect(interval.container.getBBox().height).not.toBe(Infinity);
+  });
+});


### PR DESCRIPTION
label 的问题已修复，但是无法绘制的问题需要  G2 层解决，详见 https://github.com/antvis/g2/issues/2272#issuecomment-610212056

但是可以像测试用例一样把局部刷新关掉！https://github.com/antvis/G2/compare/issue-2272?expand=1#diff-8ea33c131492f7875704e54499100cb6R16


![image](https://user-images.githubusercontent.com/6628666/78640915-1137cb80-78e3-11ea-9b30-6e77d1d24c53.png)
