### PR TITLE
fix(types): remove syntax export * as

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "the Grammar of Graphics in Javascript",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,6 +1,6 @@
 /* G2 的一个壳子，不包含 Geometry，由开发者自己定义和引入 */
 
-export const VERSION = '4.0.7';
+export const VERSION = '4.0.8';
 
 // 核心基类导出
 export { Chart, View, Event } from './chart'; // Chart, View 类
@@ -44,3 +44,7 @@ export { registerEngine, getEngine } from './engine';
 export { registerAnimation, getAnimation } from './animate/animation';
 
 export { LAYER, DIRECTION } from './constant';
+
+// 因为 typescript 部分版本不支持 export * as 语法。
+import * as Types from './interface';
+export { Types };

--- a/src/index.ts
+++ b/src/index.ts
@@ -615,7 +615,6 @@ declare module './chart/view' {
 }
 
 export * from './core';
-export * as Types from './interface';
 // 一些工具方法导出
 import { getAngle, polarToCartesian } from './util/graphics';
 import { rotate, transform, translate, zoom } from './util/transform';


### PR DESCRIPTION
 - [x] 因为 typescript 3.8 之前的版本，不支持 export * as 语法，导致 webpack ts-loader 打包 dist 出错