### PR TITLE
优化坐标轴超常文本展现策略

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "site:deploy": "npm run doc && npm run site:build && gh-pages -d public",
     "clean": "rimraf lib esm dist",
     "lint": "run-p lint:*",
-    "lint:prettier": "prettier -c 'src/**/*.ts'",
     "lint:tslint": "tslint -c tslint.json 'src/**/*.ts'",
     "test": "jest",
     "test-live": "DEBUG_MODE=1 jest --watch tests/unit",

--- a/src/chart/chart.ts
+++ b/src/chart/chart.ts
@@ -144,6 +144,7 @@ export default class Chart extends View {
    * @returns
    */
   public changeVisible(visible: boolean) {
+    super.changeVisible(visible); // 需要更新 visible 变量
     this.wrapperElement.style.display = visible ? '' : 'none';
 
     return this;

--- a/src/chart/controller/axis.ts
+++ b/src/chart/controller/axis.ts
@@ -1,5 +1,5 @@
 import { deepMix, each, get, isUndefined } from '@antv/util';
-import { COMPONENT_TYPE, DIRECTION, LAYER } from '../../constant';
+import { DIRECTION, COMPONENT_TYPE, LAYER } from '../../constant';
 import { CircleAxis, CircleGrid, IGroup, LineAxis, LineGrid, Scale } from '../../dependents';
 import { AxisCfg, AxisOption, ComponentOption } from '../../interface';
 
@@ -12,6 +12,7 @@ import {
   getAxisThemeCfg,
   getAxisTitleText,
   getCircleAxisCenterRadius,
+  isVertical,
 } from '../../util/axis';
 import { getAxisOption } from '../../util/axis';
 import { getCircleGridItems, getGridThemeCfg, getLineGridItems, showGrid } from '../../util/grid';
@@ -242,8 +243,7 @@ export default class Axis extends Controller<Option> {
       // 存在则更新
       if (axis) {
         const cfg = coordinate.isTransposed
-          ? // @ts-ignore
-            this.getLineAxisCfg(scale, xAxisOption, 'radius')
+          ? this.getLineAxisCfg(scale, xAxisOption, DIRECTION.RADIUS)
           : this.getCircleAxisCfg(scale, xAxisOption, direction);
 
         omit(cfg, OMIT_CFG);
@@ -256,8 +256,7 @@ export default class Axis extends Controller<Option> {
             // 默认不渲染转置极坐标下的坐标轴
             return;
           } else {
-            // @ts-ignore
-            axis = this.createLineAxis(scale, xAxisOption, layer, 'radius', dim);
+            axis = this.createLineAxis(scale, xAxisOption, layer, DIRECTION.RADIUS, dim);
           }
         } else {
           axis = this.createCircleAxis(scale, xAxisOption, layer, direction, dim);
@@ -271,10 +270,8 @@ export default class Axis extends Controller<Option> {
       // 存在则更新
       if (grid) {
         const cfg = coordinate.isTransposed
-          ? // @ts-ignore
-            this.getCircleGridCfg(scale, xAxisOption, 'radius', dim)
-          : // @ts-ignore
-            this.getLineGridCfg(scale, xAxisOption, 'circle', dim);
+          ? this.getCircleGridCfg(scale, xAxisOption, DIRECTION.RADIUS, dim)
+          : this.getLineGridCfg(scale, xAxisOption, DIRECTION.CIRCLE, dim);
         omit(cfg, OMIT_CFG);
         grid.component.update(cfg);
         updatedCache.set(gridId, grid);
@@ -284,12 +281,10 @@ export default class Axis extends Controller<Option> {
           if (isUndefined(xAxisOption)) {
             return;
           } else {
-            // @ts-ignore
-            grid = this.createCircleGrid(scale, xAxisOption, layer, 'radius', dim);
+            grid = this.createCircleGrid(scale, xAxisOption, layer, DIRECTION.RADIUS, dim);
           }
         } else {
-          // @ts-ignore
-          grid = this.createLineGrid(scale, xAxisOption, layer, 'circle', dim);
+          grid = this.createLineGrid(scale, xAxisOption, layer, DIRECTION.CIRCLE, dim);
         }
 
         if (grid) {
@@ -362,10 +357,8 @@ export default class Axis extends Controller<Option> {
           // 存在则更新
           if (axis) {
             const cfg = coordinate.isTransposed
-              ? // @ts-ignore
-                this.getCircleAxisCfg(scale, yAxisOption, 'circle')
-              : // @ts-ignore
-                this.getLineAxisCfg(scale, yAxisOption, 'radius');
+              ? this.getCircleAxisCfg(scale, yAxisOption, DIRECTION.CIRCLE)
+              : this.getLineAxisCfg(scale, yAxisOption, DIRECTION.RADIUS);
 
             // @ts-ignore
             omit(cfg, OMIT_CFG);
@@ -377,12 +370,10 @@ export default class Axis extends Controller<Option> {
               if (isUndefined(yAxisOption)) {
                 return;
               } else {
-                // @ts-ignore
-                axis = this.createCircleAxis(scale, yAxisOption, layer, 'circle', dim);
+                axis = this.createCircleAxis(scale, yAxisOption, layer, DIRECTION.CIRCLE, dim);
               }
             } else {
-              // @ts-ignore
-              axis = this.createLineAxis(scale, yAxisOption, layer, 'radius', dim);
+              axis = this.createLineAxis(scale, yAxisOption, layer, DIRECTION.RADIUS, dim);
             }
 
             this.cache.set(axisId, axis);
@@ -394,10 +385,8 @@ export default class Axis extends Controller<Option> {
           // 存在则更新
           if (grid) {
             const cfg = coordinate.isTransposed
-              ? // @ts-ignore
-                this.getLineGridCfg(scale, yAxisOption, 'circle', dim)
-              : // @ts-ignore
-                this.getCircleGridCfg(scale, yAxisOption, 'radius', dim);
+              ? this.getLineGridCfg(scale, yAxisOption, DIRECTION.CIRCLE, dim)
+              : this.getCircleGridCfg(scale, yAxisOption, DIRECTION.RADIUS, dim);
             omit(cfg, OMIT_CFG);
             grid.component.update(cfg);
             updatedCache.set(gridId, grid);
@@ -407,12 +396,10 @@ export default class Axis extends Controller<Option> {
               if (isUndefined(yAxisOption)) {
                 return;
               } else {
-                // @ts-ignore
-                grid = this.createLineGrid(scale, yAxisOption, layer, 'circle', dim);
+                grid = this.createLineGrid(scale, yAxisOption, layer, DIRECTION.CIRCLE, dim);
               }
             } else {
-              // @ts-ignore
-              grid = this.createCircleGrid(scale, yAxisOption, layer, 'radius', dim);
+              grid = this.createCircleGrid(scale, yAxisOption, layer, DIRECTION.RADIUS, dim);
             }
 
             if (grid) {
@@ -469,16 +456,13 @@ export default class Axis extends Controller<Option> {
           } else {
             // 如果用户打开了隐藏的坐标轴 chart.axis(true)/chart.axis('x', true)
             // 那么对于转置了的极坐标，半径轴显示的是 x 轴对应的数据
-            // @ts-ignore
-            axis = this.createLineAxis(scale, xAxisOption, layer, 'radius', dim);
-            // @ts-ignore
-            grid = this.createCircleGrid(scale, xAxisOption, layer, 'radius', dim);
+            axis = this.createLineAxis(scale, xAxisOption, layer, DIRECTION.RADIUS, dim);
+            grid = this.createCircleGrid(scale, xAxisOption, layer, DIRECTION.RADIUS, dim);
           }
         } else {
           axis = this.createCircleAxis(scale, xAxisOption, layer, direction, dim);
           // grid，极坐标下的 x 轴网格线沿着半径方向绘制
-          // @ts-ignore
-          grid = this.createLineGrid(scale, xAxisOption, layer, 'circle', dim);
+          grid = this.createLineGrid(scale, xAxisOption, layer, DIRECTION.CIRCLE, dim);
         }
 
         this.cache.set(axisId, axis);
@@ -532,16 +516,12 @@ export default class Axis extends Controller<Option> {
             if (isUndefined(yAxisOption)) {
               return;
             } else {
-              // @ts-ignore
-              axis = this.createCircleAxis(scale, yAxisOption, layer, 'circle', dim);
-              // @ts-ignore
-              grid = this.createLineGrid(scale, yAxisOption, layer, 'circle', dim);
+              axis = this.createCircleAxis(scale, yAxisOption, layer, DIRECTION.CIRCLE, dim);
+              grid = this.createLineGrid(scale, yAxisOption, layer, DIRECTION.CIRCLE, dim);
             }
           } else {
-            // @ts-ignore
-            axis = this.createLineAxis(scale, yAxisOption, layer, 'radius', dim);
-            // @ts-ignore
-            grid = this.createCircleGrid(scale, yAxisOption, layer, 'radius', dim);
+            axis = this.createLineAxis(scale, yAxisOption, layer, DIRECTION.RADIUS, dim);
+            grid = this.createCircleGrid(scale, yAxisOption, layer, DIRECTION.RADIUS, dim);
           }
           this.cache.set(this.getId('axis', scale.field), axis);
           if (grid) {
@@ -573,8 +553,7 @@ export default class Axis extends Controller<Option> {
     const axis = {
       component: new LineAxis(this.getLineAxisCfg(scale, option, direction)),
       layer,
-      // @ts-ignore
-      direction: direction === 'radius' ? DIRECTION.NONE : direction,
+      direction: direction === DIRECTION.RADIUS ? DIRECTION.NONE : direction,
       type: COMPONENT_TYPE.AXIS,
       extra: { dim, scale },
     };
@@ -690,6 +669,17 @@ export default class Axis extends Controller<Option> {
     const { animate, animateOption } = this.getAnimateCfg(cfg);
     cfg.animateOption = animateOption;
     cfg.animate = animate;
+
+    // 计算 verticalLimitLength
+    const isAxisVertical = isVertical(region);
+    // TODO: 1 / 3 等默认值需要有一个全局的配置的地方
+    const verticalLimitLength = get(cfg, 'verticalLimitLength', isAxisVertical ? 1 / 3 : 1 / 2);
+    if (verticalLimitLength <= 1) {
+      // 配置的相对值
+      const { width: viewWidth, height: viewHeight } = this.view.viewBBox;
+      cfg.verticalLimitLength = verticalLimitLength * (isAxisVertical ? viewWidth : viewHeight);
+    }
+
     return cfg;
   }
 
@@ -739,7 +729,7 @@ export default class Axis extends Controller<Option> {
     }
 
     const titleText = getAxisTitleText(scale, axisOption);
-    const axisThemeCfg = getAxisThemeCfg(this.view.getTheme(), 'circle');
+    const axisThemeCfg = getAxisThemeCfg(this.view.getTheme(), DIRECTION.CIRCLE);
     // the cfg order should be ensure
     const optionWithTitle = get(axisOption, ['title'])
       ? deepMix({ title: { style: { text: titleText } } }, axisOption)
@@ -775,8 +765,7 @@ export default class Axis extends Controller<Option> {
 
     // the cfg order should be ensure
     // grid 动画以 axis 为准
-    // @ts-ignore
-    const gridThemeCfg = getGridThemeCfg(this.view.getTheme(), 'radius');
+    const gridThemeCfg = getGridThemeCfg(this.view.getTheme(), DIRECTION.RADIUS);
     const gridCfg = deepMix(
       {
         container: this.gridContainer,

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -26,6 +26,8 @@ export enum DIRECTION {
   BOTTOM = 'bottom',
   BOTTOM_LEFT = 'bottom-left',
   BOTTOM_RIGHT = 'bottom-right',
+  RADIUS = 'radius',
+  CIRCLE = 'circle',
   // no direction information
   NONE = 'none',
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1349,6 +1349,14 @@ export interface AxisCfg {
   animateOption?: ComponentAnimateOption;
   /** 标记坐标轴 label 的方向，左侧为 1，右侧为 -1。 */
   verticalFactor?: number;
+  /**
+   * 配置坐标轴垂直方向的最大限制长度，对文本自适应有很大影响。
+   * 1. 可以直接设置像素值，如 100；
+   * 2. 也可设置绝对值，如 0.2，如果是 x 轴，则相对于图表的高度，如果是 y 轴，则相对于图表的宽度
+   *
+   * 在 G2 中，x 轴的文本默认最大高度为图表高度的 1/2，y 轴的文本默认最大长度为图表宽度的 1/3
+   */
+  verticalLimitLength?: number;
 }
 
 /** 配置项声明式 */

--- a/src/util/theme.ts
+++ b/src/util/theme.ts
@@ -162,6 +162,7 @@ export function createThemeByStylesheet(styleSheet: StyleSheet): LooseObject {
     },
     label: {
       autoRotate: true,
+      autoEllipsis: true,
       autoHide: true,
       offset: 16,
       style: {
@@ -945,11 +946,13 @@ export function createThemeByStylesheet(styleSheet: StyleSheet): LooseObject {
           position: 'top',
           grid: null,
           title: null,
+          verticalLimitLength: 1 / 2,
         }),
         bottom: deepMix({}, axisStyles, {
           position: 'bottom',
           grid: null,
           title: null,
+          verticalLimitLength: 1 / 2,
         }),
         left: deepMix({}, axisStyles, {
           position: 'left',
@@ -960,6 +963,7 @@ export function createThemeByStylesheet(styleSheet: StyleSheet): LooseObject {
           line: null,
           tickLine: null,
           grid: axisGridStyles,
+          verticalLimitLength: 1 / 3,
         }),
         right: deepMix({}, axisStyles, {
           position: 'right',
@@ -970,6 +974,7 @@ export function createThemeByStylesheet(styleSheet: StyleSheet): LooseObject {
           line: null,
           tickLine: null,
           grid: axisGridStyles,
+          verticalLimitLength: 1 / 3,
         }),
         circle: deepMix({}, axisStyles, {
           title: null,

--- a/tests/unit/chart/controller/axis-auto-overlap.ts
+++ b/tests/unit/chart/controller/axis-auto-overlap.ts
@@ -1,0 +1,55 @@
+import 'jest-extended';
+import { COMPONENT_TYPE } from '../../../../src/constant';
+import { Chart } from '../../../../src/index';
+import { removeDom } from '../../../../src/util/dom';
+import { createDiv } from '../../../util/dom';
+
+describe('axis auto overlap', () => {
+  const container = createDiv();
+  const data = [
+    { year: '1991还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗', value: 3 },
+    { year: '1992还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗', value: 4 },
+    { year: '1993还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗', value: 3.5 },
+    { year: '1994还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗', value: 5 },
+    { year: '1995还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗', value: 4.9 },
+    { year: '1996还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗', value: 6 },
+    { year: '1997还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗', value: 7 },
+    { year: '1998还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗', value: 9 },
+    { year: '1999还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗还是不够长吗', value: 13 },
+  ];
+  const chart = new Chart({
+    container,
+    width: 500,
+    height: 300,
+  });
+
+  chart.data(data);
+  chart.animate(false);
+  chart.axis('year', {
+    position: 'bottom',
+    label: {
+      autoRotate: true,
+      autoHide: false,
+      autoEllipsis: true,
+    },
+  });
+  chart.line().position('year*value').label('value');
+  chart.render();
+
+  function getAxes() {
+    return chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.AXIS);
+  }
+
+  it('axis', async () => {
+    const xAxis = getAxes().filter(axis => axis.direction === 'bottom')[0];
+    const labelGroup = xAxis.component.get('group').findAllByName('axis-label-group')[0];
+    const label = labelGroup.getChildren()[0];
+    expect(label.attr('text')).toBe('1991还是不够长吗还是不够长吗…');
+    expect(label.getCanvasBBox().height).toBeLessThan(150);
+  });
+
+  afterAll(() => {
+    chart.destroy();
+    removeDom(container);
+  });
+});


### PR DESCRIPTION
1. 只作用于直角坐标系
2. 默认 x 轴文本占据最大高度为图表高度的 1/2，y 轴文本占据最大宽度为图表宽度的 1/3，超出则自动旋转、省略
3. 开放 `verticalLimitLength` 属性用于范围限制

![image](https://user-images.githubusercontent.com/6628666/86931388-a066b080-c16a-11ea-8eb2-409fabbe62b2.png)
![Snip20200708_47](https://user-images.githubusercontent.com/6628666/86931470-b8d6cb00-c16a-11ea-9431-b206ac91f90a.png)
