### PR TITLE
feat: support tooltip reversed cfg

### DIFF
--- a/src/chart/controller/tooltip.ts
+++ b/src/chart/controller/tooltip.ts
@@ -1,4 +1,16 @@
-import { deepMix, find, flatten, get, isArray, isEqual, isFunction, mix, isString, isEmpty, isBoolean} from '@antv/util';
+import {
+  deepMix,
+  find,
+  flatten,
+  get,
+  isArray,
+  isEqual,
+  isFunction,
+  mix,
+  isString,
+  isEmpty,
+  isBoolean,
+} from '@antv/util';
 import { Crosshair, HtmlTooltip, IGroup } from '../../dependents';
 import Geometry from '../../geometry/base';
 import { Point, TooltipOption } from '../../interface';
@@ -79,11 +91,14 @@ export default class Tooltip extends Controller<TooltipOption> {
       y: items[0].y,
     }; // 数据点位置
 
-    view.emit('tooltip:show', Event.fromData(view, 'tooltip:show', {
-      items,
-      title,
-      ...point,
-    }));
+    view.emit(
+      'tooltip:show',
+      Event.fromData(view, 'tooltip:show', {
+        items,
+        title,
+        ...point,
+      })
+    );
 
     const cfg = this.getTooltipCfg();
     const { follow, showMarkers, showCrosshairs, showContent, marker } = cfg;
@@ -91,11 +106,14 @@ export default class Tooltip extends Controller<TooltipOption> {
     const lastTitle = this.title;
     if (!isEqual(lastTitle, title) || !isEqual(lastItems, items)) {
       // 内容发生变化了更新 tooltip
-      view.emit('tooltip:change', Event.fromData(view, 'tooltip:change', {
-        items,
-        title,
-        ...point,
-      }));
+      view.emit(
+        'tooltip:change',
+        Event.fromData(view, 'tooltip:change', {
+          items,
+          title,
+          ...point,
+        })
+      );
 
       if (showContent) {
         // 展示 tooltip 内容框才渲染 tooltip
@@ -244,7 +262,7 @@ export default class Tooltip extends Controller<TooltipOption> {
     this.reset();
   }
 
-  public reset() { 
+  public reset() {
     this.items = null;
     this.title = null;
     this.tooltipMarkersGroup = null;
@@ -380,14 +398,14 @@ export default class Tooltip extends Controller<TooltipOption> {
 
   // process customContent
   protected processCustomContent(option: TooltipOption) {
-    if(isBoolean(option) || !get(option, 'customContent')){
+    if (isBoolean(option) || !get(option, 'customContent')) {
       return option;
     }
     const currentCustomContent = option.customContent;
     const customContent = (title: string, items: any[]) => {
       const content = currentCustomContent(title, items) || '';
-      return isString(content) ? '<div class="g2-tooltip">' + content + '</div>' : content ;
-    }
+      return isString(content) ? '<div class="g2-tooltip">' + content + '</div>' : content;
+    };
     return {
       ...option,
       customContent,
@@ -724,7 +742,7 @@ export default class Tooltip extends Controller<TooltipOption> {
     let result = [];
     // 先从 view 本身查找
     const geometries = view.geometries;
-    const { shared, title } = this.getTooltipCfg();
+    const { shared, title, reversed } = this.getTooltipCfg();
     for (const geometry of geometries) {
       if (geometry.visible && geometry.tooltipOption !== false) {
         // geometry 可见同时未关闭 tooltip
@@ -744,6 +762,9 @@ export default class Tooltip extends Controller<TooltipOption> {
           }
         }
         if (tooltipItems.length) {
+          if (reversed) {
+            tooltipItems.reverse();
+          }
           // geometry 有可能会有多个 item，因为用户可以设置 geometry.tooltip('x*y*z')
           result.push(tooltipItems);
         }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1229,6 +1229,8 @@ export interface TooltipCfg {
   domStyles?: TooltipDomStyles;
   /** tooltip 偏移量。 */
   offset?: number;
+  /** 是否将 tooltip items 逆序 */
+  reversed?: boolean;
   /** 支持自定义模板 */
   customContent?: (title: string, data: any[]) => string | HTMLElement;
 }

--- a/tests/unit/chart/controller/tooltip-spec.ts
+++ b/tests/unit/chart/controller/tooltip-spec.ts
@@ -118,6 +118,31 @@ describe('Tooltip', () => {
     expect(items[1].data).toEqual({ name: 'Berlin', 月份: 'Mar.', 月均降雨量: 34.5 });
   });
 
+  it('reversed', () => {
+    chart.tooltip({
+      follow: true,
+      shared: true,
+      showCrosshairs: true,
+      showMarkers: true,
+      domStyles: {
+        'g2-tooltip': {
+          border: '1px solid #000',
+          boxShadow: null,
+        },
+      },
+      reversed: true,
+    });
+
+    const point = chart.getXY({ name: 'Berlin', 月份: 'Mar.', 月均降雨量: 34.5 });
+
+    const items = chart.getTooltipItems(point);
+    expect(items.length).toBe(2);
+
+    expect(items[0].title).toBe('Mar.');
+    expect(items[0].data).toEqual({ name: 'Berlin', 月份: 'Mar.', 月均降雨量: 34.5 });
+    expect(items[1].data).toEqual({ name: 'London', 月份: 'Mar.', 月均降雨量: 39.3 });
+  });
+
   it('clear', () => {
     chart.clear();
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

tooltip 支持配置 reversed 来逆序默认的 tooltip items，配合 G2Plot bar 将数据逆序后的 tooltip 顺序和柱子顺序不一致问题
