### PR TITLE
配置项及更新问题

### DIFF
--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -682,6 +682,11 @@ export class View extends Base {
     this.clear(); // 清空
     mix(this.options, options);
 
+    // 需要把已存在的 view 销毁，否则会重复创建
+    // 目前针对配置项还没有特别好的 view 更新机制，为了不影响主流流程，所以在这里直接销毁
+    this.views.forEach(view => view.destroy());
+    this.views = [];
+
     this.initOptions();
     // 初始化坐标系大小，保证 padding 计算正确
     this.coordinateBBox = this.viewBBox;

--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -69,7 +69,7 @@ import { isAutoPadding } from '../util/padding';
  */
 export class View extends Base {
   /** view id，全局唯一。 */
-  public id: string = uniqueId('view');
+  public id: string;
   /** 父级 view，如果没有父级，则为空。 */
   public parent: View;
   /** 所有的子 view。 */
@@ -149,6 +149,7 @@ export class View extends Base {
     super({ visible: props.visible });
 
     const {
+      id = uniqueId('view'),
       parent,
       canvas,
       backgroundGroup,
@@ -173,6 +174,7 @@ export class View extends Base {
     // 接受父 view 传入的参数
     this.options = { ...this.options, ...options };
     this.limitInPlot = limitInPlot;
+    this.id = id;
 
     // 初始化 theme
     this.themeObject = isObject(theme) ? deepMix({}, getTheme('default'), theme) : getTheme(theme);
@@ -679,6 +681,7 @@ export class View extends Base {
   public updateOptions(options: Options) {
     this.clear(); // 清空
     mix(this.options, options);
+
     this.initOptions();
     // 初始化坐标系大小，保证 padding 计算正确
     this.coordinateBBox = this.viewBBox;

--- a/src/geometry/element/index.ts
+++ b/src/geometry/element/index.ts
@@ -107,6 +107,7 @@ export default class Element extends Base {
     newShape.cfg.data = this.data;
     // @ts-ignore
     newShape.cfg.origin = model;
+    newShape.cfg.element = this;
 
     // step 3: 同步 shape 样式
     this.syncShapeStyle(shape, newShape, '', this.getAnimateCfg('update'));

--- a/src/geometry/element/index.ts
+++ b/src/geometry/element/index.ts
@@ -107,6 +107,7 @@ export default class Element extends Base {
     newShape.cfg.data = this.data;
     // @ts-ignore
     newShape.cfg.origin = model;
+    // label 需要使用
     newShape.cfg.element = this;
 
     // step 3: 同步 shape 样式

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -691,6 +691,8 @@ export interface GeometryOption {
 
 /** 用于配置型式的 View 声明方式 */
 export interface ViewOption {
+  /** view 的唯一表示 ID */
+  readonly id?: string;
   /** view 的绘制范围，起始点为左上角。 */
   readonly region?: Region;
   /**
@@ -771,6 +773,8 @@ export interface ChartCfg {
 
 /** View 构造参数 */
 export interface ViewCfg {
+  /** View id，可以由外部传入 */
+  readonly id?: string;
   /** 当前 view 的父级 view。 */
   readonly parent: View;
   /** canvas 实例。 */

--- a/tests/unit/chart/view/index-spec.ts
+++ b/tests/unit/chart/view/index-spec.ts
@@ -25,6 +25,7 @@ describe('View', () => {
   const foregroundGroup = canvas.addGroup();
 
   const view = new View({
+    id: 'onlyView',
     parent: null,
     canvas,
     foregroundGroup,
@@ -43,6 +44,7 @@ describe('View', () => {
     // @ts-ignore
     expect(view.foregroundGroup).toBeInstanceOf(getEngine(renderer).Group);
     expect(view.visible).toBeFalse();
+    expect(view.id).toBe('onlyView');
   });
 
   it('region', () => {

--- a/tests/unit/options/views-spec.ts
+++ b/tests/unit/options/views-spec.ts
@@ -1,61 +1,130 @@
 import { Chart } from '../../../src';
-import { createDiv } from '../../util/dom';
+import { createDiv, removeDom } from '../../util/dom';
+import DataFilter from '../../../src/interaction/action/data/filter';
+import Context from '../../../src/interaction/context';
 
 describe('Views option', () => {
-  it('views', () => {
-    const chart = new Chart({
-      autoFit: false,
-      container: createDiv(),
-      width: 400,
-      height: 400,
-      options: {
-        views: [{
-          id: 'bar-0',
-          options: {
-            data: [
-              { x: 'A', y: 10 },
-              { x: 'B', y: 15 },
-              { x: 'C', y: 40 },
-            ],
-            geometries: [{
-              type: 'interval',
-              position: {
-                fields: ['x', 'y'],
-              },
-            }],
-          },
-        }, {
-          id: 'line-1',
-          options: {
-            data: [
-              { x: 'A', y1: 10 },
-              { x: 'B', y1: 15 },
-              { x: 'C', y1: 40 },
-            ],
-            geometries: [{
-              type: 'line',
-              position: {
-                fields: ['x', 'y1']
-              },
-              size: {
-                values: [2],
-              },
-            }],
-            axes: {
-              y1: {
-                position: 'right',
-              }
+  const container = createDiv();
+  const chart = new Chart({
+    autoFit: false,
+    container,
+    width: 400,
+    height: 400,
+    // @ts-ignore
+    options: {
+      views: [{
+        id: 'bar-0',
+        options: {
+          data: [
+            { x: 'A', y: 10 },
+            { x: 'B', y: 15 },
+            { x: 'C', y: 40 },
+          ],
+          geometries: [{
+            type: 'interval',
+            position: {
+              fields: ['x', 'y'],
+            },
+          }],
+        },
+      }, {
+        id: 'line-1',
+        options: {
+          data: [
+            { x: 'A', y1: 10 },
+            { x: 'B', y1: 15 },
+            { x: 'C', y1: 40 },
+          ],
+          geometries: [{
+            type: 'line',
+            position: {
+              fields: ['x', 'y1']
+            },
+            size: {
+              values: [2],
+            },
+          }],
+          axes: {
+            y1: {
+              position: 'right',
             }
           }
-        }],
-      },
-    });
+        }
+      }],
+    },
+  });
 
+  function getLegendItems() {
+    return chart.foregroundGroup.findAll((el) => {
+      return el.get('name') === 'legend-item';
+    });
+  }
+  it('views renderer', () => {
     chart.render();
 
     expect(chart.views.length).toBe(2);
     expect(chart.views[0].id).toBe('bar-0');
     expect(chart.views[1].id).toBe('line-1');
 
+  });
+
+  it('views updateOptions', () => {
+    chart.updateOptions({
+      animate: false,
+      views: [{
+        options: {
+          data: [
+            { x: 'A', y: 10 },
+            { x: 'B', y: 15 },
+            { x: 'C', y: 40 },
+          ],
+          geometries: [{
+            type: 'interval',
+            position: {
+              fields: ['x', 'y'],
+            },
+            color: {
+              fields: ['x'],
+            },
+            label: {
+              fields: ['y'],
+              cfg: {
+                layout: {
+                  type: 'adjust-color',
+                },
+                position: 'middle',
+              },
+            }
+          }],
+        },
+      }],
+    });
+    chart.render(true);
+
+    expect(chart.views.length).toBe(1);
+  });
+
+  it('legend click, a bug test', () => {
+    // 触发图例点击
+    const context = new Context(chart);
+    const action = new DataFilter(context);
+    const items = getLegendItems();
+    const legendItem = items[0];
+    const item = legendItem.get('delegateObject').item;
+    context.event = {
+      target: legendItem,
+    };
+    item.unchecked = true;
+
+    expect(() => {
+      action.filter();
+    }).not.toThrow();
+
+    expect(chart.views[0].geometries[0].elements.length).toBe(2);
+  });
+
+  afterAll(() => {
+    chart.destroy();
+    removeDom(container);
   });
 });

--- a/tests/unit/options/views-spec.ts
+++ b/tests/unit/options/views-spec.ts
@@ -1,0 +1,61 @@
+import { Chart } from '../../../src';
+import { createDiv } from '../../util/dom';
+
+describe('Views option', () => {
+  it('views', () => {
+    const chart = new Chart({
+      autoFit: false,
+      container: createDiv(),
+      width: 400,
+      height: 400,
+      options: {
+        views: [{
+          id: 'bar-0',
+          options: {
+            data: [
+              { x: 'A', y: 10 },
+              { x: 'B', y: 15 },
+              { x: 'C', y: 40 },
+            ],
+            geometries: [{
+              type: 'interval',
+              position: {
+                fields: ['x', 'y'],
+              },
+            }],
+          },
+        }, {
+          id: 'line-1',
+          options: {
+            data: [
+              { x: 'A', y1: 10 },
+              { x: 'B', y1: 15 },
+              { x: 'C', y1: 40 },
+            ],
+            geometries: [{
+              type: 'line',
+              position: {
+                fields: ['x', 'y1']
+              },
+              size: {
+                values: [2],
+              },
+            }],
+            axes: {
+              y1: {
+                position: 'right',
+              }
+            }
+          }
+        }],
+      },
+    });
+
+    chart.render();
+
+    expect(chart.views.length).toBe(2);
+    expect(chart.views[0].id).toBe('bar-0');
+    expect(chart.views[1].id).toBe('line-1');
+
+  });
+});


### PR DESCRIPTION
修复如下问题：
1. 柱图使用 'adjust-color' label 布局算法时，图例过滤报错的问题
![image](https://user-images.githubusercontent.com/6628666/93169662-24837880-f758-11ea-8ee3-2e2cc74de6a9.png)
2. view 支持外部传入 id
3. 使用配置项创建 views 时，更新配置项会导致 views 多次创建的问题，为了不影响主流流程，直接在 updateOptions() 方法中销毁清空
