### PR TITLE
feat: support legend layout margin

### DIFF
--- a/src/chart/controller/legend.ts
+++ b/src/chart/controller/legend.ts
@@ -103,6 +103,7 @@ export default class Legend extends Controller<Option> {
    */
   public layout() {
     this.layoutBBox = this.view.viewBBox;
+    const margin = get(this.view.getTheme(), ['components', 'legend', 'margin'], [0, 0, 0, 0]);
 
     each(this.components, (co: ComponentOption) => {
       const { component, direction } = co;
@@ -134,6 +135,20 @@ export default class Legend extends Controller<Option> {
       } else {
         x = x2;
         y = y1;
+      }
+
+      // 加上 margin
+      if (direction.indexOf('left') >= 0) {
+        x += margin[3];
+      }
+      if (direction.indexOf('right') >= 0) {
+        x -= margin[1];
+      }
+      if (direction.indexOf('top') >= 0) {
+        y += margin[0];
+      }
+      if (direction.indexOf('bottom') >= 0) {
+        y -= margin[2];
       }
 
       // 更新位置

--- a/src/util/theme.ts
+++ b/src/util/theme.ts
@@ -1033,6 +1033,8 @@ export function createThemeByStylesheet(styleSheet: StyleSheet): LooseObject {
           },
           slidable: true,
         },
+        // 图例与四条边之间的间距
+        margin: [0, 0, 0, 0],
       },
       tooltip: {
         showContent: true,

--- a/tests/unit/chart/controller/legend-spec.ts
+++ b/tests/unit/chart/controller/legend-spec.ts
@@ -242,11 +242,46 @@ describe('Legend', () => {
     chart.interval().position('月份*月均降雨量').color('name').adjust('dodge');
     chart.render();
 
-    expect(chart).toBeDefined();
-
     const legend = chart.getController('legend').getComponents()[0].component;
     const legendBBox = legend.getBBox();
     expect(legendBBox.x).toBe(0);
+  });
+
+  it('legend margin', () => {
+    const container = createDiv();
+    chart = new Chart({
+      container,
+      height: 500,
+      width: 600,
+      autoFit: false,
+      theme: {
+        components: {
+          legend: {
+            margin: [1, 2, 3, 4],
+          },
+        },
+      },
+    });
+    chart.data([
+      { name: 'London', 月份: 'Jan.', 月均降雨量: 18.9 },
+      { name: 'London', 月份: 'Feb.', 月均降雨量: 28.8 },
+      { name: 'London', 月份: 'Mar.', 月均降雨量: 39.3 },
+      { name: 'Berlin', 月份: 'Jan.', 月均降雨量: 12.4 },
+      { name: 'Berlin', 月份: 'Feb.', 月均降雨量: 23.2 },
+      { name: 'Berlin', 月份: 'Mar.', 月均降雨量: 34.5 },
+    ]);
+
+    chart.legend('name', {
+      position: 'top-left',
+    });
+
+    chart.interval().position('月份*月均降雨量').color('name').adjust('dodge');
+    chart.render();
+
+    const legend = chart.getController('legend').getComponents()[0].component;
+    const legendBBox = legend.getBBox();
+    expect(legendBBox.x).toBe(4);
+    expect(legendBBox.y).toBe(1);
   });
 
   afterAll(() => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

G2Plot 中有 bleeding 的概念，在 legend 默认布局上需要加个 margin 才能对齐
