### PR TITLE
feat(slider): add `formatter` property

### DIFF
--- a/docs/manual/tutorial/slider.en.md
+++ b/docs/manual/tutorial/slider.en.md
@@ -96,7 +96,7 @@ export interface SliderOption {
   readonly start?: number;
   readonly end?: number;
   /** 格式化 Mask */
-  mask?: (val: any) => string;
+  readonly mask?: (options: {val: string, datum: Datum, idx: number}) => string;
 }
 ```
 

--- a/docs/manual/tutorial/slider.en.md
+++ b/docs/manual/tutorial/slider.en.md
@@ -96,7 +96,7 @@ export interface SliderOption {
   readonly start?: number;
   readonly end?: number;
   /** 滑块文本格式化函数 */
-  readonly formatter?: (options: {val: any, datum: Datum, idx: number}) => string;
+  readonly formatter?: (val: any, datum: Datum, idx: number) => any;
 }
 ```
 

--- a/docs/manual/tutorial/slider.en.md
+++ b/docs/manual/tutorial/slider.en.md
@@ -96,7 +96,7 @@ export interface SliderOption {
   readonly start?: number;
   readonly end?: number;
   /** 格式化 Mask */
-  readonly mask?: (options: {val: string, datum: Datum, idx: number}) => string;
+  readonly mask?: (options: {val: any, datum: Datum, idx: number}) => string;
 }
 ```
 

--- a/docs/manual/tutorial/slider.en.md
+++ b/docs/manual/tutorial/slider.en.md
@@ -95,8 +95,8 @@ export interface SliderOption {
   // 初始位置
   readonly start?: number;
   readonly end?: number;
-  /** 格式化 Mask */
-  readonly mask?: (options: {val: any, datum: Datum, idx: number}) => string;
+  /** 滑块文本格式化函数 */
+  readonly formatter?: (options: {val: any, datum: Datum, idx: number}) => string;
 }
 ```
 

--- a/docs/manual/tutorial/slider.en.md
+++ b/docs/manual/tutorial/slider.en.md
@@ -95,6 +95,8 @@ export interface SliderOption {
   // 初始位置
   readonly start?: number;
   readonly end?: number;
+  /** 格式化 Mask */
+  mask?: (val: any) => string;
 }
 ```
 

--- a/docs/manual/tutorial/slider.zh.md
+++ b/docs/manual/tutorial/slider.zh.md
@@ -96,7 +96,7 @@ export interface SliderOption {
   readonly start?: number;
   readonly end?: number;
   /** 格式化 Mask */
-  mask?: (val: any) => string;
+  readonly mask?: (options: {val: string, datum: Datum, idx: number}) => string;
 }
 ```
 

--- a/docs/manual/tutorial/slider.zh.md
+++ b/docs/manual/tutorial/slider.zh.md
@@ -96,7 +96,7 @@ export interface SliderOption {
   readonly start?: number;
   readonly end?: number;
   /** 滑块文本格式化函数 */
-  readonly formatter?: (options: {val: any, datum: Datum, idx: number}) => string;
+  readonly formatter?: (val: any, datum: Datum, idx: number) => any;
 }
 ```
 

--- a/docs/manual/tutorial/slider.zh.md
+++ b/docs/manual/tutorial/slider.zh.md
@@ -96,7 +96,7 @@ export interface SliderOption {
   readonly start?: number;
   readonly end?: number;
   /** 格式化 Mask */
-  readonly mask?: (options: {val: string, datum: Datum, idx: number}) => string;
+  readonly mask?: (options: {val: any, datum: Datum, idx: number}) => string;
 }
 ```
 

--- a/docs/manual/tutorial/slider.zh.md
+++ b/docs/manual/tutorial/slider.zh.md
@@ -95,8 +95,8 @@ export interface SliderOption {
   // 初始位置
   readonly start?: number;
   readonly end?: number;
-  /** 格式化 Mask */
-  readonly mask?: (options: {val: any, datum: Datum, idx: number}) => string;
+  /** 滑块文本格式化函数 */
+  readonly formatter?: (options: {val: any, datum: Datum, idx: number}) => string;
 }
 ```
 

--- a/docs/manual/tutorial/slider.zh.md
+++ b/docs/manual/tutorial/slider.zh.md
@@ -95,6 +95,8 @@ export interface SliderOption {
   // 初始位置
   readonly start?: number;
   readonly end?: number;
+  /** 格式化 Mask */
+  mask?: (val: any) => string;
 }
 ```
 

--- a/src/chart/controller/slider.ts
+++ b/src/chart/controller/slider.ts
@@ -8,7 +8,7 @@ import { isBetween, omit } from '../../util/helper';
 import View from '../view';
 import { Controller } from './base';
 
-export type SliderMaskType = (options: {val: any, datum: Datum, idx: number}) => string;
+export type SliderFormatterType = (options: {val: any, datum: Datum, idx: number}) => string;
 /** Slider 配置 */
 export interface SliderOption {
   /** slider 高度 */
@@ -32,8 +32,8 @@ export interface SliderOption {
   readonly start?: number;
   /** 滑块初始化的结束位置 */
   readonly end?: number;
-  /** 格式化 Mask */
-  mask?: SliderMaskType;
+  /** 滑块文本格式化函数 */
+  formatter?: SliderFormatterType;
 }
 
 type Option = SliderOption | boolean;
@@ -229,10 +229,10 @@ export default class Slider extends Controller<Option> {
     let minText = get(xData, [minIndex]);
     let maxText = get(xData, [maxIndex]);
 
-    const mask = this.getSliderCfg().mask as SliderMaskType;
-    if (mask) {
-      minText = mask({ val: minText, datum: data[minIndex], idx: minIndex });
-      maxText = mask({ val: maxText, datum: data[maxIndex], idx: maxIndex });
+    const formatter = this.getSliderCfg().formatter as SliderFormatterType;
+    if (formatter) {
+      minText = formatter({ val: minText, datum: data[minIndex], idx: minIndex });
+      maxText = formatter({ val: maxText, datum: data[maxIndex], idx: maxIndex });
     }
 
     // 更新文本

--- a/src/chart/controller/slider.ts
+++ b/src/chart/controller/slider.ts
@@ -8,7 +8,6 @@ import { isBetween, omit } from '../../util/helper';
 import View from '../view';
 import { Controller } from './base';
 
-export type FormatMaskType = (val: any) => string;
 /** Slider 配置 */
 export interface SliderOption {
   /** slider 高度 */
@@ -33,7 +32,7 @@ export interface SliderOption {
   /** 滑块初始化的结束位置 */
   readonly end?: number;
   /** 格式化 Mask */
-  formatMask?: FormatMaskType;
+  mask?: (val: any) => string;
 }
 
 type Option = SliderOption | boolean;
@@ -229,10 +228,10 @@ export default class Slider extends Controller<Option> {
     let minText = get(xData, [minIndex]);
     let maxText = get(xData, [maxIndex]);
 
-    const formatMask = this.getSliderCfg().formatMask as FormatMaskType;
-    if (typeof formatMask === 'function') {
-      minText = formatMask(minText);
-      maxText = formatMask(maxText);
+    const mask = this.getSliderCfg().mask as ((val: any) => string);
+    if (typeof mask === 'function') {
+      minText = mask(minText);
+      maxText = mask(maxText);
     }
 
     // 更新文本

--- a/src/chart/controller/slider.ts
+++ b/src/chart/controller/slider.ts
@@ -8,7 +8,7 @@ import { isBetween, omit } from '../../util/helper';
 import View from '../view';
 import { Controller } from './base';
 
-export type SliderMaskType = (options: {val: string, datum: Datum, idx: number}) => string;
+export type SliderMaskType = (options: {val: any, datum: Datum, idx: number}) => string;
 /** Slider 配置 */
 export interface SliderOption {
   /** slider 高度 */

--- a/src/chart/controller/slider.ts
+++ b/src/chart/controller/slider.ts
@@ -8,6 +8,7 @@ import { isBetween, omit } from '../../util/helper';
 import View from '../view';
 import { Controller } from './base';
 
+export type FormatMaskType = (val: any) => string;
 /** Slider 配置 */
 export interface SliderOption {
   /** slider 高度 */
@@ -31,6 +32,8 @@ export interface SliderOption {
   readonly start?: number;
   /** 滑块初始化的结束位置 */
   readonly end?: number;
+  /** 格式化 Mask */
+  formatMask?: FormatMaskType;
 }
 
 type Option = SliderOption | boolean;
@@ -223,8 +226,14 @@ export default class Slider extends Controller<Option> {
     const minIndex = Math.floor(min * (dataSize - 1));
     const maxIndex = Math.floor(max * (dataSize - 1));
 
-    const minText = get(xData, [minIndex]);
-    const maxText = get(xData, [maxIndex]);
+    let minText = get(xData, [minIndex]);
+    let maxText = get(xData, [maxIndex]);
+
+    const formatMask = this.getSliderCfg().formatMask as FormatMaskType;
+    if (typeof formatMask === 'function') {
+      minText = formatMask(minText);
+      maxText = formatMask(maxText);
+    }
 
     // 更新文本
     this.slider.component.update({

--- a/src/chart/controller/slider.ts
+++ b/src/chart/controller/slider.ts
@@ -8,6 +8,7 @@ import { isBetween, omit } from '../../util/helper';
 import View from '../view';
 import { Controller } from './base';
 
+export type SliderMaskType = (options: {val: string, datum: Datum, idx: number}) => string;
 /** Slider 配置 */
 export interface SliderOption {
   /** slider 高度 */
@@ -32,7 +33,7 @@ export interface SliderOption {
   /** 滑块初始化的结束位置 */
   readonly end?: number;
   /** 格式化 Mask */
-  mask?: (val: any) => string;
+  readonly mask?: SliderMaskType;
 }
 
 type Option = SliderOption | boolean;
@@ -228,10 +229,10 @@ export default class Slider extends Controller<Option> {
     let minText = get(xData, [minIndex]);
     let maxText = get(xData, [maxIndex]);
 
-    const mask = this.getSliderCfg().mask as ((val: any) => string);
-    if (typeof mask === 'function') {
-      minText = mask(minText);
-      maxText = mask(maxText);
+    const mask = this.getSliderCfg().mask as SliderMaskType;
+    if (mask) {
+      minText = mask({ val: minText, datum: data[minIndex], idx: minIndex });
+      maxText = mask({ val: maxText, datum: data[maxIndex], idx: maxIndex });
     }
 
     // 更新文本

--- a/src/chart/controller/slider.ts
+++ b/src/chart/controller/slider.ts
@@ -8,7 +8,7 @@ import { isBetween, omit } from '../../util/helper';
 import View from '../view';
 import { Controller } from './base';
 
-export type SliderFormatterType = (options: {val: any, datum: Datum, idx: number}) => string;
+export type SliderFormatterType = (val: any, datum: Datum, idx: number) => any;
 /** Slider 配置 */
 export interface SliderOption {
   /** slider 高度 */
@@ -231,8 +231,8 @@ export default class Slider extends Controller<Option> {
 
     const formatter = this.getSliderCfg().formatter as SliderFormatterType;
     if (formatter) {
-      minText = formatter({ val: minText, datum: data[minIndex], idx: minIndex });
-      maxText = formatter({ val: maxText, datum: data[maxIndex], idx: maxIndex });
+      minText = formatter(minText, data[minIndex], minIndex);
+      maxText = formatter(maxText, data[maxIndex], maxIndex);
     }
 
     // 更新文本

--- a/src/chart/controller/slider.ts
+++ b/src/chart/controller/slider.ts
@@ -33,7 +33,7 @@ export interface SliderOption {
   /** 滑块初始化的结束位置 */
   readonly end?: number;
   /** 格式化 Mask */
-  readonly mask?: SliderMaskType;
+  mask?: SliderMaskType;
 }
 
 type Option = SliderOption | boolean;

--- a/tests/unit/chart/controller/slider-spec.ts
+++ b/tests/unit/chart/controller/slider-spec.ts
@@ -94,11 +94,11 @@ describe('Slider', () => {
     expect(slider.component.get('maxText')).toBe('1992');
   });
 
-  it('mask', () => {
+  it('formatter', () => {
     const fn = jest.fn().mockReturnValue(`test`);
     chart.option('slider', {
       height: 16,
-      mask: fn,
+      formatter: fn,
     });
 
     chart.render();

--- a/tests/unit/chart/controller/slider-spec.ts
+++ b/tests/unit/chart/controller/slider-spec.ts
@@ -94,6 +94,20 @@ describe('Slider', () => {
     expect(slider.component.get('maxText')).toBe('1992');
   });
 
+  it('formatMask', () => {
+    const fn = jest.fn().mockReturnValue(`test`);
+    chart.option('slider', {
+      height: 16,
+      formatMask: fn,
+    });
+
+    chart.render();
+
+    expect(fn).toBeCalledTimes(2);
+    expect(slider.component.get('minText')).toBe('test');
+    expect(slider.component.get('maxText')).toBe('test');
+  });
+
   afterAll(() => {
     chart.destroy();
     removeDom(div);

--- a/tests/unit/chart/controller/slider-spec.ts
+++ b/tests/unit/chart/controller/slider-spec.ts
@@ -4,6 +4,7 @@ import { Chart } from '../../../../src/index';
 import { createDiv } from '../../../util/dom';
 import { delay } from '../../../util/delay';
 import { removeDom } from '../../../../src/util/dom';
+import { SliderFormatterType } from '../../../../src/chart/controller/slider';
 
 const Data = [
   { year: '1991', value: 3 },
@@ -95,17 +96,14 @@ describe('Slider', () => {
   });
 
   it('formatter', () => {
-    const fn = jest.fn().mockReturnValue(`test`);
     chart.option('slider', {
-      height: 16,
-      formatter: fn,
+      formatter: ((v, datum, idx) => `${v}-${datum.value}-${idx}`) as SliderFormatterType,
     });
+    chart.changeData(Data.slice(0, 3));
+    chart.render(true);
 
-    chart.render();
-
-    expect(fn).toBeCalledTimes(2);
-    expect(slider.component.get('minText')).toBe('test');
-    expect(slider.component.get('maxText')).toBe('test');
+    expect(slider.component.get('minText')).toBe(`1991-3-0`);
+    expect(slider.component.get('maxText')).toBe(`1992-4-1`);
   });
 
   afterAll(() => {

--- a/tests/unit/chart/controller/slider-spec.ts
+++ b/tests/unit/chart/controller/slider-spec.ts
@@ -94,11 +94,11 @@ describe('Slider', () => {
     expect(slider.component.get('maxText')).toBe('1992');
   });
 
-  it('formatMask', () => {
+  it('mask', () => {
     const fn = jest.fn().mockReturnValue(`test`);
     chart.option('slider', {
       height: 16,
-      formatMask: fn,
+      mask: fn,
     });
 
     chart.render();


### PR DESCRIPTION
若直接 `mask: 'HH:mm'` 之类需要额外增加 time 的处理，但是 G2 目前没有统一的时间，因此由一种外部自定义选择如何格式化。

- close #2332

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
