### PR TITLE
fix: 更改默认 scale type 设置：time -> timeCat

### DIFF
--- a/src/util/scale.ts
+++ b/src/util/scale.ts
@@ -14,7 +14,7 @@ const dateRegex = /^(?:(?!0000)[0-9]{4}([-/.]+)(?:(?:0?[1-9]|1[0-2])\1(?:0?[1-9]
 function getDefaultType(value: any): string {
   let type = 'linear';
   if (dateRegex.test(value)) {
-    type = 'time';
+    type = 'timeCat';
   } else if (isString(value)) {
     type = 'cat';
   }

--- a/tests/unit/geometry/interval-spec.ts
+++ b/tests/unit/geometry/interval-spec.ts
@@ -1,5 +1,6 @@
 import { getCoordinate } from '@antv/coord';
-import { getScale } from '@antv/scale';
+import { getScale, Scale } from '@antv/scale';
+import { ScaleType } from  '../../../src/interface';
 import { isNumberEqual } from '@antv/util';
 import Interval from '../../../src/geometry/interval';
 import { getTheme } from '../../../src/theme/';
@@ -294,7 +295,7 @@ describe('Interval', () => {
       ];
       const newScaleDefs = {
         a: { range: [0.25, 0.75] },
-        b: null,
+        b: { type: 'time' as ScaleType },
       };
       const newScales = {
         a: createScale('a', newData, newScaleDefs),

--- a/tests/unit/util/scale-spec.ts
+++ b/tests/unit/util/scale-spec.ts
@@ -48,10 +48,17 @@ describe('ScaleUtil', () => {
   });
 
   it('create time scale', () => {
-    const scale = createScaleByField('c', data1);
+    const scale = createScaleByField('c', data1, { type: 'time' });
     expect(scale.type).toBe('time');
     // @ts-ignore
     expect(scale.nice).toBe(false);
+  });
+
+  it('create timeCat scale', () => {
+    const scale = createScaleByField('c', data1);
+    expect(scale.type).toBe('timeCat');
+    // @ts-ignore
+    expect(scale.nice).toBeUndefined();
   });
 
   it('create defined scale', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
对于‘2010-10-01’ 类似的数据，默认使用 timeCat 类型