### PR TITLE
Fix axis style callback

### DIFF
--- a/examples/gallery/line/demo/line1.ts
+++ b/examples/gallery/line/demo/line1.ts
@@ -10,7 +10,7 @@ fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/terrorism.json')
       container: 'container',
       autoFit: true,
       height: 500,
-      padding: [20, 40],
+      syncViewPadding: true,
     });
 
     chart.scale({

--- a/src/chart/chart.ts
+++ b/src/chart/chart.ts
@@ -43,6 +43,7 @@ export default class Chart extends View {
       options,
       limitInPlot,
       theme,
+      syncViewPadding,
     } = props;
 
     const ele: HTMLElement = isString(container) ? document.getElementById(container) : container;
@@ -78,6 +79,7 @@ export default class Chart extends View {
       options,
       limitInPlot,
       theme,
+      syncViewPadding,
     });
 
     this.ele = ele;

--- a/src/chart/controller/axis.ts
+++ b/src/chart/controller/axis.ts
@@ -544,6 +544,7 @@ export default class Axis extends Controller<Option> {
         verticalFactor: coordinate.isPolar
           ? getAxisFactorByRegion(region, coordinate.getCenter()) * -1
           : getAxisFactorByRegion(region, coordinate.getCenter()),
+        theme: axisThemeCfg,
       },
       axisThemeCfg,
       optionWithTitle
@@ -625,6 +626,7 @@ export default class Axis extends Controller<Option> {
         ...getCircleAxisCenterRadius(this.view.getCoordinate()),
         ticks,
         verticalFactor: 1,
+        theme: axisThemeCfg,
       },
       axisThemeCfg,
       optionWithTitle

--- a/src/chart/layout/auto.ts
+++ b/src/chart/layout/auto.ts
@@ -11,12 +11,12 @@ import { PaddingCal } from './padding-cal';
  * 根据 view 中的组件，计算实际的 padding 数值
  * @param view
  */
-export function calculatePadding(view: View): Padding {
+export function calculatePadding(view: View): PaddingCal {
   const padding = view.padding;
 
   // 如果不是 auto padding，那么直接解析之后返回
   if (!isAutoPadding(padding)) {
-    return parsePadding(padding);
+    return new PaddingCal(...parsePadding(padding));
   }
 
   // 是 auto padding，根据组件的情况，来计算 padding
@@ -72,5 +72,5 @@ export function calculatePadding(view: View): Padding {
     paddingCal.inc(componentBBox, direction);
   });
 
-  return paddingCal.getPadding();
+  return paddingCal;
 }

--- a/src/chart/layout/index.ts
+++ b/src/chart/layout/index.ts
@@ -20,21 +20,25 @@ export type Layout = (view: View) => void;
  * @param view
  */
 export default function defaultLayout(view: View): void {
+  // 1. 自动加 auto padding -> absolute padding
+  // 并且增加 appendPadding
+  const paddingCal = calculatePadding(view).shrink(parsePadding(view.appendPadding));
+
+  // 存储起来
+  view.autoPadding = paddingCal;
+
+  // 2. 计算出新的 coordinateBBox
+  view.coordinateBBox = view.viewBBox.shrink(paddingCal.getPadding());
+
+  view.adjustCoordinate();
+
+  // 3. 根据最新的 coordinate 重新布局组件
   const axis = view.getController('axis');
   const legend = view.getController('legend');
   const annotation = view.getController('annotation');
   const slider = view.getController('slider');
   const scrollbar = view.getController('scrollbar');
 
-  // 1. 自动加 auto padding -> absolute padding
-  const padding = calculatePadding(view);
-
-  // 2. 计算出新的 coordinateBBox
-  view.coordinateBBox = view.viewBBox.shrink(padding).shrink(parsePadding(view.appendPadding));
-
-  view.adjustCoordinate();
-
-  // 3. 根据最新的 coordinate 重新布局组件
   [axis, slider, scrollbar, legend, annotation].forEach((controller: Controller) => {
     if (controller) {
       controller.layout();

--- a/src/chart/layout/index.ts
+++ b/src/chart/layout/index.ts
@@ -1,7 +1,5 @@
 import { Controller } from '../controller/base';
 import View from '../view';
-import { parsePadding } from '../../util/padding';
-import { calculatePadding } from './auto';
 
 // 布局函数的定义
 // 布局函数的职责：根据 view 中组件信息，计算出最终的图形 padding 数值，以及最终各个组件的布局和位置
@@ -16,29 +14,17 @@ export type Layout = (view: View) => void;
  * 2. 根据 padding 和 direction 去分配对应方向的 padding 数值
  * 3. 移动组件位置
  *
- * 对于组件响应式布局，可以尝试使用约束布局的方式去求解位置信息。
+ * 前面 1，2 步骤在 view 中已经做掉了。对于组件响应式布局，可以尝试使用约束布局的方式去求解位置信息。
  * @param view
  */
 export default function defaultLayout(view: View): void {
-  // 1. 自动加 auto padding -> absolute padding
-  // 并且增加 appendPadding
-  const paddingCal = calculatePadding(view).shrink(parsePadding(view.appendPadding));
-
-  // 存储起来
-  view.autoPadding = paddingCal;
-
-  // 2. 计算出新的 coordinateBBox
-  view.coordinateBBox = view.viewBBox.shrink(paddingCal.getPadding());
-
-  view.adjustCoordinate();
-
-  // 3. 根据最新的 coordinate 重新布局组件
   const axis = view.getController('axis');
   const legend = view.getController('legend');
   const annotation = view.getController('annotation');
   const slider = view.getController('slider');
   const scrollbar = view.getController('scrollbar');
 
+  // 根据最新的 coordinate 重新布局组件
   [axis, slider, scrollbar, legend, annotation].forEach((controller: Controller) => {
     if (controller) {
       controller.layout();

--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -62,7 +62,7 @@ import TooltipComponent from './controller/tooltip';
 import Event from './event';
 import defaultLayout, { Layout } from './layout';
 import { ScalePool } from './util/scale-pool';
-import { isAutoPadding } from '../util/padding';
+import { PaddingCal } from './layout/padding-cal';
 
 /**
  * G2 视图 View 类
@@ -91,8 +91,8 @@ export class View extends Base {
   public appendPadding: ViewAppendPadding;
   /** G.Canvas 实例。 */
   public canvas: ICanvas;
-  /** 存储自动计算的 padding 值 */
-  public autoPadding: number[];
+  /** 存储最终计算的 padding 结果 */
+  public autoPadding: PaddingCal;
 
   /** 三层 Group 图形中的背景层。 */
   public backgroundGroup: IGroup;
@@ -1327,19 +1327,6 @@ export class View extends Base {
     this.initComponents(isUpdate);
     // 4. 进行布局，计算 coordinateBBox，进行组件布局，update 位置
     this.doLayout();
-    // 5. 更新并存储最终的 padding 值
-    const viewBBox = this.viewBBox;
-    const coordinateBBox = this.coordinateBBox;
-
-    if (isAutoPadding(this.padding)) {
-      // 用户未设置 padding 时，将自动计算的 padding 保存至 autoPadding 属性中
-      this.autoPadding = [
-        coordinateBBox.tl.y - viewBBox.tl.y,
-        viewBBox.tr.x - coordinateBBox.tr.x,
-        viewBBox.bl.y - coordinateBBox.bl.y,
-        coordinateBBox.tl.x - viewBBox.tl.x,
-      ];
-    }
 
     // 同样递归处理子 views
     const views = this.views;

--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -1355,18 +1355,19 @@ export class View extends Base {
   protected renderLayoutRecursive(isUpdate: boolean) {
     // 1. 同步子 view padding
     if (this.syncViewPadding) {
-      console.log(this.syncViewPadding);
       const syncPadding = new PaddingCal();
 
       // 所有的 view 的 autoPadding 指向同一个引用
       this.views.forEach((v: View) => {
         v.autoPadding = syncPadding.max(v.autoPadding.getPadding());
       });
-    }
 
-    // 2. 计算出新的 coordinateBBox，更新 Coordinate
-    this.coordinateBBox = this.viewBBox.shrink(this.autoPadding.getPadding());
-    this.adjustCoordinate();
+      // 更新 coordinate
+      this.views.forEach((v: View) => {
+        v.coordinateBBox = v.viewBBox.shrink(v.autoPadding.getPadding());
+        v.adjustCoordinate();
+      });
+    }
 
     // 3. 将 view 中的组件按照 view padding 移动到对应的位置
     this.doLayout();

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -721,7 +721,7 @@ export interface ViewOption {
 }
 
 /** Chart 构造方法的入参 */
-export interface ChartCfg {
+export interface ChartCfg extends Omit<ViewCfg, 'parent' | 'canvas' | 'foregroundGroup' | 'middleGroup' | 'backgroundGroup' | 'region'> {
   /** 指定 chart 绘制的 DOM，可以传入 DOM id，也可以直接传入 dom 实例。 */
   readonly container: string | HTMLElement;
   /** 图表宽度。 */
@@ -738,44 +738,15 @@ export interface ChartCfg {
   /** 设置设备像素比，默认取浏览器的值 `window.devicePixelRatio`。 */
   readonly pixelRatio?: number;
   /**
-   * 设置图表的内边距，使用方式参考 CSS 盒模型。
-   * 下图黄色区域即为 padding 的范围。
-   * ![](https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*pYwiQrdXGJ8AAAAAAAAAAABkARQnAQ)
-   *
-   * @example
-   * 1. padding: 20
-   * 2. padding: [ 10, 30, 30 ]
-   */
-  readonly padding?: ViewPadding;
-  /**
-   * 图表的内边距会在图表的padding的基础上加上appendPadding，使用方式参考 CSS 盒模型。
-   * @example
-   * 1. appendPadding: 20
-   * 2. appendPadding: [ 10, 30, 30 ]
-   */
-  readonly appendPadding?: ViewAppendPadding;
-  /**
    * 是否开启局部刷新，默认开启。
    */
   readonly localRefresh?: boolean;
-  /**
-   * chart 是否可见，默认为 true，设置为 false 则会隐藏。
-   */
-  readonly visible?: boolean;
-  /**
-   * 当使用配置项式创建 chart 时使用，详见 [配置项式创建图表教程](docs/tutorial/schema)。
-   */
-  readonly options?: Options;
+  /** 支持 CSS transform，开启后图表的交互以及事件将在页面设置了 css transform 属性时生效，默认关闭。 */
+  readonly supportCSSTransform?: boolean;
   /**
    * 配置图表默认交互，仅支持字符串形式。
    */
   readonly defaultInteractions?: string[];
-  /** 是否对超出坐标系范围的 Geometry 进行剪切 */
-  readonly limitInPlot?: boolean;
-  /** 主题 */
-  readonly theme?: LooseObject | string;
-  /** 支持 CSS transform，开启后图表的交互以及事件将在页面设置了 css transform 属性时生效，默认关闭。 */
-  readonly supportCSSTransform?: boolean;
 }
 
 /** View 构造参数 */
@@ -813,6 +784,14 @@ export interface ViewCfg {
    * 2. padding: [ 10, 30, 30 ]
    */
   readonly appendPadding?: ViewAppendPadding;
+  /**
+   * 是否同步子 view 的 padding
+   * 比如:
+   *  view1 的 padding 10
+   *  view2 的 padding 20
+   * 那么两个子 view 的 padding 统一变成最大的 20（后面可以传入 function 自己写策略）
+   */
+  readonly syncViewPadding?: boolean;
   /** 设置 view 实例主题。 */
   readonly theme?: LooseObject | string;
   /**

--- a/tests/bugs/2356-spec.ts
+++ b/tests/bugs/2356-spec.ts
@@ -42,7 +42,7 @@ describe('2356', () => {
 
     const element = chart.geometries[0].elements[4];
     expect(element.getBBox().height).toBe(500);
-    expect(chart.autoPadding).toBeUndefined();
+    expect(chart.autoPadding.getPadding()).toEqual(chart.padding);
     expect(chart.padding).toEqual([50, 20, 50, 20]);
   });
 });

--- a/tests/bugs/2570-spec.ts
+++ b/tests/bugs/2570-spec.ts
@@ -27,6 +27,6 @@ describe('2570', () => {
     chart.render();
 
     chart.changeSize(400, 300);
-    expect(chart.autoPadding).toEqual([20, 20, 20, 20]);
+    expect(chart.autoPadding.getPadding()).toEqual([20, 20, 20, 20]);
   });
 });

--- a/tests/bugs/2658-spec.ts
+++ b/tests/bugs/2658-spec.ts
@@ -30,7 +30,7 @@ describe('#2658', () => {
     // re-render
     chart.changeData(data.slice(0, 5));
 
-    const [top, right, bottom, left] = chart.autoPadding;
+    const [top, right, bottom, left] = chart.autoPadding.getPadding();
 
     expect(chart.padding).toBe('auto');
     expect(left > 10).toBe(true);

--- a/tests/bugs/2841-spec.ts
+++ b/tests/bugs/2841-spec.ts
@@ -1,0 +1,60 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+
+describe('2841 syncViewPadding', () => {
+  it('2841', () => {
+    const data = [
+      { name: 'a', time: '10:10', call: 4, waiting: 2, people: 2 },
+      { name: 'b', time: '10:10', call: 4, waiting: 21, people: 2 },
+      { name: 'a', time: '10:15', call: 2, waiting: 6, people: 3 },
+      { name: 'b', time: '10:15', call: 2, waiting: 16, people: 3 },
+      { name: 'a', time: '10:20', call: 13, waiting: 2, people: 5 },
+      { name: 'b', time: '10:20', call: 13, waiting: 12, people: 5 },
+      { name: 'a', time: '10:25', call: 9, waiting: 9, people: 1 },
+      { name: 'b', time: '10:25', call: 9, waiting: 19, people: 1 },
+    ];
+    const chart = new Chart({
+      container: createDiv(),
+      width: 400,
+      height: 300,
+      autoFit: true,
+      syncViewPadding: true,
+    });
+    chart.data(data);
+    chart.tooltip({
+      shared: true,
+    });
+
+    const v1 = chart.createView();
+    v1.line().position('time*people').color('#fdae6b').size(3).shape('smooth');
+
+    v1.axis('people', { position: 'left' });
+
+    const v2 = chart.createView();
+    v2.interval()
+      .position('time*waiting')
+      .color('name')
+      .adjust([
+        {
+          type: 'dodge',
+          marginRatio: 1 / 32,
+        },
+      ]);
+    v2.axis('waiting', { position: 'right' });
+
+    chart.render();
+
+    // xy 坐标轴都显示
+    expect(v1.getComponents().filter((co) => co.type === 'axis').length).toBe(2);
+    expect(v2.getComponents().filter((co) => co.type === 'axis').length).toBe(2);
+
+    // 因为同步，所以使用同一个实例 autoPadding
+    expect(v1.autoPadding).toBe(v2.autoPadding);
+
+    // legend 在 x 轴的下方
+    expect(chart.getComponents()[0].component.getBBox().minY).toBeGreaterThan(v1.getComponents()[0].component.getBBox().maxY);
+
+    // v1 v2 的 axis 轴坐标一模一样
+    expect(v1.getComponents()[0].component.getBBox()).toEqual(v2.getComponents()[0].component.getBBox());
+  });
+});

--- a/tests/unit/chart/controller/legend-spec.ts
+++ b/tests/unit/chart/controller/legend-spec.ts
@@ -285,7 +285,7 @@ describe('Legend', () => {
     const legend = chart.getController('legend').getComponents()[0].component;
     const legendBBox = legend.getBBox();
     expect(legendBBox.height).toBe(12);
-    expect(chart.autoPadding[0]).toBe(32);
+    expect(chart.autoPadding.getPadding()[0]).toBe(32);
   });
 
   afterAll(() => {

--- a/tests/unit/component/legend-category-spec.ts
+++ b/tests/unit/component/legend-category-spec.ts
@@ -1,68 +1,8 @@
 import { Chart } from '../../../src/';
 import { COMPONENT_TYPE } from '../../../src/constant';
 import { GroupComponent, GroupComponentCfg } from '../../../src/dependents';
-import { CITY_SALE, DIAMOND } from '../../util/data';
+import { DIAMOND } from '../../util/data';
 import { createDiv, removeDom } from '../../util/dom';
-
-// describe('Legend category', () => {
-//   const div = createDiv();
-
-//   const chart = new Chart({
-//     container: div,
-//     width: 800,
-//     height: 600,
-//     autoFit: false,
-//   });
-
-//   chart.animate(false);
-
-//   chart.data(CITY_SALE);
-
-//   chart.interval().position('city*sale').color('category').adjust({ type: 'dodge' });
-
-//   it('close legend', () => {
-//     chart.legend(false);
-//     chart.render();
-//     const legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
-//     expect(legends.length).toBe(0);
-//   });
-
-//   it('legend component', () => {
-//     chart.legend('category', {
-//       position: 'right',
-//     });
-
-//     chart.render();
-//     const legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
-//     expect(legends.length).toBe(1);
-
-//     const legend = legends[0].component;
-//     // @ts-ignore
-//     const items: any[] = legend.get('items');
-
-//     // two legend items
-//     expect(items.length).toBe(2);
-
-//     // legend item style
-//     expect(items[0].name).toBe('电脑');
-//     expect(items[1].name).toBe('鼠标');
-//     expect(items[0].marker.style.fill).toBe('#5B8FF9');
-//     expect(items[1].marker.style.fill).toBe('#5AD8A6');
-
-//     // position
-//     // @ts-ignore
-//     const x: any[] = legend.get('x');
-
-//     // right
-//     expect(x).toBeGreaterThan(700);
-
-//     expect(chart.autoPadding.length).toBe(4);
-//     expect(chart.autoPadding[0]).toBe(6);
-//     expect(chart.autoPadding[1]).toBe(56);
-//     expect(chart.autoPadding[2]).toBe(20);
-//     expect(chart.autoPadding[3]).toBeCloseTo(28.0159912109375);
-//   });
-// });
 
 describe('Legend category navigation', () => {
   const div = createDiv();

--- a/tests/unit/options/options-spec.ts
+++ b/tests/unit/options/options-spec.ts
@@ -211,10 +211,7 @@ describe('Schema', () => {
       ],
     });
     chart.render();
-    expect(chart.autoPadding[0]).toBe(0);
-    expect(chart.autoPadding[1]).toBe(0.5);
-    expect(chart.autoPadding[2]).toBe(20);
-    expect(chart.autoPadding[3]).toBe(34.68798828125);
+    expect(chart.autoPadding.getPadding()).toEqual([0, 0.5, 20, 34.68798828125]);
   });
 
   afterAll(() => {


### PR DESCRIPTION
配合 ：https://github.com/antvis/component/pull/191   （测试用例也在该 PR 补充）

对于 axis 的样式回调，从样式统一、易用性角度，需要 mix G2 默认主题样式，否则用户需要自己填写样式属性，如果用户不知情，在某些情况下就会以为是 BUG，比如只是对文本内容进行回调：

```ts
chart.axis('x', {
  label: {
    style: (val) => { 
      return {
        text: val + '$'
      };
    }
  }
});
```