### PR TITLE
fix: site build

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@commitlint/config-angular": "^8.2.0",
     "@types/jest": "^24.0.18",
     "conventional-changelog-cli": "^2.0.28",
-    "gatsby": "2.19.5",
+    "gatsby": "^2.20.23",
     "generate-changelog": "^1.8.0",
     "gh-pages": "^2.1.1",
     "husky": "^3.0.4",


### PR DESCRIPTION
修复 site build 报错的问题。

注意不能用 `tnpm` 和 `cnpm`，会报 `$export is not a function` 的问题，原因未知。

先用 `npm` 或者 `tnpm i --by=npm` 来安装。