### PR TITLE
fix: #2279 修复canvas resize之后tooltip越界的问题

### DIFF
--- a/src/chart/controller/tooltip.ts
+++ b/src/chart/controller/tooltip.ts
@@ -138,6 +138,18 @@ export default class Tooltip extends Controller<TooltipOption> {
       const isCrosshairsFollowCursor = get(cfg, ['crosshairs', 'follow'], false); // 辅助线是否要跟随鼠标
       this.renderCrosshairs(isCrosshairsFollowCursor ? point : dataPoint, cfg);
     }
+
+    // #2279 修复resize之后tooltip越界的问题
+    // 兼容没有 changeRegion 这个方法的版本
+    if( this.tooltip.changeRegion ) {
+      const canvas = this.view.getCanvas();
+      // 更新 region
+      const region = {
+        start: { x: 0, y: 0 },
+        end: { x: canvas.get('width'), y: canvas.get('height') },
+      };
+      this.tooltip.changeRegion(region);
+    }
   }
 
   public hideTooltip() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->


复现步骤（借之前issues的图）#2279 
> 之前官方说4.0.4 版本应该修复了吧，然而并没有修复

![image](http://s.verydog.cn/78635715-6b339380-78d9-11ea-8397-79ae93e1957d.gif)  
看不到动图的话用这个链接 
`http://s.verydog.cn/78635715-6b339380-78d9-11ea-8397-79ae93e1957d.gif`

个人发现是 `@antv/component` 的 `HtmlTooltip` 在初始化后，在canvas resize 后就没有更改 `region`，实践后具体建议修改如下

@ `@antv/component` `/src/tooltip/html.ts`

添加方法

```ts
  // 当resize的时候应当改变限制区域
  public changeRegion(region) {
    this.set('region', region);
  }
```

@ `@antv/g2` `/src/chart/controller/tooltip.ts`

```ts
// 修改 showTooltip 方法，当显示的时候重新传递限制区域
public showTooltip(point: Point) {
   ...
    // 兼容没有 changeRegion 这个方法的版本
    if( this.tooltip.changeRegion ) {
      const canvas = this.view.getCanvas();
      // 更新 region
      const region = {
        start: { x: 0, y: 0 },
        end: { x: canvas.get('width'), y: canvas.get('height') },
      };
      this.tooltip.changeRegion(region);
    }
}
```
由于需要修改2个项目的不同地方，我提了2个pr，本地已经测试过了。慎重起见请官方在测试看看是否可以合并。