### PR TITLE
Fix 2356

### DIFF
--- a/src/chart/layout/auto.ts
+++ b/src/chart/layout/auto.ts
@@ -20,7 +20,7 @@ export function calculatePadding(view: View): Padding {
   }
 
   // 是 auto padding，根据组件的情况，来计算 padding
-  const { viewBBox } = view;
+  const { viewBBox, autoPadding } = view;
 
   const paddingCal = new PaddingCal();
 
@@ -48,6 +48,17 @@ export function calculatePadding(view: View): Padding {
     }
   });
 
-  // 返回最终的 padding
-  return paddingCal.getPadding();
+  const calculatedPadding = paddingCal.getPadding();
+
+  if (autoPadding) {
+    // 取上一次以及当前计算结果的最大区间
+    return [
+      Math.max(autoPadding[0], calculatedPadding[0]),
+      Math.max(autoPadding[1], calculatedPadding[1]),
+      Math.max(autoPadding[2], calculatedPadding[2]),
+      Math.max(autoPadding[3], calculatedPadding[3]),
+    ];
+  }
+
+  return calculatedPadding;
 }

--- a/src/chart/layout/index.ts
+++ b/src/chart/layout/index.ts
@@ -26,7 +26,6 @@ export default function defaultLayout(view: View): void {
 
   // 1. 自动加 auto padding -> absolute padding
   const padding = calculatePadding(view);
-
   // 2. 计算出新的 coordinateBBox
   const newCoordinateBBox = view.viewBBox.shrink(padding);
   // 3. 如果 coordinateBBox 前后未发生变化则不需要进行组件的重布局

--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -17,6 +17,7 @@ import {
   set,
   size,
   uniqueId,
+  isEqual,
 } from '@antv/util';
 import { Attribute, Coordinate, Event as GEvent, GroupComponent, ICanvas, IGroup, IShape, Scale } from '../dependents';
 import {
@@ -1206,8 +1207,15 @@ export class View extends Base {
    * 调整 coordinate 的坐标范围。
    */
   public adjustCoordinate() {
+    const { start: curStart, end: curEnd } = this.getCoordinate();
     const start = this.coordinateBBox.bl;
     const end = this.coordinateBBox.tr;
+
+    if (isEqual(curStart, start) && isEqual(curEnd, end)) {
+      // 如果大小没有变化则不更新
+      return;
+    }
+
     this.coordinateInstance = this.coordinateController.adjust(start, end);
   }
 

--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -87,6 +87,8 @@ export class View extends Base {
   public padding: ViewPadding;
   /** G.Canvas 实例。 */
   public canvas: ICanvas;
+  /** 存储自动计算的 padding 值 */
+  public autoPadding: number[];
 
   /** 三层 Group 图形中的背景层。 */
   public backgroundGroup: IGroup;
@@ -132,6 +134,8 @@ export class View extends Base {
   private isPreMouseInPlot: boolean = false;
   /** 默认标识位，用于判定数据是否更新 */
   private isDataChanged: boolean = false;
+  /** 用于判断坐标系范围是否发生变化的标志位 */
+  private isCoordinateChanged: boolean = false;
   /** 从当前这个 view 创建的 scale key */
   private createdScaleKeys = new Map<string, boolean>();
 
@@ -230,6 +234,7 @@ export class View extends Base {
     this.filteredData = [];
     this.coordinateInstance = undefined;
     this.isDataChanged = false; // 复位
+    this.isCoordinateChanged = false; // 复位
 
     // 2. 清空 geometries
     const geometries = this.geometries;
@@ -1211,11 +1216,13 @@ export class View extends Base {
     const start = this.coordinateBBox.bl;
     const end = this.coordinateBBox.tr;
 
+    // 在 defaultLayoutFn 中只会在 coordinateBBox 发生变化的时候会调用 adjustCoorinate()，所以不用担心被置位
     if (isEqual(curStart, start) && isEqual(curEnd, end)) {
+      this.isCoordinateChanged = false;
       // 如果大小没有变化则不更新
       return;
     }
-
+    this.isCoordinateChanged = true;
     this.coordinateInstance = this.coordinateController.adjust(start, end);
   }
 
@@ -1249,6 +1256,19 @@ export class View extends Base {
     this.initComponents(isUpdate);
     // 4. 进行布局，计算 coordinateBBox，进行组件布局，update 位置
     this.doLayout();
+    // 5. 更新并存储最终的 padding 值
+    const viewBBox = this.viewBBox;
+    const coordinateBBox = this.coordinateBBox;
+
+    if (!this.padding) {
+      // 用户未设置 padding 时，将自动计算的 padding 保存至 autoPadding 属性中
+      this.autoPadding = [
+        coordinateBBox.tl.y - viewBBox.tl.y,
+        viewBBox.tr.x - coordinateBBox.tr.x,
+        viewBBox.bl.y - coordinateBBox.bl.y,
+        coordinateBBox.tl.x - viewBBox.tl.x
+      ];
+    }
 
     // 同样递归处理子 views
     const views = this.views;
@@ -1358,15 +1378,25 @@ export class View extends Base {
     const { start, end } = this.region;
 
     // 根据 region 计算当前 view 的 bbox 大小。
-    this.viewBBox = new BBox(
+    const viewBBox = new BBox(
       x + width * start.x,
       y + height * start.y,
       width * (end.x - start.x),
       height * (end.y - start.y)
     );
 
-    // 初始的 coordinate bbox 大小
-    this.coordinateBBox = this.viewBBox;
+    if (!this.viewBBox || !this.viewBBox.isEqual(viewBBox)) {
+      // viewBBox 发生变化的时候进行更新
+      this.viewBBox = new BBox(
+        x + width * start.x,
+        y + height * start.y,
+        width * (end.x - start.x),
+        height * (end.y - start.y)
+      );
+
+      // 初始的 coordinate bbox 大小
+      this.coordinateBBox = this.viewBBox;
+    }
   }
 
   /**
@@ -1494,7 +1524,7 @@ export class View extends Base {
           }
           e.type = PLOT_EVENTS.LEAVE;
           this.emit(PLOT_EVENTS.LEAVE, e);
-         } else if (!this.isPreMouseInPlot && currentInPlot) {
+        } else if (!this.isPreMouseInPlot && currentInPlot) {
           if (type === 'mousemove') {
             e.type = PLOT_EVENTS.MOUSE_ENTER;
             this.emit(PLOT_EVENTS.MOUSE_ENTER, e);
@@ -1543,7 +1573,7 @@ export class View extends Base {
     const geometries = this.geometries;
     for (let i = 0, len = geometries.length; i < len; i++) {
       const geometry = geometries[i];
-    // 保持 scales 引用不要变化
+      // 保持 scales 引用不要变化
       geometry.scales = this.getGeometryScales();
       const cfg = {
         coordinate, // 使用 coordinate 引用，可以保持 coordinate 的同步更新
@@ -1551,6 +1581,7 @@ export class View extends Base {
         data: this.filteredData,
         theme: this.themeObject,
         isDataChanged: this.isDataChanged,
+        isCoordinateChanged: this.isCoordinateChanged,
       };
 
       if (isUpdate) {

--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -92,6 +92,7 @@ export interface InitCfg {
   scaleDefs?: Record<string, ScaleOption>;
   /** 因为数据使用的引用，所以需要有一个标识位标识数据是否发生了更新 */
   isDataChanged?: boolean;
+  isCoordinateChanged?: boolean;
 }
 
 /** Geometry 构造函数参数 */
@@ -207,6 +208,7 @@ export default class Geometry extends Base {
   private offscreenGroup: IGroup;
   private groupScales: Scale[];
   private hasSorted: boolean = false;
+  protected isCoordinateChanged: boolean = false;
 
   /**
    * 创建 Geometry 实例。
@@ -793,7 +795,7 @@ export default class Geometry extends Base {
    * @param [cfg] 更新的配置
    */
   public update(cfg: InitCfg = {}) {
-    const { data, isDataChanged } = cfg;
+    const { data, isDataChanged, isCoordinateChanged } = cfg;
     const { attributeOption, lastAttributeOption } = this;
 
     if (!isEqual(attributeOption, lastAttributeOption)) {
@@ -810,6 +812,7 @@ export default class Geometry extends Base {
 
     // 调整 scale
     this.adjustScale();
+    this.isCoordinateChanged = isCoordinateChanged;
   }
 
   /**
@@ -911,6 +914,7 @@ export default class Geometry extends Base {
     this.idFields = [];
     this.groupScales = undefined;
     this.hasSorted = false;
+    this.isCoordinateChanged = false;
   }
 
   /**
@@ -1369,7 +1373,7 @@ export default class Geometry extends Base {
         // element 已经创建
         const currentShapeCfg = this.getDrawCfg(mappingDatum);
         const preShapeCfg = result.getModel();
-        if (isModelChange(currentShapeCfg, preShapeCfg)) {
+        if (this.isCoordinateChanged || isModelChange(currentShapeCfg, preShapeCfg)) {
           result.animate = this.animateOption;
           // 通过绘制数据的变更来判断是否需要更新，因为用户有可能会修改图形属性映射
           result.update(currentShapeCfg); // 更新对应的 element

--- a/src/geometry/path.ts
+++ b/src/geometry/path.ts
@@ -56,7 +56,7 @@ export default class Path extends Geometry {
     } else {
       // element 已经创建
       const preShapeCfg = result.getModel();
-      if (isModelChange(preShapeCfg, shapeCfg)) {
+      if (this.isCoordinateChanged || isModelChange(preShapeCfg, shapeCfg)) {
         result.animate = this.animateOption;
         // 通过绘制数据的变更来判断是否需要更新，因为用户有可能会修改图形属性映射
         result.update(shapeCfg); // 更新对应的 element

--- a/tests/bugs/2356-spec.ts
+++ b/tests/bugs/2356-spec.ts
@@ -1,0 +1,49 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+
+describe('2356', () => {
+  it('2356', () => {
+    const data = [
+      { type: '未知', value: 654, percent: 0.02 },
+      { type: '17 岁以下', value: 654, percent: 0.02 },
+      { type: '18-24 岁', value: 4400, percent: 0.2 },
+      { type: '25-29 岁', value: 5300, percent: 0.24 },
+      { type: '30-39 岁', value: 6200, percent: 0.28 },
+      { type: '40-49 岁', value: 3300, percent: 0.14 },
+      { type: '50 岁以上', value: 1500, percent: 0.06 },
+    ];
+
+    const chart = new Chart({
+      container: createDiv(),
+      width: 400,
+      height: 300,
+      padding: [50, 20, 50, 20],
+    });
+    chart.data(data);
+    chart.animate(false);
+    chart.scale('value', {
+      alias: '销售额(万)',
+    });
+
+    chart.axis('type', {
+      tickLine: {
+        alignTick: false,
+      },
+    });
+    chart.axis('value', false);
+
+    chart.tooltip({
+      showMarkers: false,
+    });
+    chart.interval().position('type*value');
+    chart.render();
+
+    chart.changeSize(400, 600);
+
+    const element = chart.geometries[0].elements[4];
+    expect(element.getBBox().height).toBe(500);
+    expect(chart.autoPadding).toBeUndefined();
+    expect(chart.padding).toEqual([50, 20, 50, 20]);
+
+  });
+});

--- a/tests/unit/component/legend-category-spec.ts
+++ b/tests/unit/component/legend-category-spec.ts
@@ -59,6 +59,12 @@ describe('Legend category', () => {
 
     // right
     expect(x).toBeGreaterThan(700);
+
+    expect(chart.autoPadding.length).toBe(4);
+    expect(chart.autoPadding[0]).toBe(6);
+    expect(chart.autoPadding[1]).toBe(40);
+    expect(chart.autoPadding[2]).toBe(28);
+    expect(chart.autoPadding[3]).toBeCloseTo(28.2659912109375);
   });
 });
 


### PR DESCRIPTION
1. 首先导致这个 bug 的原因是，在 Geometry 更新阶段，无法只根据 element 的 model 进行判断，因为有的情况整个 shape 的 bbox 发生变化，当时它的数据点对应的 x 和 y 坐标并未发生变化
2. 解决这个问题，做了以下几点的修改：
    * 增加 `isCoordinateChanged` 标志位，这样当坐标系范围发生变换的时候，就要对 shape 进行更新
    * 添加 `autoPadding` 属性来存储每次自动计算出来的 padding 值，这样就可以保证每次更新后的 padding 是正确的（因为我在 `calculateViewBBox()` 方法里做了个是否更新的判断）