### PR TITLE
fix(#2737): 修复布局之后收缩过程中,axis 坐标轴被遮挡, 传入 verticalLimitLength 限制 axis 的绘制

### DIFF
--- a/src/chart/controller/axis.ts
+++ b/src/chart/controller/axis.ts
@@ -11,6 +11,7 @@ import {
   getAxisRegion,
   getAxisThemeCfg,
   getAxisTitleText,
+  getAxisVerticalLimitLength,
   getCircleAxisCenterRadius,
   isVertical,
 } from '../../util/axis';
@@ -91,7 +92,10 @@ export default class Axis extends Controller<Option> {
               : getAxisRegion(coordinate, direction);
           }
         } else {
-          updated = getAxisRegion(coordinate, direction);
+          updated = {
+            ...getAxisRegion(coordinate, direction),
+            ...getAxisVerticalLimitLength(coordinate, co, direction),
+          }
         }
       } else if (type === COMPONENT_TYPE.GRID) {
         if (coordinate.isPolar) {

--- a/src/util/axis.ts
+++ b/src/util/axis.ts
@@ -1,9 +1,9 @@
 import { get, isBoolean } from '@antv/util';
+import { vec2 } from '@antv/matrix-util';
 import { DIRECTION } from '../constant';
 import { Coordinate, Scale } from '../dependents';
-import { AxisCfg, AxisOption, Point, Region } from '../interface';
+import { AxisCfg, AxisOption, ComponentOption, Point, Region } from '../interface';
 import { getName } from './scale';
-import { vec2 } from '@antv/matrix-util';
 
 /**
  * @ignore
@@ -91,6 +91,22 @@ export function getAxisRegion(coordinate: Coordinate, direction: DIRECTION): Reg
     start: coordinate.convert(start),
     end: coordinate.convert(end),
   };
+}
+
+/**
+ * 获得 axis 的 VerticalLimitLength 目前仅对 rect 进行处理
+ * @param coordinate
+ * @param co
+ * @param direction
+ */
+export function getAxisVerticalLimitLength(coordinate: Coordinate, co: ComponentOption, direction: DIRECTION): object {
+  if (coordinate.isRect) {
+    const bbox = co.component.getLayoutBBox();
+    return {
+      verticalLimitLength: isVertical(getLineAxisRelativeRegion(direction)) ? bbox.width : bbox.height,
+    }
+  }
+  return {};
 }
 
 /**

--- a/tests/bugs/2737-spec.ts
+++ b/tests/bugs/2737-spec.ts
@@ -1,0 +1,32 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+
+describe('2737', () => {
+  it('2737', () => {
+    const data = [
+      { year: '1991', value: 3 },
+      { year: '1992', value: 4 },
+      { year: '1993', value: 3.5 },
+      { year: '1994', value: 5 },
+      { year: '1995', value: 4.9 },
+      { year: '1996', value: 6 },
+      { year: '1997', value: 7 },
+      { year: '1998', value: 9 },
+      { year: '1999', value: 13 },
+    ];
+
+    const chart = new Chart({
+      container: createDiv(),
+      width: 268,
+      height: 300,
+      autoFit: true,
+    });
+    chart.data(data);
+    chart.line().position('year*value').shape('smooth');
+
+    chart.render();
+
+    // @ts-ignore
+    window.chart = chart;
+  });
+});


### PR DESCRIPTION
 fixed #2702, #2737 

 - [x] layout 的时候传入 verticalLimitLength，防止收缩过程中，axis 自动旋转被裁剪
 - [ ] component axis 中对于 autoRotate autoHide 的策略问题 / 或者在 G2 axis controller 层检测出问题，然后自动关闭 autoRotate