### PR TITLE
refactor(tooltip): 确保第一次触发'tooltip:show'的时候tooltip元素已经创建

### DIFF
--- a/src/chart/controller/tooltip.ts
+++ b/src/chart/controller/tooltip.ts
@@ -75,16 +75,25 @@ export default class Tooltip extends Controller<TooltipOption> {
       y: items[0].y,
     }; // 数据点位置
 
+    const cfg = this.getTooltipCfg();
+    const { follow, showMarkers, showCrosshairs, showContent, marker } = cfg;
+    const lastItems = this.items;
+    const lastTitle = this.title;
+
+    // 展示 tooltip 内容框才渲染 tooltip
+    if (showContent && !this.tooltip) {
+      // 延迟生成
+      this.renderTooltip();
+    }
+
+    // 放在渲染tooltip之后，可以确保第一次触发'tooltip:show'
+    // 的时候tooltip元素已经存在
     view.emit('tooltip:show', {
       items,
       title,
       ...point,
     });
 
-    const cfg = this.getTooltipCfg();
-    const { follow, showMarkers, showCrosshairs, showContent, marker } = cfg;
-    const lastItems = this.items;
-    const lastTitle = this.title;
     if (!isEqual(lastTitle, title) || !isEqual(lastItems, items)) {
       // 内容发生变化了更新 tooltip
       view.emit('tooltip:change', {
@@ -93,12 +102,7 @@ export default class Tooltip extends Controller<TooltipOption> {
         ...point,
       });
 
-      if (showContent) {
-        // 展示 tooltip 内容框才渲染 tooltip
-        if (!this.tooltip) {
-          // 延迟生成
-          this.renderTooltip();
-        }
+      if (showContent && this.tooltip) {
         this.tooltip.update(mix({}, cfg, {
           items,
           title,

--- a/src/chart/controller/tooltip.ts
+++ b/src/chart/controller/tooltip.ts
@@ -80,6 +80,11 @@ export default class Tooltip extends Controller<TooltipOption> {
     const lastItems = this.items;
     const lastTitle = this.title;
 
+    // 该变量用于确定是否应该触发tooltip:show
+    // "!this.tooltip"如果为true则表示tooltip元素还未渲染，所以应该触发
+    // "!this.tooltip.get('visible')"如果为true，则表示之前是隐藏的，所以应该触发
+    const isEmitShow = !this.tooltip || !this.tooltip.get('visible');
+
     // 展示 tooltip 内容框才渲染 tooltip
     if (showContent && !this.tooltip) {
       // 延迟生成
@@ -88,11 +93,13 @@ export default class Tooltip extends Controller<TooltipOption> {
 
     // 放在渲染tooltip之后，可以确保第一次触发'tooltip:show'
     // 的时候tooltip元素已经存在
-    view.emit('tooltip:show', {
-      items,
-      title,
-      ...point,
-    });
+    if (isEmitShow) {
+      view.emit('tooltip:show', {
+        items,
+        title,
+        ...point,
+      });
+    }
 
     if (!isEqual(lastTitle, title) || !isEqual(lastItems, items)) {
       // 内容发生变化了更新 tooltip


### PR DESCRIPTION
有的时候需要在“tooltip:show”或者“tooltip:change”触发的时候处理tooltip元素，但原来的代码，当它们第一次触发的时候，tooltip元素还没有被创建，所以我希望能在保证tooltip元素已经被创建了，才去触发这两个事件。

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
