### PR TITLE
fix(legend): 修改 legend 布局的宽高限制

### DIFF
--- a/src/chart/controller/legend.ts
+++ b/src/chart/controller/legend.ts
@@ -587,14 +587,15 @@ export default class Legend extends Controller<Option> {
 
   private getCategoryLegendSizeCfg(layout: 'horizontal' | 'vertical') {
     const { width: vw, height: vh } = this.view.viewBBox;
-    const { width: cw, height: ch } = this.view.coordinateBBox;
+    // 目前 legend 的布局是以 viewBBox 为参照
+    // const { width: cw, height: ch } = this.view.coordinateBBox;
     return layout === 'vertical'
       ? {
           maxWidth: vw * COMPONENT_MAX_VIEW_PERCENTAGE,
-          maxHeight: ch,
+          maxHeight: vh,
         }
       : {
-          maxWidth: cw,
+          maxWidth: vw,
           maxHeight: vh * COMPONENT_MAX_VIEW_PERCENTAGE,
         };
   }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -858,6 +858,11 @@ export interface LegendItem {
   marker?: MarkerCfg;
 }
 
+export interface G2LegendTitleCfg extends LegendTitleCfg {
+  /** title 文本显示内容 */
+  text?: string;
+}
+
 /**
  * 图例项配置
  */
@@ -884,7 +889,7 @@ export interface LegendCfg {
    *
    * 详见 {@link https://github.com/antvis/component/blob/81890719a431b3f9088e0c31c4d5d382ef0089df/src/types.ts#L639|LegendTitleCfg}，
    */
-  title?: LegendTitleCfg;
+  title?: G2LegendTitleCfg;
   /**
    * 背景框配置项。
    *

--- a/tests/unit/chart/controller/legend-spec.ts
+++ b/tests/unit/chart/controller/legend-spec.ts
@@ -127,7 +127,6 @@ describe('Legend', () => {
       { name: 'Berlin', 月份: 'Mar.', 月均降雨量: 34.5 },
     ]);
 
-    // @ts-ignore
     chart.legend({
       custom: true,
       items: [
@@ -198,6 +197,7 @@ describe('Legend', () => {
     });
 
     chart.data(data);
+    chart.animate(false);
     chart.scale('sold', {
       max: 3600,
       nice: false,
@@ -209,14 +209,15 @@ describe('Legend', () => {
 
     const legend = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND)[0].component;
 
-    // expect(legend.get('flipPage')).toBe(true);
-    // // @ts-ignore
-    // expect(legend.totalPagesCnt).toBe(2);
-    // // @ts-ignore
-    // expect(legend.pageHeight).toBe(20);
-
     expect(legend.get('maxWidth')).toBe(chart.viewBBox.width);
     expect(legend.get('maxHeight')).toBe(chart.viewBBox.height * COMPONENT_MAX_VIEW_PERCENTAGE);
+
+    chart.changeSize(300, 300);
+    expect(legend.get('flipPage')).toBe(true);
+    // @ts-ignore
+    expect(legend.totalPagesCnt).toBe(2);
+    // @ts-ignore
+    expect(legend.pageHeight).toBe(20);
   });
 
   it('legend align with axis', () => {

--- a/tests/unit/chart/controller/legend-spec.ts
+++ b/tests/unit/chart/controller/legend-spec.ts
@@ -1,4 +1,4 @@
-import { COMPONENT_TYPE } from '../../../../src/constant';
+import { COMPONENT_TYPE, COMPONENT_MAX_VIEW_PERCENTAGE } from '../../../../src/constant';
 import { Chart } from '../../../../src/index';
 import { createDiv } from '../../../util/dom';
 
@@ -127,16 +127,14 @@ describe('Legend', () => {
       { name: 'Berlin', 月份: 'Mar.', 月均降雨量: 34.5 },
     ]);
 
+    // @ts-ignore
     chart.legend({
       custom: true,
       items: [
-        // @ts-ignore
         { name: 'London', value: 'London', marker: { symbol: 'tick', style: { r: 10 } } },
-        // @ts-ignore
         { name: 'Berlin', value: 'Berlin', marker: { symbol: 'circle', style: { r: 10 } } },
       ],
       title: {
-        // @ts-ignore
         text: '城市',
       },
     });
@@ -211,11 +209,14 @@ describe('Legend', () => {
 
     const legend = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND)[0].component;
 
-    expect(legend.get('flipPage')).toBe(true);
-    // @ts-ignore
-    expect(legend.totalPagesCnt).toBe(2);
-    // @ts-ignore
-    expect(legend.pageHeight).toBe(20);
+    // expect(legend.get('flipPage')).toBe(true);
+    // // @ts-ignore
+    // expect(legend.totalPagesCnt).toBe(2);
+    // // @ts-ignore
+    // expect(legend.pageHeight).toBe(20);
+
+    expect(legend.get('maxWidth')).toBe(chart.viewBBox.width);
+    expect(legend.get('maxHeight')).toBe(chart.viewBBox.height * COMPONENT_MAX_VIEW_PERCENTAGE);
   });
 
   it('legend align with axis', () => {


### PR DESCRIPTION
目前 legend 的布局范围已经改为整个画布了，但是的最大宽高还是 coordinateBBox，就导致了本该展示一行的图例意外折行了
