### PR TITLE
docs(label): 修复文档中Layout Function参数的错误

### DIFF
--- a/docs/manual/developer/registerlabel.en.md
+++ b/docs/manual/developer/registerlabel.en.md
@@ -41,7 +41,7 @@ chart
 import { registerGeometryLabelLayout } from '@antv/g2';
 
 // Step 1: 定义 label 布局函数
-function limitInShape(labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+function limitInShape(items: LabelItem[], labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
   each(labels, (label, index) => {
     const labelBBox = label.getCanvasBBox(); // 文本有可能发生旋转
     const shapeBBox = shapes[index].getBBox();

--- a/docs/manual/developer/registerlabel.zh.md
+++ b/docs/manual/developer/registerlabel.zh.md
@@ -41,7 +41,7 @@ chart
 import { registerGeometryLabelLayout } from '@antv/g2';
 
 // Step 1: 定义 label 布局函数
-function limitInShape(labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
+function limitInShape(items: LabelItem[], labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox) {
   each(labels, (label, index) => {
     const labelBBox = label.getCanvasBBox(); // 文本有可能发生旋转
     const shapeBBox = shapes[index].getBBox();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

##### Description of change
开发者教程 - 自定义 Label - 自定义Label布局函数 中的example中给出的limitInShape参数有误。

正确的应为
`function limitInShape(items: LabelItem[], labels: IGroup[], shapes: IShape[] | IGroup[], region: BBox)`
