### PR TITLE
fix: 修复 interval 下 shape='line' 设置 lineCap 失效的问题

### DIFF
--- a/src/geometry/shape/interval/line.ts
+++ b/src/geometry/shape/interval/line.ts
@@ -32,7 +32,7 @@ registerShape('interval', 'line', {
   },
   draw(cfg: ShapeInfo, container: IGroup) {
     const style = getStyle(cfg, true, false, 'lineWidth');
-    const path = this.parsePath(getRectPath(cfg.points as Point[]));
+    const path = this.parsePath(getRectPath(cfg.points as Point[], false));
     const shape = container.addShape('path', {
       attrs: {
         ...style,

--- a/src/geometry/shape/interval/util.ts
+++ b/src/geometry/shape/interval/util.ts
@@ -64,6 +64,7 @@ export function getRectPoints(pointInfo: ShapePoint, isPyramid = false): Point[]
  * @ignore
  * 根据矩形关键点绘制 path
  * @param points 关键点数组
+ * @param isClosed path 是否需要闭合
  * @returns 返回矩形的 path
  */
 export function getRectPath(points: Point[], isClosed: boolean = true): PathCommand[] {

--- a/src/geometry/shape/interval/util.ts
+++ b/src/geometry/shape/interval/util.ts
@@ -66,15 +66,18 @@ export function getRectPoints(pointInfo: ShapePoint, isPyramid = false): Point[]
  * @param points 关键点数组
  * @returns 返回矩形的 path
  */
-export function getRectPath(points: Point[]): PathCommand[] {
+export function getRectPath(points: Point[], isClosed: boolean = true): PathCommand[] {
   const path = [];
   const firstPoint = points[0];
   path.push(['M', firstPoint.x, firstPoint.y]);
   for (let i = 1, len = points.length; i < len; i++) {
     path.push(['L', points[i].x, points[i].y]);
   }
-  path.push(['L', firstPoint.x, firstPoint.y]); // 需要闭合
-  path.push(['z']);
+  // 对于 shape="line" path 不应该闭合，否则会造成 lineCap 绘图属性失效
+  if (isClosed) {
+    path.push(['L', firstPoint.x, firstPoint.y]); // 需要闭合
+    path.push(['z']);
+  }
   return path;
 }
 

--- a/tests/unit/geometry/shape/interval-spec.ts
+++ b/tests/unit/geometry/shape/interval-spec.ts
@@ -269,7 +269,7 @@ describe('Interval shapes', () => {
       canvas.draw();
       const path = shape.attr('path');
       expect(shape.attr('stroke')).toBe('green');
-      expect(path.length).toBe(4);
+      expect(path.length).toBe(2);
       expect(shape.getBBox().width).toBe(10);
       expect(path[0][2] - path[1][2]).toBe(125);
     });


### PR DESCRIPTION
如果 path 闭合的话，就会失效。