### PR TITLE
feat(label): add limitInPlot label layout

### DIFF
--- a/src/geometry/label/layout/limit-in-plot.ts
+++ b/src/geometry/label/layout/limit-in-plot.ts
@@ -1,0 +1,87 @@
+import { each } from '@antv/util';
+import { BBox, IGroup, IShape } from '../../../dependents';
+import { translate } from '../../../util/transform';
+import { getCoordinateBBox } from '../../../util/coordinate';
+import { LabelItem } from '../interface';
+
+/** limitInPlot layout 的可选配置 */
+export interface LimitInPlotLayoutCfg {
+  /** 需要限制哪些方向上不能超过 Plot 范围，默认四个方向上都限制 */
+  direction?: ('top' | 'right' | 'bottom' | 'left')[];
+  /** 可以允许的 margin */
+  margin?: number;
+  /** 超过限制后的动作，默认 translate 移动位置 */
+  action?: 'hide' | 'translate';
+}
+
+/**
+ * @ignore
+ * 将 label 限制在 Plot 范围内，将超出 Plot 范围的 label 可选择进行隐藏或者移动位置
+ * @param labels
+ * @param cfg
+ */
+export function limitInPlot(
+  items: LabelItem[],
+  labels: IGroup[],
+  shapes: IShape[] | IGroup[],
+  region: BBox,
+  cfg?: LimitInPlotLayoutCfg
+) {
+  const direction = cfg?.direction || ['top', 'right', 'bottom', 'left'];
+  const action = cfg?.action || 'translate';
+  const margin = cfg?.margin || 0;
+  if (labels.length <= 0) {
+    return;
+  }
+  const coordinate = labels[0].get('coordinate');
+  if (!coordinate) {
+    return;
+  }
+  const { minX: regionMinX, minY: regionMinY, maxX: regionMaxX, maxY: regionMaxY } = getCoordinateBBox(
+    coordinate,
+    margin
+  );
+
+  each(labels, (label: IGroup) => {
+    const { minX, minY, maxX, maxY, x, y, width, height } = label.getCanvasBBox();
+
+    let finalX = x;
+    let finalY = y;
+    if (direction.indexOf('left') >= 0 && (minX < regionMinX || maxX < regionMinX)) {
+      // 超出左侧
+      finalX = regionMinX;
+    }
+    if (direction.indexOf('top') >= 0 && (minY < regionMinY || maxY < regionMinY)) {
+      // 超出顶部
+      finalY = regionMinY;
+    }
+
+    if (direction.indexOf('right') >= 0) {
+      if (minX > regionMaxX) {
+        // 整体超出右侧
+        finalX = regionMaxX - width;
+      } else if (maxX > regionMaxX) {
+        // 超出右侧
+        finalX = finalX - (maxX - regionMaxX);
+      }
+    }
+
+    if (direction.indexOf('bottom') >= 0) {
+      if (minY > regionMaxY) {
+        // 整体超出底部
+        finalY = regionMaxY - height;
+      } else if (maxY > regionMaxY) {
+        // 超出底部
+        finalY = finalY - (maxY - regionMaxY);
+      }
+    }
+
+    if (finalX !== x || finalY !== y) {
+      if (action === 'translate') {
+        translate(label, finalX - x, finalY - y);
+      } else {
+        label.hide();
+      }
+    }
+  });
+}

--- a/src/geometry/label/layout/limit-in-plot.ts
+++ b/src/geometry/label/layout/limit-in-plot.ts
@@ -27,12 +27,12 @@ export function limitInPlot(
   region: BBox,
   cfg?: LimitInPlotLayoutCfg
 ) {
-  const direction = cfg?.direction || ['top', 'right', 'bottom', 'left'];
-  const action = cfg?.action || 'translate';
-  const margin = cfg?.margin || 0;
   if (labels.length <= 0) {
     return;
   }
+  const direction = cfg?.direction || ['top', 'right', 'bottom', 'left'];
+  const action = cfg?.action || 'translate';
+  const margin = cfg?.margin || 0;
   const coordinate = labels[0].get('coordinate');
   if (!coordinate) {
     return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ import { intervalAdjustPosition } from './geometry/label/layout/interval/adjust-
 import { intervalHideOverlap } from './geometry/label/layout/interval/hide-overlap';
 import { pointAdjustPosition } from './geometry/label/layout/point/adjust-position';
 import { pathAdjustPosition } from './geometry/label/layout/path/adjust-position';
+import { limitInPlot } from './geometry/label/layout/limit-in-plot';
 
 registerGeometryLabelLayout('overlap', overlap);
 registerGeometryLabelLayout('distribute', distribute);
@@ -97,6 +98,7 @@ registerGeometryLabelLayout('fixed-overlap', fixedOverlap);
 registerGeometryLabelLayout('hide-overlap', hideOverlap);
 registerGeometryLabelLayout('limit-in-shape', limitInShape);
 registerGeometryLabelLayout('limit-in-canvas', limitInCanvas);
+registerGeometryLabelLayout('limit-in-plot', limitInPlot);
 registerGeometryLabelLayout('pie-outer', pieOuterLabelLayout);
 registerGeometryLabelLayout('adjust-color', adjustColor);
 registerGeometryLabelLayout('interval-adjust-position', intervalAdjustPosition);

--- a/src/util/coordinate.ts
+++ b/src/util/coordinate.ts
@@ -2,6 +2,7 @@ import { Coordinate } from '../dependents';
 import { Point } from '../interface';
 import { getSectorPath } from './graphics';
 import { isBetween } from './helper';
+import { BBox } from './bbox';
 
 /**
  * @ignore
@@ -141,4 +142,19 @@ export function getCoordinateClipCfg(coordinate: Coordinate, margin: number = 0)
       height: height + margin * 2,
     },
   };
+}
+
+/**
+ * 获取坐标系范围的 BBox
+ * @param coordinate
+ * @param margin
+ */
+export function getCoordinateBBox(coordinate: Coordinate, margin = 0) {
+  const { start, end } = coordinate;
+  const width = coordinate.getWidth();
+  const height = coordinate.getHeight();
+  const minX = Math.min(start.x, end.x);
+  const minY = Math.min(start.y, end.y);
+
+  return BBox.fromRange(minX - margin, minY - margin, minX + width + margin, minY + height + margin);
 }

--- a/tests/unit/geometry/label/layout/limit-in-plot-spec.ts
+++ b/tests/unit/geometry/label/layout/limit-in-plot-spec.ts
@@ -1,0 +1,227 @@
+import { IGroup, ShapeAttrs } from '@antv/g-base';
+import { getCoordinate, Coordinate } from '@antv/coord';
+import { limitInPlot } from '../../../../../src/geometry/label/layout/limit-in-plot';
+import { createCanvas, createDiv, removeDom } from '../../../../util/dom';
+
+const Polar = getCoordinate('polar');
+const Cartesian = getCoordinate('rect');
+
+describe('GeometryLabel layout limitInPlot', () => {
+  const div = createDiv();
+  const WIDTH = 150;
+  const HEIGHT = 100;
+  const canvas = createCanvas({
+    container: div,
+    width: WIDTH,
+    height: HEIGHT,
+  });
+
+  const group = canvas.addGroup();
+  const region = group.getBBox();
+  const coord = new Cartesian({ start: { x: 0, y: 0 }, end: { x: WIDTH, y: HEIGHT } });
+  const addLabel = (instance: Coordinate, x: number, y: number, text = 'label', attrs: ShapeAttrs = {}) => {
+    const labelGroup = group.addGroup({
+      id: `group-${text}`,
+      coordinate: instance,
+    });
+    labelGroup.addShape({
+      type: 'text',
+      id: `text-${text}`,
+      attrs: {
+        x,
+        y,
+        text,
+        fill: 'red',
+        textAlign: 'start',
+        textBaseline: 'top',
+        ...attrs,
+      },
+    });
+  };
+  const getLabels = () => group.getChildren() as IGroup[];
+  const getCount = () =>
+    getLabels().filter((labelGroup) => labelGroup.get('visible') && labelGroup.getFirst().get('visible')).length;
+
+  beforeEach(() => {
+    group.clear();
+  });
+
+  it('top', () => {
+    addLabel(coord, -5, 50, 'label1');
+    addLabel(coord, 40, 50, 'label2');
+    limitInPlot([], getLabels(), [], region);
+
+    expect(getCount()).toBe(2);
+    expect(getLabels()[0].getCanvasBBox().minX).toBe(0);
+    expect(getLabels()[0].getCanvasBBox().minY).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().minX).toBe(40);
+    expect(getLabels()[1].getCanvasBBox().minY).toBe(50);
+  });
+
+  it('top, margin', () => {
+    addLabel(coord, -5, 50, 'label1');
+    addLabel(coord, 40, 50, 'label2');
+    addLabel(coord, -10, 50, 'label3');
+    limitInPlot([], getLabels(), [], region, { margin: 6 });
+
+    expect(getCount()).toBe(3);
+    expect(getLabels()[0].getCanvasBBox().minX).toBe(-5);
+    expect(getLabels()[0].getCanvasBBox().minY).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().minX).toBe(40);
+    expect(getLabels()[1].getCanvasBBox().minY).toBe(50);
+    expect(getLabels()[2].getCanvasBBox().minX).toBe(-6);
+    expect(getLabels()[2].getCanvasBBox().minY).toBe(50);
+  });
+
+  it('right', () => {
+    addLabel(coord, 150, 40, 'label1');
+    addLabel(coord, 50, 40, 'label2');
+    limitInPlot([], getLabels(), [], region);
+
+    expect(getCount()).toBe(2);
+    expect(getLabels()[0].getCanvasBBox().maxX).toBe(150);
+    expect(getLabels()[0].getCanvasBBox().y).toBe(40);
+    expect(getLabels()[1].getCanvasBBox().x).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().y).toBe(40);
+  });
+
+  it('right, margin', () => {
+    addLabel(coord, 155, 40, 'label1', { textAlign: 'right' });
+    addLabel(coord, 50, 40, 'label2', { textAlign: 'right' });
+    addLabel(coord, 160, 40, 'label3', { textAlign: 'right' });
+    limitInPlot([], getLabels(), [], region, { margin: 6 });
+
+    expect(getCount()).toBe(3);
+    expect(getLabels()[0].getCanvasBBox().maxX).toBe(155);
+    expect(getLabels()[1].getCanvasBBox().minY).toBe(40);
+    expect(getLabels()[1].getCanvasBBox().maxX).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().minY).toBe(40);
+    expect(getLabels()[2].getCanvasBBox().maxX).toBe(156);
+    expect(getLabels()[2].getCanvasBBox().minY).toBe(40);
+  });
+
+  it('bottom', () => {
+    addLabel(coord, 40, 50, 'label1');
+    addLabel(coord, 40, 100, 'label2');
+    limitInPlot([], getLabels(), [], region);
+
+    expect(getCount()).toBe(2);
+    expect(getLabels()[0].getCanvasBBox().minX).toBe(40);
+    expect(getLabels()[0].getCanvasBBox().minY).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().minX).toBe(40);
+    expect(getLabels()[1].getCanvasBBox().maxY).toBe(100);
+  });
+
+  it('bottom, margin', () => {
+    addLabel(coord, 40, 50, 'label1', { textBaseline: 'bottom' });
+    addLabel(coord, 40, 105, 'label2', { textBaseline: 'bottom' });
+    addLabel(coord, 40, 110, 'label3', { textBaseline: 'bottom' });
+    limitInPlot([], getLabels(), [], region, { margin: 6 });
+
+    expect(getCount()).toBe(3);
+    expect(getLabels()[0].getCanvasBBox().minX).toBe(40);
+    expect(getLabels()[0].getCanvasBBox().maxY).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().minX).toBe(40);
+    expect(getLabels()[1].getCanvasBBox().maxY).toBe(105);
+    expect(getLabels()[2].getCanvasBBox().minX).toBe(40);
+    expect(getLabels()[2].getCanvasBBox().maxY).toBe(106);
+  });
+
+  it('left', () => {
+    addLabel(coord, 40, 50, 'label1');
+    addLabel(coord, -5, 50, 'label2');
+    limitInPlot([], getLabels(), [], region);
+
+    expect(getCount()).toBe(2);
+    expect(getLabels()[0].getCanvasBBox().minX).toBe(40);
+    expect(getLabels()[0].getCanvasBBox().minY).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().minX).toBe(0);
+    expect(getLabels()[1].getCanvasBBox().minY).toBe(50);
+  });
+
+  it('left, margin', () => {
+    addLabel(coord, 40, 50, 'label1');
+    addLabel(coord, -5, 50, 'label2');
+    addLabel(coord, -10, 50, 'label3');
+    limitInPlot([], getLabels(), [], region, { margin: 6 });
+
+    expect(getCount()).toBe(3);
+    expect(getLabels()[0].getCanvasBBox().minX).toBe(40);
+    expect(getLabels()[0].getCanvasBBox().minY).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().minX).toBe(-5);
+    expect(getLabels()[1].getCanvasBBox().minY).toBe(50);
+    expect(getLabels()[2].getCanvasBBox().minX).toBe(-6);
+    expect(getLabels()[2].getCanvasBBox().minY).toBe(50);
+  });
+
+  it('multiple direction', () => {
+    addLabel(coord, -5, -5, 'label1'); // top-left
+    addLabel(coord, 50, 40, 'label2');
+    addLabel(coord, 150, 100, 'label3'); // bottom-right
+    limitInPlot([], getLabels(), [], region);
+
+    expect(getCount()).toBe(3);
+    expect(getLabels()[0].getCanvasBBox().minX).toBe(0);
+    expect(getLabels()[0].getCanvasBBox().minY).toBe(0);
+    expect(getLabels()[1].getCanvasBBox().minX).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().minY).toBe(40);
+    expect(getLabels()[2].getCanvasBBox().maxX).toBe(150);
+    expect(getLabels()[2].getCanvasBBox().maxY).toBe(100);
+  });
+
+  it('multiple direction', () => {
+    addLabel(coord, 155, -5, 'label1'); // right-top
+    addLabel(coord, 50, 40, 'label2');
+    addLabel(coord, -5, 105, 'label3'); // left-bottom
+    limitInPlot([], getLabels(), [], region);
+
+    expect(getCount()).toBe(3);
+    expect(getLabels()[0].getCanvasBBox().maxX).toBe(150);
+    expect(getLabels()[0].getCanvasBBox().minY).toBe(0);
+    expect(getLabels()[1].getCanvasBBox().minX).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().minY).toBe(40);
+    expect(getLabels()[2].getCanvasBBox().minX).toBe(0);
+    expect(getLabels()[2].getCanvasBBox().maxY).toBe(100);
+  });
+
+  it('multiple direction, action = hide', () => {
+    addLabel(coord, -5, -5, 'label1'); // top-left
+    addLabel(coord, 50, 40, 'label2');
+    addLabel(coord, 150, 100, 'label3'); // bottom-right
+    limitInPlot([], getLabels(), [], region, { action: 'hide' });
+
+    expect(getCount()).toBe(1);
+    expect(getLabels()[0].getCanvasBBox().minX).toBe(-5);
+    expect(getLabels()[0].getCanvasBBox().minY).toBe(-5);
+    expect(getLabels()[0].get('visible')).toBeFalsy();
+    expect(getLabels()[1].getCanvasBBox().minX).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().minY).toBe(40);
+    expect(getLabels()[1].get('visible')).toBeTruthy();
+    expect(getLabels()[2].getCanvasBBox().minX).toBe(150);
+    expect(getLabels()[2].getCanvasBBox().minY).toBe(100);
+    expect(getLabels()[2].get('visible')).toBeFalsy();
+  });
+
+  it('multiple direction, action = hide', () => {
+    addLabel(coord, 155, -5, 'label1'); // right-top
+    addLabel(coord, 50, 40, 'label2');
+    addLabel(coord, -5, 105, 'label3'); // left-bottom
+    limitInPlot([], getLabels(), [], region, { action: 'hide' });
+
+    expect(getCount()).toBe(1);
+    expect(getLabels()[0].getCanvasBBox().minX).toBe(155);
+    expect(getLabels()[0].getCanvasBBox().minY).toBe(-5);
+    expect(getLabels()[0].get('visible')).toBeFalsy();
+    expect(getLabels()[1].getCanvasBBox().minX).toBe(50);
+    expect(getLabels()[1].getCanvasBBox().minY).toBe(40);
+    expect(getLabels()[1].get('visible')).toBeTruthy();
+    expect(getLabels()[2].getCanvasBBox().minX).toBe(-5);
+    expect(getLabels()[2].getCanvasBBox().minY).toBe(105);
+    expect(getLabels()[2].get('visible')).toBeFalsy();
+  });
+
+  afterAll(() => {
+    canvas.destroy();
+    removeDom(div);
+  });
+});

--- a/tests/unit/util/coordinate-spec.ts
+++ b/tests/unit/util/coordinate-spec.ts
@@ -1,5 +1,11 @@
 import { getCoordinate } from '@antv/coord';
-import { getAngleByPoint, getDistanceToCenter, getXDimensionLength, isFullCircle } from '../../../src/util/coordinate';
+import {
+  getAngleByPoint,
+  getDistanceToCenter,
+  getXDimensionLength,
+  isFullCircle,
+  getCoordinateBBox,
+} from '../../../src/util/coordinate';
 
 const Polar = getCoordinate('polar');
 const Cartesian = getCoordinate('rect');
@@ -93,5 +99,43 @@ describe('CoordinateUtil', () => {
         y: 100,
       })
     ).toBe(Math.PI);
+  });
+
+  it('getCoordinateBBox()', () => {
+    expect(getCoordinateBBox(cartesian).minX).toBe(0);
+    expect(getCoordinateBBox(cartesian).maxX).toBe(30);
+    expect(getCoordinateBBox(cartesian).minY).toBe(0);
+    expect(getCoordinateBBox(cartesian).maxY).toBe(40);
+
+    const coord = new Cartesian({
+      start: { x: 10, y: 20 },
+      end: { x: 200, y: 300 },
+    });
+    expect(getCoordinateBBox(coord).minX).toBe(10);
+    expect(getCoordinateBBox(coord).maxX).toBe(200);
+    expect(getCoordinateBBox(coord).minY).toBe(20);
+    expect(getCoordinateBBox(coord).maxY).toBe(300);
+    expect(getCoordinateBBox(coord, 5).minX).toBe(5);
+    expect(getCoordinateBBox(coord, 5).maxX).toBe(205);
+    expect(getCoordinateBBox(coord, 5).minY).toBe(15);
+    expect(getCoordinateBBox(coord, 5).maxY).toBe(305);
+
+    expect(getCoordinateBBox(polar).minX).toBe(0);
+    expect(getCoordinateBBox(polar).maxX).toBe(200);
+    expect(getCoordinateBBox(polar).minY).toBe(0);
+    expect(getCoordinateBBox(polar).maxY).toBe(200);
+    expect(getCoordinateBBox(polar, 5).minX).toBe(-5);
+    expect(getCoordinateBBox(polar, 5).maxX).toBe(205);
+    expect(getCoordinateBBox(polar, 5).minY).toBe(-5);
+    expect(getCoordinateBBox(polar, 5).maxY).toBe(205);
+
+    expect(getCoordinateBBox(theta).minX).toBe(0);
+    expect(getCoordinateBBox(theta).maxX).toBe(30);
+    expect(getCoordinateBBox(theta).minY).toBe(0);
+    expect(getCoordinateBBox(theta).maxY).toBe(40);
+    expect(getCoordinateBBox(theta, 5).minX).toBe(-5);
+    expect(getCoordinateBBox(theta, 5).maxX).toBe(35);
+    expect(getCoordinateBBox(theta, 5).minY).toBe(-5);
+    expect(getCoordinateBBox(theta, 5).maxY).toBe(45);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

limitInPlot 用来解决 label 和 坐标轴之类的组件出现的重叠遮挡问题：

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1142242/100705827-dd199980-33e2-11eb-8e1f-c922ddcaec6d.png) | ![image](https://user-images.githubusercontent.com/1142242/100705979-1d791780-33e3-11eb-95c9-fd9e64f99906.png) |

配置方式：

```js
view1.line().position('Year*Deaths').label('Deaths', {
      layout: [
        { type: 'limit-in-plot' },
        { type: 'path-adjust-position' },
        { type: 'limit-in-plot', cfg: { action: 'hide' } }
      ]
    });
```