### PR TITLE
fix auto hide legend padding

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1380,9 +1380,9 @@ export interface AxisCfg {
    *   rotate?: number;
    *   // 格式化函数
    *   formatter?: (text: string, item: ListItem, index: number) => any;
-   *   // 是否自动旋转，默认 true
+   *   // 是否自动旋转，默认 false
    *   autoRotate?: boolean | (isVertical: boolean, labelGroup: IGroup, limitLength?: number) => boolean; | string;
-   *   // 是否自动隐藏，默认 false
+   *   // 是否自动隐藏，默认 true
    *   autoHide?: boolean | (isVertical: boolean, labelGroup: IGroup, limitLength?: number) => boolean; | string;
    *   // 是否自动省略，默认 false
    *   autoEllipsis?: boolean | (isVertical: boolean, labelGroup: IGroup, limitLength?: number) => boolean; | string;
@@ -1841,6 +1841,10 @@ export interface StyleSheet {
   legendItemMarginBottom?: number;
   /** 图例与图表绘图区域的偏移距离  */
   legendPadding?: number[];
+  /** 水平布局的图例与绘图区域偏移距离 */
+  legendHorizontalPadding?: number[];
+  /** 垂直布局的图例与绘图区域偏移距离 */
+  legendVerticalPadding?: number[];
 
   /** 连续图例滑块填充色 */
   sliderRailFillColor?: string;

--- a/src/theme/style-sheet/dark.ts
+++ b/src/theme/style-sheet/dark.ts
@@ -178,6 +178,12 @@ export const createDarkStyleSheet = (cfg: StyleSheetCfg = {}) => {
     legendItemMarginBottom: 12,
     /** 图例与图表绘图区域的便宜距离  */
     legendSpacing: 16,
+    /** 图例与图表绘图区域的偏移距离  */
+    legendPadding: [8, 8, 8, 8],
+    /** 水平布局的图例与绘图区域偏移距离 */
+    legendHorizontalPadding: [8, 0, 8, 0],
+    /** 垂直布局的图例与绘图区域偏移距离 */
+    legendVerticalPadding: [0, 8, 0, 8],
 
     /** 连续图例滑块填充色 */
     sliderRailFillColor: BLACK_COLORS[15],

--- a/src/theme/style-sheet/light.ts
+++ b/src/theme/style-sheet/light.ts
@@ -178,6 +178,10 @@ export const createLightStyleSheet = (cfg: StyleSheetCfg = {}) => {
     legendItemMarginBottom: 12,
     /** 图例与图表绘图区域的偏移距离  */
     legendPadding: [8, 8, 8, 8],
+    /** 水平布局的图例与绘图区域偏移距离 */
+    legendHorizontalPadding: [8, 0, 8, 0],
+    /** 垂直布局的图例与绘图区域偏移距离 */
+    legendVerticalPadding: [0, 8, 0, 8],
 
     /** 连续图例滑块填充色 */
     sliderRailFillColor: BLACK_COLORS[15],

--- a/src/theme/util/create-by-style-sheet.ts
+++ b/src/theme/util/create-by-style-sheet.ts
@@ -24,9 +24,9 @@ function createAxisStyles(styleSheet: StyleSheet): LooseObject {
       },
     },
     label: {
-      autoRotate: true,
-      autoEllipsis: true,
-      autoHide: true,
+      autoRotate: false,
+      autoEllipsis: false,
+      autoHide: { type: 'equidistance', cfg: { minGap: 6 } },
       offset: styleSheet.axisLabelOffset,
       style: {
         fill: styleSheet.axisLabelFillColor,
@@ -1012,15 +1012,19 @@ export function createThemeByStyleSheet(styleSheet: StyleSheet): LooseObject {
         common: legendStyles,
         right: deepMix({}, legendStyles, {
           layout: 'vertical',
+          padding: styleSheet.legendVerticalPadding,
         }),
         left: deepMix({}, legendStyles, {
           layout: 'vertical',
+          padding: styleSheet.legendVerticalPadding,
         }),
         top: deepMix({}, legendStyles, {
           layout: 'horizontal',
+          padding: styleSheet.legendHorizontalPadding,
         }),
         bottom: deepMix({}, legendStyles, {
           layout: 'horizontal',
+          padding: styleSheet.legendHorizontalPadding,
         }),
         continuous: {
           title: null,

--- a/tests/unit/chart/controller/axis-spec.ts
+++ b/tests/unit/chart/controller/axis-spec.ts
@@ -125,6 +125,66 @@ describe('Axis', () => {
     expect(y.component.get('animate')).toBe(false);
   });
 
+  it('axis theme default', () => {
+    chart = new Chart({
+      container: div,
+      height: 500,
+      width: 600,
+      autoFit: false,
+      padding: 'auto',
+    });
+    const data = new Array(100).fill(0).map((v, idx) => ({
+      x: `2020-12-${idx}`,
+      y: Math.random() * 100,
+    }));
+    chart.data(data);
+    chart.animate(false);
+    chart.line().position('x*y');
+    chart.render();
+    chart.render(true);
+
+    const axes = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.AXIS);
+    const [x, y] = axes;
+    let xAxis;
+
+    axes.forEach((axis) => {
+      expect(axis.component.cfg.label.autoHide).toEqual({
+        type: 'equidistance',
+        cfg: {
+          minGap: 6,
+        },
+      });
+    });
+
+    chart.axis('x', {
+      label: {
+        autoHide: {
+          type: 'equidistance',
+          cfg: {
+            minGap: 12,
+          },
+        },
+      },
+    });
+    chart.render();
+    xAxis = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.AXIS)[0];
+    expect(xAxis.component.cfg.label.autoHide).toEqual({
+      type: 'equidistance',
+      cfg: {
+        minGap: 12,
+      },
+    });
+
+    chart.axis('x', {
+      label: {
+        autoHide: false,
+      },
+    });
+    chart.render();
+    xAxis = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.AXIS)[0];
+    expect(xAxis.component.cfg.label.autoHide).toBe(false);
+  });
+
   afterEach(() => {
     chart.destroy();
   });

--- a/tests/unit/chart/controller/legend-padding-spec.ts
+++ b/tests/unit/chart/controller/legend-padding-spec.ts
@@ -28,10 +28,34 @@ describe('Legend', () => {
     chart.interval().position('月份*月均降雨量').color('name').adjust('dodge');
     chart.render();
 
-    const legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
+    let legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
 
-    expect(legends[0].component.get('padding')).toEqual([8, 8, 8, 8]); // 主题默认 8
+    expect(legends[0].component.get('padding')).toEqual([0, 8, 0, 8]); // 主题垂直默认 8
     expect(legends[0].component.getBBox().maxX).toBeLessThan(600 - 7);
+
+    chart.legend('name', {
+      position: 'left',
+    });
+    chart.render();
+
+    legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
+    expect(legends[0].component.get('padding')).toEqual([0, 8, 0, 8]); // 主题垂直默认 8
+
+    chart.legend('name', {
+      position: 'top',
+    });
+    chart.render();
+
+    legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
+    expect(legends[0].component.get('padding')).toEqual([8, 0, 8, 0]); // 主题水平默认 8
+
+    chart.legend('name', {
+      position: 'bottom',
+    });
+    chart.render();
+
+    legends = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.LEGEND);
+    expect(legends[0].component.get('padding')).toEqual([8, 0, 8, 0]); // 主题水平默认 8
   });
 
   it('update padding', () => {

--- a/tests/unit/chart/controller/legend-spec.ts
+++ b/tests/unit/chart/controller/legend-spec.ts
@@ -246,7 +246,7 @@ describe('Legend', () => {
 
     const legend = chart.getController('legend').getComponents()[0].component;
     const legendBBox = legend.getBBox();
-    expect(legendBBox.x).toBe(8);
+    expect(legendBBox.x).toBe(0);
   });
 
   it('legend padding', () => {
@@ -261,7 +261,7 @@ describe('Legend', () => {
           legend: {
             top: {
               padding: [20, 0, 0, 20],
-            }
+            },
           },
         },
       },

--- a/tests/unit/interaction/action/ellipsis-text-spec.ts
+++ b/tests/unit/interaction/action/ellipsis-text-spec.ts
@@ -19,6 +19,13 @@ describe('test component tooltip', () => {
   ]);
   chart.animate(false);
   chart.interval().position('year*value').color('year');
+  chart.axis('year', {
+    label: {
+      autoRotate: true,
+      autoEllipsis: true,
+      autoHide: true,
+    },
+  });
   chart.render();
 
   const interaction = createInteraction('ellipsis-text', chart);
@@ -61,6 +68,6 @@ describe('test component tooltip', () => {
   });
 
   afterAll(() => {
-    chart.destroy();
+    // chart.destroy();
   });
 });

--- a/tests/unit/theme/create-theme-spec.ts
+++ b/tests/unit/theme/create-theme-spec.ts
@@ -49,4 +49,13 @@ describe('createTheme', () => {
     expect(theme.labels.style.fontFamily).toBe('roboto-regular');
     expect(theme.innerLabels.style.fontFamily).toBe('roboto-regular');
   });
+
+  it('styleSheet legendPadding', () => {
+    let theme = createTheme({});
+    expect(theme.components.legend.top.padding).toEqual([8, 0, 8, 0]);
+    expect(theme.components.legend.bottom.padding).toEqual([8, 0, 8, 0]);
+    expect(theme.components.legend.left.padding).toEqual([0, 8, 0, 8]);
+    expect(theme.components.legend.right.padding).toEqual([0, 8, 0, 8]);
+    expect(theme.components.legend.continuous.padding).toEqual([8, 8, 8, 8]);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

1. 调整坐标轴标签默认的 autoHide 配置，默认开启 autoHide，并设置最小间距 6px

| before | after|
|--- | --- |
| ![image](https://user-images.githubusercontent.com/1142242/100538364-517cfd00-326a-11eb-9a09-1ba080ad86a9.png)| ![image](https://user-images.githubusercontent.com/1142242/100538359-3f02c380-326a-11eb-953a-dcd451a7af6f.png)| 

2. 调整图例的默认 padding，使得图例和图形对齐
	- 可通过主题分别对水平布局的图例和垂直布局的图例分别配置 padding
	- 默认的 light/dark 主题设置合适的 padding

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1142242/101777075-e7e3d500-3b2c-11eb-843c-5d67a65b3066.png) | ![image](https://user-images.githubusercontent.com/1142242/101777282-35604200-3b2d-11eb-84c9-7dd476f8ea1a.png) |





