### PR TITLE
fix(pie-label): 饼图 label 若干修复

### DIFF
--- a/src/component/labels.ts
+++ b/src/component/labels.ts
@@ -1,12 +1,11 @@
 import { deepMix, each, get, isArray } from '@antv/util';
-
-import { BBox, IGroup, IShape } from '../dependents';
+import { BBox, Coordinate, IGroup, IShape } from '../dependents';
 import { LabelItem } from '../geometry/label/interface';
 import { AnimateOption, GeometryLabelLayoutCfg } from '../interface';
 
 import { doAnimate } from '../animate';
 import { getGeometryLabelLayout } from '../geometry/label';
-import { getReplaceAttrs } from '../util/graphics';
+import { getReplaceAttrs, polarToCartesian } from '../util/graphics';
 import { rotate, translate } from '../util/transform';
 
 /**
@@ -230,7 +229,11 @@ export default class Labels {
   }
 
   private renderLabelLine(labelItems: LabelItem[]) {
+    const coordinate: Coordinate = get(labelItems[0], 'coordinate');
+
     each(labelItems, (labelItem) => {
+      const center = coordinate.getCenter();
+      const radius = coordinate.getRadius();
       if (!labelItem) {
         return;
       }
@@ -242,7 +245,7 @@ export default class Labels {
       const id = labelItem.id;
       let path = labelLineCfg.path;
       if (!path) {
-        const start = labelItem.start;
+        const start = polarToCartesian(center.x, center.y, radius, labelItem.angle);
         path = [
           ['M', start.x, start.y],
           ['L', labelItem.x, labelItem.y],

--- a/src/geometry/label/layout/distribute.ts
+++ b/src/geometry/label/layout/distribute.ts
@@ -1,9 +1,10 @@
-import { isObject, each, get } from '@antv/util';
+import { isObject, each, find, get } from '@antv/util';
 
 import { BBox, IGroup, IShape } from '../../../dependents';
 import { LabelItem } from '../interface';
 
 import { polarToCartesian } from '../../../util/graphics';
+import { IElement } from '@antv/g-base';
 
 /** label text和line距离 4px */
 const MARGIN = 4;
@@ -104,6 +105,14 @@ function antiCollision(labelShapes, labels, lineHeight, plotRange, center, isRig
     const labelShape = labelsMap[label.id];
     labelShape.attr('x', label.x);
     labelShape.attr('y', label.y);
+
+    // because group could not effect text-shape, should set text-shape position manually
+    const textShape = find(labelShape.getChildren(), (ele) => ele.get('type') === 'text') as IElement;
+    // @ts-ignore
+    if (textShape) {
+      textShape.attr('y', label.y);
+      textShape.attr('x', label.x);
+    }
   });
 }
 

--- a/tests/bugs/2347-spec.ts
+++ b/tests/bugs/2347-spec.ts
@@ -1,0 +1,81 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+import { BBox } from '@antv/g-svg';
+import { IGroup } from '@antv/g-base';
+
+describe('#2347 饼图密集区域 label 布局错乱', () => {
+  const data = [
+    { item: '事例一', count: 40, percent: 0.009 },
+    { item: '事例二', count: 21, percent: 0.011 },
+    { item: '事例三', count: 17, percent: 0.17 },
+    { item: '事例四', count: 13, percent: 0.13 },
+    { item: '事例五', count: 9, percent: 0.09 },
+  ];
+
+  const chart = new Chart({
+    container: createDiv(),
+    autoFit: true,
+    height: 500,
+  });
+
+  chart.coordinate('theta', {
+    radius: 0.75,
+  });
+
+  chart.data(data);
+
+  chart.scale('percent', {
+    formatter: (val) => {
+      val = val * 100 + '%';
+      return val;
+    },
+  });
+
+  chart.tooltip({
+    showTitle: false,
+    showMarkers: false,
+  });
+
+  chart
+    .interval()
+    .position('percent')
+    .color('item')
+    .label('percent', {
+      content: (data) => {
+        return `${data.item}: ${data.percent * 100}%`;
+      },
+    })
+    .adjust('stack');
+
+  chart.interaction('element-active');
+  chart.render();
+  const pieGeom = chart.geometries.find((geom) => geom.type === 'interval');
+  const labels = pieGeom.labelsContainer.getChildren() as IGroup[];
+
+  /** 判断两个 box 是否遮挡 */
+  function isIntersectRect(box1: BBox, box2: BBox): boolean {
+    return !(
+      box2.x > box1.x + box1.width ||
+      box2.x + box2.width < box1.x ||
+      box2.y > box1.y + box1.height ||
+      box2.y + box2.height < box1.y
+    );
+  }
+
+  test('标签 & 迁移线 互不重叠', () => {
+    for (let i = 0; i < labels.length - 1; i += 1) {
+      const prev = labels[i];
+      const next = labels[i + 1];
+
+      const prevTextShape = prev.getChildren()[0];
+      const prevLineShape = prev.getChildren()[1];
+      const nextTextShape = next.getChildren()[0];
+      const nextLineShape = next.getChildren()[1];
+
+      if (prev.get('visible') && next.get('visible')) {
+        expect(isIntersectRect(prevTextShape.getBBox(), nextTextShape.getBBox())).toEqual(false);
+        expect(isIntersectRect(prevLineShape.getBBox(), nextLineShape.getBBox())).toEqual(false);
+      }
+    }
+  });
+});

--- a/tests/bugs/2629-spec.ts
+++ b/tests/bugs/2629-spec.ts
@@ -1,0 +1,81 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+import { BBox } from '@antv/g-svg';
+import { IGroup } from '@antv/g-base';
+
+describe('#2629 饼图-环图，所占比例较小时，label 文字重叠', () => {
+  const data = [
+    { item: '事例一', count: 40, percent: 0.009 },
+    { item: '事例二', count: 21, percent: 0.011 },
+    { item: '事例三', count: 17, percent: 0.17 },
+    { item: '事例四', count: 13, percent: 0.13 },
+    { item: '事例五', count: 9, percent: 0.09 },
+  ];
+
+  const chart = new Chart({
+    container: createDiv(),
+    autoFit: true,
+    height: 500,
+  });
+
+  chart.coordinate('theta', {
+    radius: 0.75,
+  });
+
+  chart.data(data);
+
+  chart.scale('percent', {
+    formatter: (val) => {
+      val = val * 100 + '%';
+      return val;
+    },
+  });
+
+  chart.tooltip({
+    showTitle: false,
+    showMarkers: false,
+  });
+
+  chart
+    .interval()
+    .position('percent')
+    .color('item')
+    .label('percent', {
+      content: (data) => {
+        return `${data.item}: ${data.percent * 100}%`;
+      },
+    })
+    .adjust('stack');
+
+  chart.interaction('element-active');
+  chart.render();
+  const pieGeom = chart.geometries.find((geom) => geom.type === 'interval');
+  const labels = pieGeom.labelsContainer.getChildren() as IGroup[];
+
+  /** 判断两个 box 是否遮挡 */
+  function isIntersectRect(box1: BBox, box2: BBox): boolean {
+    return !(
+      box2.x > box1.x + box1.width ||
+      box2.x + box2.width < box1.x ||
+      box2.y > box1.y + box1.height ||
+      box2.y + box2.height < box1.y
+    );
+  }
+
+  test('标签 & 迁移线 互不重叠', () => {
+    for (let i = 0; i < labels.length - 1; i += 1) {
+      const prev = labels[i];
+      const next = labels[i + 1];
+
+      const prevTextShape = prev.getChildren()[0];
+      const prevLineShape = prev.getChildren()[1];
+      const nextTextShape = next.getChildren()[0];
+      const nextLineShape = next.getChildren()[1];
+
+      if (prev.get('visible') && next.get('visible')) {
+        expect(isIntersectRect(prevTextShape.getBBox(), nextTextShape.getBBox())).toEqual(false);
+        expect(isIntersectRect(prevLineShape.getBBox(), nextLineShape.getBBox())).toEqual(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
详细看 commit:

- [x] fix: 饼图 label 布局类型设置不为 distribute 时，label line 没有绘制
- [x] fix: 饼图 label 布局不生效，原因：对 group 的坐标位置调整，不会影响 text-shape 的坐标位置，因此不生效

close #2647
close #2629
close #2347 


**before**
![image](https://user-images.githubusercontent.com/15646325/87251491-ae843c00-c49e-11ea-81c1-5abda5e50946.png)


**after**
![image](https://user-images.githubusercontent.com/15646325/87251460-898fc900-c49e-11ea-99a7-937c0214fdf4.png)



<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
