### PR TITLE
feat(legend): set default maxItemWidth = 200

### DIFF
--- a/src/util/theme.ts
+++ b/src/util/theme.ts
@@ -226,7 +226,7 @@ export function createThemeByStylesheet(styleSheet: StyleSheet): LooseObject {
     },
     flipPage: true,
     animate: false,
-    maxItemWidth: 0.2,
+    maxItemWidth: 200,
     itemSpacing: styleSheet.legendItemSpacing,
     itemMarginBottom: styleSheet.legendItemMarginBottom,
     padding: styleSheet.legendPadding, // 图例组件自己的外边距

--- a/tests/unit/component/legend-category-spec.ts
+++ b/tests/unit/component/legend-category-spec.ts
@@ -135,10 +135,10 @@ describe('Legend auto ellipsis', () => {
 
     const legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
     const legend = legends[0].component as GroupComponent<GroupComponentCfg>;
-    expect(legend.get('maxItemWidth')).toBe(80);
+    expect(legend.get('maxItemWidth')).toBe(200);
     expect(
       legend.getElementById('-legend-item-测试测试测试测试测试测试测试测试测试测试测试测试测试测试1-name').attr('text')
-    ).toBe('测试测试…');
+    ).toBe('测试测试测试测试测试测试测试…');
   });
 
   it('itemWidth', () => {
@@ -151,7 +151,7 @@ describe('Legend auto ellipsis', () => {
 
     const legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
     const legend = legends[0].component as GroupComponent<GroupComponentCfg>;
-    expect(legend.get('maxItemWidth')).toBe(80);
+    expect(legend.get('maxItemWidth')).toBe(200);
     expect(legend.get('itemWidth')).toBe(60);
     expect(
       legend.getElementById('-legend-item-测试测试测试测试测试测试测试测试测试测试测试测试测试测试1-name').attr('text')


### PR DESCRIPTION
 - [x] 修改默认的 maxItemWidth 为固定值。因为相对值确实有点不合适

200px 相对来说比较靠谱一些。这个参数对业务来说应该还是很重要的。

![image](https://user-images.githubusercontent.com/7856674/94669753-38c49980-0344-11eb-9c3b-10cd0569503e.png)

![image](https://user-images.githubusercontent.com/7856674/94669588-074bce00-0344-11eb-93a0-a32fdf006579.png)

