### PR TITLE
fix: return early from sectorPathUpdate if path is invalid

### DIFF
--- a/src/animate/animation/sector-path-update.ts
+++ b/src/animate/animation/sector-path-update.ts
@@ -108,9 +108,10 @@ function getArcInfo(path: PathCommand[]) {
  */
 export function sectorPathUpdate(shape: IShape, animateCfg: GAnimateCfg, cfg: AnimateExtraCfg) {
   const { toAttrs, coordinate } = cfg;
-  // @ts-ignore
-  const path = toAttrs.path;
+  const path = (toAttrs as { path: PathCommand[] }).path || [];
   const pathCommands = path.map((command) => command[0]);
+
+  if (path.length < 1) return;
 
   const { startAngle: curStartAngle, endAngle: curEndAngle, radius, innerRadius } = getArcInfo(path);
   const { startAngle: preStartAngle, endAngle: preEndAngle } = getArcInfo(shape.attr('path'));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

In a project, I'm getting `Cannot read property '0' of undefined`. Sentry report:

```
Crashed in non-app:
/tmp/build_dfe7ac4f_/node_modules/@antv/g2/esm/animate/animation/sector-path-update.js in getArcStartPoint
```

This is (superficially) because there's nothing that checks whether `toAttrs.path` is a valid `PathCommand[]`. I've added that check with an early return.