### PR TITLE
fix: error if chart destroyed during resize

### DIFF
--- a/src/chart/chart.ts
+++ b/src/chart/chart.ts
@@ -156,9 +156,12 @@ export default class Chart extends View {
    * 自动根据容器大小 resize 画布
    */
   public forceFit() {
-    // 注意第二参数用 true，意思是即时 autoFit = false，forceFit() 调用之后一样是适配容器
-    const { width, height } = getChartSize(this.ele, true, this.width, this.height);
-    this.changeSize(width, height);
+    // skip if already destroyed
+    if(!this.destroyed){
+      // 注意第二参数用 true，意思是即时 autoFit = false，forceFit() 调用之后一样是适配容器
+      const { width, height } = getChartSize(this.ele, true, this.width, this.height);
+      this.changeSize(width, height);
+    }
   }
 
   private updateCanvasStyle() {

--- a/tests/unit/chart/chart-spec.ts
+++ b/tests/unit/chart/chart-spec.ts
@@ -174,6 +174,7 @@ describe('Chart', () => {
     expect(chart.getLayer(LAYER.FORE).destroyed).toBe(true);
     expect(destroyEvent).toBeCalledTimes(1);
 
+    expect(() => { chart.forceFit() }).not.toBeThrow();
     expect(chart.destroyed).toBe(true);
     expect(chart.canvas.destroyed).toBe(true);
     expect(div.childNodes.length).toBe(0);

--- a/tests/unit/chart/chart-spec.ts
+++ b/tests/unit/chart/chart-spec.ts
@@ -174,6 +174,7 @@ describe('Chart', () => {
     expect(chart.getLayer(LAYER.FORE).destroyed).toBe(true);
     expect(destroyEvent).toBeCalledTimes(1);
 
+    expect(chart.destroyed).toBe(true);
     expect(chart.canvas.destroyed).toBe(true);
     expect(div.childNodes.length).toBe(0);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
Check if the chart is destroyed before attempting to resize chart.
The onResize method is debounced so it always gets called