### PR TITLE
feat(annotation): text annotation content 提供回调，将图表filteredData作为回调参数

### DIFF
--- a/src/chart/controller/annotation.ts
+++ b/src/chart/controller/annotation.ts
@@ -559,10 +559,16 @@ export default class Annotation extends Controller<BaseOption[]> {
         end: this.parsePosition(end),
       };
     } else if (type === 'text') {
-      const { position, ...rest } = option as TextOption;
+      const filteredData = this.view.getData();
+      const { position, content, ...rest } = option as TextOption;
+      let textContent = content;
+      if (isFunction(content)) {
+        textContent = content(filteredData);
+      }
       o = {
         ...this.parsePosition(position),
         ...rest,
+        content: textContent,
       };
     } else if (type === 'dataMarker') {
       const { position, point, line, text, autoAdjust, direction } = option as DataMarkerOption;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -524,7 +524,9 @@ export type ArcOption = RegionPositionBaseOption;
 /** 使用 Region Annotation 组件的配置定义 */
 export type RegionOption = RegionPositionBaseOption;
 /** 使用 Text Annotation 组件的配置定义 */
-export interface TextOption extends PointPositionBaseOption, EnhancedTextCfg {}
+export interface TextOption extends PointPositionBaseOption, Omit<EnhancedTextCfg, 'content'> {
+  content?: string | number | ((filteredData: object[]) => string | number);
+}
 /** 使用 DataMarker Annotation 组件的配置定义 */
 export interface DataMarkerOption extends PointPositionBaseOption {
   /** point 设置 */

--- a/tests/unit/component/annotation-spec.ts
+++ b/tests/unit/component/annotation-spec.ts
@@ -163,12 +163,7 @@ describe('annotation', () => {
     // style
     expect(text.get('style').fill).toBe('red');
     expect(text.get('rotate')).toBeCloseTo(Math.PI * 0.25);
-    expect(
-      text
-        .get('group')
-        .getFirst()
-        .attr('matrix')
-    ).not.toEqual([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+    expect(text.get('group').getFirst().attr('matrix')).not.toEqual([1, 0, 0, 0, 1, 0, 0, 0, 1]);
 
     // @ts-ignore
     expect(text.getElementById('-annotation-text').attr('text').indexOf('…')).toBeGreaterThan(-1);
@@ -250,7 +245,7 @@ describe('annotation', () => {
             stroke: '#289990',
             lineWidth: 1,
           },
-        }
+        },
       },
     });
     chart.render();
@@ -315,6 +310,22 @@ describe('annotation', () => {
     const regionFilter = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.ANNOTATION)[9].component;
     expect(regionFilter.get('type')).toEqual('regionFilter');
     expect(regionFilter.get('shapes')).toHaveLength(1);
+  });
+
+  it('text with callback', () => {
+    // @ts-ignore
+    chart.getController('annotation').clear(true);
+    chart.annotation().text({
+      position: ['50%', '50%'],
+      content: (filteredData) => `${filteredData.reduce((a, b: any) => a + b.sale, 0)}`,
+    });
+
+    chart.render();
+
+    const text = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.ANNOTATION)[0].component;
+    expect(text).toBeDefined();
+    // @ts-ignore
+    expect(text.get('content')).toBe(`${DATA.reduce((a, b) => a + b.sale, 0)}`);
   });
 
   afterAll(() => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

**背景**
环图使用 annotation 绘制中心汇总指标卡的时候，首次render之前，使用 `chart.getData()` 获取数据为空；
另外，由于饼图图例可以进行数据过滤，相应的中心汇总指标卡也应该进行过滤，所以需要通过 `chart.getData()` 来获取数据

两种解决方案：
1. text annotation， 提供 content 回调的方式，将图表 filteredData 作为入参
2. 业务层监听 图表 render 之后，再执行 annotation，但同时维护也较难


```js
import { Chart } from '@antv/g2';

const data = [
  { item: '事例一', count: 40, percent: 0.4 },
  { item: '事例二', count: 21, percent: 0.21 },
  { item: '事例三', count: 17, percent: 0.17 },
  { item: '事例四', count: 13, percent: 0.13 },
  { item: '事例五', count: 9, percent: 0.09 },
];
const chart = new Chart({
  container: 'container',
  autoFit: true,
  height: 500,
});
chart.data(data);

chart.coordinate('theta', {
  radius: 0.75,
  innerRadius: 0.6,
});

// 辅助文本
chart
  .annotation()
  .text({
    position: ['50%', '50%'],
    content: (chart.getData() || []).reduce((a, b) => a + b.count, 0),
  })
chart
  .interval()
  .adjust('stack')
  .position('percent')
  .color('item')
  .label('percent')


chart.interaction('element-active');

chart.render();
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
