### PR TITLE
组件文本的自适应

### DIFF
--- a/src/chart/controller/annotation.ts
+++ b/src/chart/controller/annotation.ts
@@ -559,11 +559,10 @@ export default class Annotation extends Controller<BaseOption[]> {
         end: this.parsePosition(end),
       };
     } else if (type === 'text') {
-      const { position, rotate } = option as TextOption;
+      const { position, ...rest } = option as TextOption;
       o = {
         ...this.parsePosition(position),
-        content: option.content,
-        rotate,
+        ...rest,
       };
     } else if (type === 'dataMarker') {
       const { position, point, line, text, autoAdjust, direction } = option as DataMarkerOption;

--- a/src/chart/controller/legend.ts
+++ b/src/chart/controller/legend.ts
@@ -570,7 +570,8 @@ export default class Legend extends Controller<Option> {
    * @param direction
    */
   private mergeLegendCfg(baseCfg: object, legendOption: LegendOption, direction: DIRECTION) {
-    const themeObject = get(this.view.getTheme(), ['components', 'legend', direction], {});
+    const position = direction.split('-')[0];
+    const themeObject = get(this.view.getTheme(), ['components', 'legend', position], {});
 
     return deepMix({}, themeObject, baseCfg, legendOption);
   }

--- a/src/chart/controller/legend.ts
+++ b/src/chart/controller/legend.ts
@@ -554,6 +554,12 @@ export default class Legend extends Controller<Option> {
       categoryCfg.items.reverse();
     }
 
+    const maxItemWidth = get(categoryCfg, 'maxItemWidth');
+    if (maxItemWidth && maxItemWidth <= 1) {
+      // 转换成像素值
+      categoryCfg.maxItemWidth = this.view.viewBBox.width * maxItemWidth;
+    }
+
     return categoryCfg;
   }
 

--- a/src/dependents.ts
+++ b/src/dependents.ts
@@ -62,6 +62,8 @@ export {
   CrosshairTextBackgroundCfg,
   SliderCfg,
   TrendCfg,
+  EnhancedTextCfg,
+  LineAnnotationTextCfg,
 } from '@antv/component/lib/types';
 export { HtmlComponent, GroupComponent, Component, Crosshair };
 export { Annotation };

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -930,6 +930,12 @@ export interface LegendCfg {
    */
   itemSpacing?: number;
   /**
+   * **分类图例适用**，图例项的最大宽度，超出则自动缩略。
+   * `maxItemWidth` 可以是像素值；
+   * 也可以是相对值（取 0 到 1 范围的数值），代表占图表宽度的多少
+   */
+  maxItemWidth?: number;
+  /**
    * **分类图例适用**，图例项的宽度, 默认为 null，自动计算。
    */
   itemWidth?: number;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -14,6 +14,7 @@ import {
   CrosshairLineCfg,
   CrosshairTextBackgroundCfg,
   CrosshairTextCfg,
+  EnhancedTextCfg,
   GridLineCfg,
   GroupComponent,
   HtmlComponent,
@@ -29,6 +30,7 @@ import {
   Scale,
   ScaleConfig,
   ShapeAttrs,
+  LineAnnotationTextCfg,
 } from './dependents';
 
 import { View } from './chart';
@@ -478,12 +480,10 @@ export interface AnnotationBaseOption {
   readonly type?: string;
   /** 指定 annotation 是否绘制在 canvas 最上层，默认为 false, 即绘制在最下层 */
   readonly top?: boolean;
-  /** 图形样式属性 */
-  readonly style?: object;
   /** 是否进行动画 */
   readonly animate?: boolean;
   /** 动画参数配置，当且仅当 `animate` 属性为 true，即动画开启时生效。 */
-  animateOption?: ComponentAnimateOption;
+  readonly animateOption?: ComponentAnimateOption;
   /** x 方向的偏移量 */
   readonly offsetX?: number;
   /** y 方向的偏移量 */
@@ -496,6 +496,8 @@ export interface RegionPositionBaseOption extends AnnotationBaseOption {
   readonly start: AnnotationPosition;
   /** 结束位置 */
   readonly end: AnnotationPosition;
+  /** 图形样式属性 */
+  readonly style?: ShapeAttrs;
 }
 
 /** 使用 PointPosition 定位的组件配置 */
@@ -510,43 +512,27 @@ export interface ImageOption extends RegionPositionBaseOption {
   readonly src: string;
 }
 
+
+
 /** 使用 Line Annotation 组件的配置定义 */
 export interface LineOption extends RegionPositionBaseOption {
   /** 文本配置定义 */
-  readonly text?: {
-    /** 文本位置，除了制定 'start', 'center' 和 'end' 外，还可以使用百分比进行定位， 比如 '30%' */
-    readonly position: 'start' | 'center' | 'end' | string;
-    /** 是否自动旋转 */
-    readonly autoRotate?: boolean;
-    /** 显示的文本内容 */
-    readonly content: string;
-    /** 文本的图形样式属性 */
-    readonly style?: object;
-    /** x 方向的偏移量 */
-    readonly offsetX?: number;
-    /** y 方向偏移量 */
-    readonly offsetY?: number;
-  };
+  readonly text?: LineAnnotationTextCfg;
 }
 /** 使用 Arc Annotation 组件的配置定义 */
 export type ArcOption = RegionPositionBaseOption;
 /** 使用 Region Annotation 组件的配置定义 */
 export type RegionOption = RegionPositionBaseOption;
 /** 使用 Text Annotation 组件的配置定义 */
-export interface TextOption extends PointPositionBaseOption {
-  /** 显示的文本内容 */
-  readonly content: string | number;
-  /** 文本的旋转角度，弧度制 */
-  readonly rotate?: number;
-}
+export interface TextOption extends PointPositionBaseOption, EnhancedTextCfg {}
 /** 使用 DataMarker Annotation 组件的配置定义 */
 export interface DataMarkerOption extends PointPositionBaseOption {
   /** point 设置 */
-  readonly point?: null | { style?: object };
+  readonly point?: null | { style?: ShapeAttrs };
   /** line 设置 */
-  readonly line?: null | { style?: object; length?: number };
+  readonly line?: null | { style?: ShapeAttrs; length?: number };
   /** text 设置 */
-  readonly text: null | { style?: object; content: string };
+  readonly text: null | EnhancedTextCfg;
   /** 文本超出绘制区域时，是否自动调节文本方向，默认为 true */
   readonly autoAdjust?: boolean;
   /** 朝向，默认为 upward，可选值为 'upward' 或者 'downward' */
@@ -557,9 +543,9 @@ export interface DataRegionOption extends RegionPositionBaseOption {
   /** line长度，default为 0 */
   readonly lineLength?: number;
   /** 标注区间的配置 */
-  readonly region?: null | { style?: object };
+  readonly region?: null | { style?: ShapeAttrs };
   /** 文本的配置 */
-  readonly text?: null | { style?: object; content: string };
+  readonly text?: null | EnhancedTextCfg;
 }
 /** 使用 RegionFilter Annotation 组件的配置定义 */
 export interface RegionFilterOption extends RegionPositionBaseOption {

--- a/src/util/theme.ts
+++ b/src/util/theme.ts
@@ -225,6 +225,7 @@ export function createThemeByStylesheet(styleSheet: StyleSheet): LooseObject {
     },
     flipPage: true,
     animate: false,
+    maxItemWidth: 0.2,
   };
 
   return {

--- a/tests/unit/component/annotation-spec.ts
+++ b/tests/unit/component/annotation-spec.ts
@@ -55,7 +55,7 @@ describe('annotation', () => {
     chart.animate(true);
     chart.annotation().line({
       start: { city: '上海', sale: 110 },
-      end: { city: '呼和浩特', sale: 40 },
+      end: { city: '呼和浩特', sale: 110 },
       style: {
         stroke: 'green',
         lineDash: [2, 2],
@@ -63,6 +63,16 @@ describe('annotation', () => {
       text: {
         position: 'end',
         content: '呼和浩特和上海',
+        maxLength: 60,
+        autoEllipsis: true,
+        background: {
+          padding: 5,
+          style: {
+            fill: '#1890ff',
+            fillOpacity: 0.3,
+            radius: 3,
+          },
+        },
         style: {
           fill: 'red',
           fontSize: 14,
@@ -73,7 +83,6 @@ describe('annotation', () => {
     chart.render();
 
     const line = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.ANNOTATION)[1].component;
-
     // theme
     expect(line.get('style').lineDash).toEqual([2, 2]);
     // pos
@@ -81,12 +90,16 @@ describe('annotation', () => {
     expect(line.get('start').y).toBe(70);
 
     expect(line.get('end').x).toBe(682);
-    expect(line.get('end').y).toBe(392);
+    expect(line.get('end').y).toBe(70);
     // style
     expect(line.get('style').stroke).toBe('green');
 
     expect(line.get('text').style.fill).toBe('red');
     expect(line.get('text').style.fontSize).toBe(14);
+    // @ts-ignore
+    expect(line.getElementById('-annotation-line-text').attr('text').indexOf('…')).toBeGreaterThan(-1);
+    // @ts-ignore
+    expect(line.getElementById('-annotation-line-text-bg')).toBeDefined();
 
     expect(line.get('animate')).toBe(true);
   });
@@ -120,6 +133,16 @@ describe('annotation', () => {
     chart.annotation().text({
       position: { city: '杭州', sale: 100 },
       content: '杭州的数据' + 100,
+      maxLength: 80,
+      autoEllipsis: true,
+      background: {
+        padding: 3,
+        style: {
+          fill: '#ccc',
+          fillOpacity: 0.5,
+          radius: 3,
+        },
+      },
       style: {
         fill: 'red',
         textBaseline: 'bottom',
@@ -146,6 +169,11 @@ describe('annotation', () => {
         .getFirst()
         .attr('matrix')
     ).not.toEqual([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+
+    // @ts-ignore
+    expect(text.getElementById('-annotation-text').attr('text').indexOf('…')).toBeGreaterThan(-1);
+    // @ts-ignore
+    expect(text.getElementById('-annotation-text-bg')).toBeDefined();
   });
 
   it('use percentage position', () => {
@@ -212,14 +240,30 @@ describe('annotation', () => {
       position: { city: '上海', sale: 110 },
       text: {
         content: 'data marker test',
+        maxLength: 80,
+        autoEllipsis: true,
+        background: {
+          padding: 5,
+          style: {
+            fill: '#289990',
+            fillOpacity: 0.3,
+            stroke: '#289990',
+            lineWidth: 1,
+          },
+        }
       },
     });
     chart.render();
 
     const dataMarker = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.ANNOTATION)[7].component;
+
     expect(dataMarker.get('type')).toEqual('dataMarker');
     expect(dataMarker.get('x')).toEqual(494);
     expect(dataMarker.get('y')).toEqual(70);
+    // @ts-ignore
+    expect(dataMarker.getElementById('-annotation-text').attr('text').indexOf('…')).toBeGreaterThan(-1);
+    // @ts-ignore
+    expect(dataMarker.getElementById('-annotation-text-bg')).toBeDefined();
   });
 
   it('dataRegion', () => {
@@ -228,6 +272,18 @@ describe('annotation', () => {
       end: { city: '上海', sale: 110 },
       text: {
         content: 'data region test',
+        maxLength: 80,
+        autoEllipsis: true,
+        background: {
+          padding: 5,
+          style: {
+            fill: '#289990',
+            fillOpacity: 0.3,
+            stroke: '#289990',
+            lineWidth: 1,
+            radius: 4,
+          },
+        },
       },
     });
     chart.render();
@@ -239,6 +295,11 @@ describe('annotation', () => {
       { x: 306, y: 438 },
       { x: 494, y: 70 },
     ]);
+
+    // @ts-ignore
+    expect(dataRegion.getElementById('-annotation-text').attr('text').indexOf('…')).toBeGreaterThan(-1);
+    // @ts-ignore
+    expect(dataRegion.getElementById('-annotation-text-bg')).toBeDefined();
   });
 
   it('regionFilter', () => {

--- a/tests/unit/component/legend-category-spec.ts
+++ b/tests/unit/component/legend-category-spec.ts
@@ -2,7 +2,7 @@ import { Chart } from '../../../src/';
 import { COMPONENT_TYPE } from '../../../src/constant';
 import { GroupComponent, GroupComponentCfg } from '../../../src/dependents';
 import { CITY_SALE, DIAMOND } from '../../util/data';
-import { createDiv } from '../../util/dom';
+import { createDiv, removeDom } from '../../util/dom';
 
 describe('Legend category', () => {
   const div = createDiv();
@@ -168,5 +168,67 @@ describe('Legend Category Vertical', () => {
     // text
     expect(children[1].get('type')).toBe('text');
     expect(children[1].attr('text')).toEqual('1/3');
+  });
+});
+
+describe('Legend auto ellipsis', () => {
+  const div = createDiv();
+  const data = [
+    { genre: '测试测试测试测试测试测试测试测试测试测试测试测试测试测试1', sold: 100 },
+    { genre: '测试测试2', sold: null },
+    { genre: '测试测试3', sold: 45 },
+    { genre: '测试测试4', sold: 100 },
+    { genre: '测试测试5', sold: 100 },
+    { genre: '测试测试6', sold: 100 },
+    { genre: '测试测试7', sold: 100 },
+    { genre: '测试测试8', sold: 100 },
+    { genre: '测试测试9', sold: 100 },
+    { genre: '测试测试10', sold: 100 },
+    { genre: '测试测试11', sold: 100 },
+    { genre: '测试测试12', sold: 100 },
+    { genre: '测试测试13', sold: 100 },
+  ];
+  const chart = new Chart({
+    container: div,
+    width: 400,
+    height: 300,
+  });
+
+  it('vertical ellipsis', () => {
+    chart.data(data);
+    chart.animate(false);
+    chart.legend({
+      layout: 'vertical',
+      position: 'right'
+    });
+    chart.interval().position('genre*sold').color('genre');
+    chart.render();
+
+    const legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
+    const legend = legends[0].component as GroupComponent<GroupComponentCfg>;
+    expect(legend.get('maxItemWidth')).toBe(80);
+    expect(legend.getElementById('-legend-item-测试测试测试测试测试测试测试测试测试测试测试测试测试测试1-name').attr('text')).toBe('测试测试…');
+  });
+
+  it('itemWidth', () => {
+    chart.legend({
+      layout: 'horizontal',
+      position: 'top',
+      itemWidth: 60,
+    });
+    chart.render(true);
+
+    const legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
+    const legend = legends[0].component as GroupComponent<GroupComponentCfg>;
+    expect(legend.get('maxItemWidth')).toBe(80);
+    expect(legend.get('itemWidth')).toBe(60);
+    expect(legend.getElementById('-legend-item-测试测试测试测试测试测试测试测试测试测试测试测试测试测试1-name').attr('text')).toBe('测试…');
+
+    expect(legend.getElementById('-legend-item-测试测试4').getBBox().width).toBeLessThan(60);
+  });
+
+  afterAll(() => {
+    chart.destroy();
+    removeDom(div);
   });
 });

--- a/tests/unit/component/legend-category-spec.ts
+++ b/tests/unit/component/legend-category-spec.ts
@@ -199,7 +199,7 @@ describe('Legend auto ellipsis', () => {
     chart.animate(false);
     chart.legend({
       layout: 'vertical',
-      position: 'right'
+      position: 'right-top'
     });
     chart.interval().position('genre*sold').color('genre');
     chart.render();


### PR DESCRIPTION
关联 PR：https://github.com/antvis/component/pull/179

- [x] 分类图例的自适应，策略：超出最大图例项最大宽度 maxItemWidth 时自动缩略
![image](https://user-images.githubusercontent.com/6628666/88173852-dec59a80-cc55-11ea-8497-19d48f5e0d84.png)
![image](https://user-images.githubusercontent.com/6628666/88173942-00bf1d00-cc56-11ea-8778-b89f4ca09485.png)
- [x] Annotation 中的文本自动缩略
![image](https://user-images.githubusercontent.com/6628666/88196423-c19fc480-cc73-11ea-9d4f-692dd79ef50a.png)
![image](https://user-images.githubusercontent.com/6628666/88196546-e6943780-cc73-11ea-8f05-b5c8d09ebf73.png)
![image](https://user-images.githubusercontent.com/6628666/88196840-3a9f1c00-cc74-11ea-991d-2285129ba028.png)
![image](https://user-images.githubusercontent.com/6628666/88197487-2576bd00-cc75-11ea-9b79-0d2753209db5.png)

