### PR TITLE
fix(issue-2905): 自定义 shape 的默认样式设置

### DIFF
--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -1367,6 +1367,12 @@ export default class Geometry extends Base {
     // 获取默认样式
     const theme = this.theme.geometries[this.shapeType];
     cfg.defaultStyle = get(theme, [shapeName, 'default'], {}).style;
+    if (!cfg.defaultStyle && this.getShapeFactory()) {
+      cfg.defaultStyle = this.getShapeFactory().getDefaultStyle(theme);
+      if (!cfg.color) {
+        cfg.color = get(cfg.defaultStyle, ['fill']);
+      }
+    }
 
     const styleOption = this.styleOption;
     if (styleOption) {

--- a/src/geometry/shape/base.ts
+++ b/src/geometry/shape/base.ts
@@ -1,3 +1,4 @@
+import { LooseObject } from '@antv/g-svg';
 import { parsePathString } from '@antv/path-util';
 import { deepMix, get, upperFirst } from '@antv/util';
 import { IGroup, IShape, PathCommand } from '../../dependents';
@@ -54,6 +55,12 @@ const ShapeFactoryBase = {
    */
   getDefaultPoints() {
     return [];
+  },
+  /**
+   * 获取 shape 的默认绘制样式 (内置的 shapeFactory 均有注册默认样式)
+   */
+  getDefaultStyle(geometryTheme: LooseObject): LooseObject {
+    return get(geometryTheme, [this.defaultShapeType, 'default', 'style'], {});
   },
   /**
    * 获取 shape 对应的缩略图配置信息。

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -423,6 +423,8 @@ export interface RegisterShapeFactory {
   readonly defaultShapeType: string;
   /** 返回绘制 shape 所有的关键点集合。 */
   readonly getDefaultPoints?: (pointInfo: ShapePoint) => Point[];
+  /** 获取 shape 的默认绘制样式 */
+  readonly getDefaultStyle?: (geometryTheme: LooseObject) => LooseObject;
   /** 获取 shape 对应的缩略图配置。 */
   readonly getMarker?: (shapeType: string, markerCfg: ShapeMarkerCfg) => ShapeMarkerAttrs;
   /** 创建具体的 G.Shape 实例。 */
@@ -721,7 +723,8 @@ export interface ViewOption {
 }
 
 /** Chart 构造方法的入参 */
-export interface ChartCfg extends Omit<ViewCfg, 'parent' | 'canvas' | 'foregroundGroup' | 'middleGroup' | 'backgroundGroup' | 'region'> {
+export interface ChartCfg
+  extends Omit<ViewCfg, 'parent' | 'canvas' | 'foregroundGroup' | 'middleGroup' | 'backgroundGroup' | 'region'> {
   /** 指定 chart 绘制的 DOM，可以传入 DOM id，也可以直接传入 dom 实例。 */
   readonly container: string | HTMLElement;
   /** 图表宽度。 */
@@ -1177,7 +1180,7 @@ export interface TooltipCfg {
   /** tooltip 偏移量。 */
   offset?: number;
   /** 支持自定义模板 */
-  customContent?: (title: string, data: any[]) =>  string | HTMLElement;
+  customContent?: (title: string, data: any[]) => string | HTMLElement;
 }
 
 /** 坐标系配置 */

--- a/tests/bugs/2905-spec.ts
+++ b/tests/bugs/2905-spec.ts
@@ -1,0 +1,90 @@
+import { Chart, registerShape } from '../../src';
+import { createDiv, simulateMouseEvent } from '../util/dom';
+import { getClientPoint } from '../util/simulate';
+
+describe('#2905: 没有自定义主题或者设置 color 映射的时候，自定义 shape 中 draw 方法获取不到 defaultStyle 或 color', () => {
+  const data = [
+    { name: 'MODIFY', value: 138, washaway: 0.21014492753623193 },
+    { name: 'PRERELEASE', value: 109, washaway: 0.5596330275229358 },
+    { name: 'RELEASING', value: 48, washaway: 0 },
+  ];
+
+  registerShape('interval', 'text-interval', {
+    draw(cfg, container) {
+      const points = this.parsePoints(cfg.points); // 将0-1空间的坐标转换为画布坐标
+      const group = container.addGroup();
+      group.addShape('polygon', {
+        attrs: {
+          points: points.map((point) => [point.x, point.y]),
+          fill: cfg.color,
+        },
+      });
+
+      return group;
+    },
+  });
+
+  const chart = new Chart({
+    container: createDiv(),
+    width: 400,
+    height: 300,
+    autoFit: true,
+  });
+
+  chart.data(data);
+  chart.scale({
+    value: {
+      alias: '访问数',
+      nice: true,
+    },
+    name: {
+      alias: '步骤名称',
+    },
+  });
+
+  chart.interval().position('name*value').shape('text-interval').size(30);
+
+  chart.render();
+
+  it('default: 默认取 defaultShapeType 的主题设置', () => {
+    expect(chart.geometries[0].elements[0].getModel().color).not.toBeUndefined();
+    expect(chart.geometries[0].elements[0].getModel().defaultStyle).toEqual(
+      chart.getTheme().geometries.interval.rect.default.style
+    );
+  });
+
+  it('manual: 手动设置自定义 shape 的主题', () => {
+    chart.theme({
+      geometries: {
+        interval: {
+          'text-interval': {
+            default: {
+              style: {
+                fill: 'red',
+              },
+            },
+            active: {
+              style: {
+                stroke: 'green',
+              },
+            },
+          },
+        },
+      },
+    });
+    chart.interaction('element-active');
+    chart.render();
+    const element0 = chart.geometries[0].elements[0];
+    // expect(element0.getModel().color).toBe('red');
+
+    const canvas = chart.getCanvas();
+    const el = canvas.get('el');
+    const box = element0.shape.getCanvasBBox();
+
+    simulateMouseEvent(el, 'mouseenter', getClientPoint(canvas, (box.minX + box.maxX) / 2, (box.minY + box.maxY) / 2));
+    expect(element0.hasState('active')).toBe(true);
+    setTimeout(() => {
+      expect(element0.shape.get('children')[0].attr('stroke')).toBe('green');
+    }, 0);
+  });
+});


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines
- [ ] docs 补全：自定义注册 shape 的主题设置（下方 PR 处理）

##### Description of change
<!-- Provide a description of the change below this comment. -->

获取图形绘制数据时,若 theme 中未注册,则默认取 shapeFactory 默认shapeType注册的主题样式

closed: #2905 