### PR TITLE
fix(theme): 修复主题设置画布背景色在导出状态下不生效 & 显式调用 theme api 设置主题背景色不生效

### DIFF
--- a/src/chart/chart.ts
+++ b/src/chart/chart.ts
@@ -78,14 +78,6 @@ export default class Chart extends View {
       theme,
     });
 
-    // 设置主题背景色
-    const chartTheme = this.getTheme();
-    if (get(chartTheme, 'background')) {
-      modifyCSS(wrapperElement, {
-        background: get(chartTheme, 'background'),
-      });
-    }
-
     this.ele = ele;
     this.canvas = canvas;
     this.width = size.width;

--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -51,6 +51,7 @@ import { createInteraction, Interaction } from '../interaction';
 import { getTheme } from '../theme';
 import { BBox } from '../util/bbox';
 import { getCoordinateClipCfg, isFullCircle, isPointInCoordinate } from '../util/coordinate';
+import { modifyCSS } from '../util/dom';
 import { uniq } from '../util/helper';
 import { findDataByPoint } from '../util/tooltip';
 import Chart from './chart';
@@ -1240,6 +1241,8 @@ export class View extends Base {
 
     this.emit(VIEW_LIFE_CIRCLE.BEFORE_PAINT);
 
+    this.drawCanvasStyle();
+
     this.renderLayoutRecursive(isUpdate);
 
     this.renderPaintRecursive(isUpdate);
@@ -1247,6 +1250,18 @@ export class View extends Base {
     this.emit(VIEW_LIFE_CIRCLE.AFTER_PAINT);
 
     this.isDataChanged = false; // 渲染完毕复位
+  }
+
+  /**
+   * 绘制 canvas 样式
+   * @param
+   */
+  protected drawCanvasStyle() {
+    const canvas = this.getCanvas();
+    // 修改主题背景色
+    modifyCSS(canvas.get('el'), {
+      background: get(this.themeObject, 'background'),
+    });
   }
 
   /**

--- a/tests/bugs/2505-spec.ts
+++ b/tests/bugs/2505-spec.ts
@@ -26,6 +26,6 @@ describe('2505', () => {
 
     chart.render();
 
-    expect(chart.getCanvas().get('container').style.background).toBe('rgb(20, 20, 20)');
+    expect(chart.getCanvas().get('el').style.background).toBe('rgb(20, 20, 20)');
   });
 });

--- a/tests/unit/theme/background-spec.ts
+++ b/tests/unit/theme/background-spec.ts
@@ -1,0 +1,53 @@
+import { Chart } from '../../../src';
+import { createDiv, removeDom } from '../../util/dom';
+
+describe('Custom theme background', () => {
+  const data = [
+    { x: 'a', y: 1, z: 'z1' },
+    { x: 'b', y: 2, z: 'z1' },
+    { x: 'c', y: 3, z: 'z1' },
+    { x: 'a', y: 4, z: 'z2' },
+    { x: 'b', y: 5, z: 'z2' },
+    { x: 'c', y: 6, z: 'z2' },
+  ];
+
+  it('Theme background', () => {
+    const chart = new Chart({
+      container: createDiv(),
+      width: 600,
+      height: 500,
+      theme: 'dark',
+    });
+
+    chart.data(data);
+    chart.line().position('x*y').color('z');
+
+    chart.render();
+
+    expect(chart.getCanvas().get('el').style.background).toBe('rgb(20, 20, 20)');
+  });
+
+  it('modify backgroud with `theme` API', () => {
+    const chart = new Chart({
+      container: createDiv(),
+      width: 600,
+      height: 500,
+    });
+
+    chart.data(data);
+    chart.line().position('x*y').color('z');
+
+    chart.render();
+    expect(chart.getCanvas().get('el').style.background).not.toBe('rgb(20, 20, 20)');
+
+    chart.theme('dark');
+    chart.render();
+    expect(chart.getCanvas().get('el').style.background).toBe('rgb(20, 20, 20)');
+
+    chart.theme({
+      background: 'red',
+    });
+    chart.render();
+    expect(chart.getCanvas().get('el').style.background).toBe('red');
+  });
+});


### PR DESCRIPTION
related issue: [#2654](https://github.com/antvis/G2/issues/2654)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
