### PR TITLE
feat: 增强饼图标签跟随切片颜色

### DIFF
--- a/src/component/labels.ts
+++ b/src/component/labels.ts
@@ -188,6 +188,7 @@ export default class Labels {
           textBaseline: get(cfg, 'textBaseline', 'middle'),
           text: cfg.content,
           ...cfg.style,
+          fill: (!get(cfg, ['style', 'fill']) && cfg.color) || get(cfg, ['style', 'fill'], '#595959'),
         },
         ...shapeAppendCfg,
       });

--- a/src/component/labels.ts
+++ b/src/component/labels.ts
@@ -188,7 +188,7 @@ export default class Labels {
           textBaseline: get(cfg, 'textBaseline', 'middle'),
           text: cfg.content,
           ...cfg.style,
-          fill: (!get(cfg, ['style', 'fill']) && cfg.color) || get(cfg, ['style', 'fill'], '#595959'),
+          fill: get(cfg, ['style', 'fill'], cfg.color),
         },
         ...shapeAppendCfg,
       });

--- a/src/component/labels.ts
+++ b/src/component/labels.ts
@@ -1,4 +1,4 @@
-import { deepMix, each, get, isArray } from '@antv/util';
+import { deepMix, each, get, isArray, isNull } from '@antv/util';
 import { BBox, Coordinate, IGroup, IShape } from '../dependents';
 import { LabelItem } from '../geometry/label/interface';
 import { AnimateOption, GeometryLabelLayoutCfg } from '../interface';
@@ -180,6 +180,7 @@ export default class Labels {
       labelShape = content;
       labelGroup.add(content);
     } else {
+      const fill = get(cfg, ['style', 'fill']);
       labelShape = labelGroup.addShape('text', {
         attrs: {
           x: cfg.x,
@@ -188,7 +189,7 @@ export default class Labels {
           textBaseline: get(cfg, 'textBaseline', 'middle'),
           text: cfg.content,
           ...cfg.style,
-          fill: get(cfg, ['style', 'fill'], cfg.color),
+          fill: isNull(fill) ? cfg.color : fill,
         },
         ...shapeAppendCfg,
       });

--- a/src/geometry/label/pie.ts
+++ b/src/geometry/label/pie.ts
@@ -1,8 +1,8 @@
 import { deepMix, get, isArray } from '@antv/util';
-import { getAngleByPoint } from '../../../util/coordinate';
-import { polarToCartesian } from '../../../util/graphics';
-import { LabelItem } from '../interface';
-import PolarLabel from '../polar';
+import { getAngleByPoint } from '../../util/coordinate';
+import { polarToCartesian } from '../../util/graphics';
+import { LabelItem } from './interface';
+import PolarLabel from './polar';
 
 /**
  * 饼图 label

--- a/tests/bugs/3146-spec.ts
+++ b/tests/bugs/3146-spec.ts
@@ -1,0 +1,82 @@
+// 欢迎使用全新的 G2 4.0
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+
+describe('#3146', () => {
+  const chart = new Chart({
+    container: createDiv(),
+    width: 500,
+    height: 500,
+  });
+
+  chart.data([
+    { type: '分类一', value: 10 },
+    { type: '分类二', value: 10 },
+    { type: '分类三', value: 10 },
+  ]);
+
+  function render(labelCfg = {}) {
+    chart.clear();
+    chart.coordinate('theta');
+    chart.interval().position('1*value').color('type').adjust('stack').label('type', labelCfg);
+    chart.render();
+  }
+
+  it('pie label,style.fill 为 undefined 时，跟随旧逻辑，取默认色', () => {
+    render();
+    let labels = chart.geometries[0].labelsContainer.getChildren();
+    expect((labels[0] as any).getChildByIndex(0).attr('fill')).toBe('#595959');
+
+    render({ style: { fill: undefined } });
+    labels = chart.geometries[0].labelsContainer.getChildren();
+    expect((labels[0] as any).getChildByIndex(0).attr('fill')).toBe('#595959');
+
+    render({ style: { fill: 'red' } });
+    labels = chart.geometries[0].labelsContainer.getChildren();
+    expect((labels[0] as any).getChildByIndex(0).attr('fill')).toBe('red');
+  });
+
+  it('当 pie.label.style.fill 设置为 null 时，映射为对应块的颜色', () => {
+    const theme = chart.getTheme();
+    render({ style: { fill: null } });
+    let labels = chart.geometries[0].labelsContainer.getChildren();
+    expect((labels[0] as any).getChildByIndex(0).attr('fill')).toBe(theme.colors10[0]);
+
+    render((type) => ({
+      style: { fill: type === '分类一' ? 'blue' : type === '分类二' ? undefined : null },
+    }));
+    labels = chart.geometries[0].labelsContainer.getChildren();
+    expect((labels[0] as any).getChildByIndex(0).attr('fill')).toBe('blue');
+    expect((labels[1] as any).getChildByIndex(0).attr('fill')).toBe('#595959');
+    expect((labels[2] as any).getChildByIndex(0).attr('fill')).toBe(theme.colors10[2]);
+  });
+
+  it('修改主题色, 优先级 pieLabels > labels', () => {
+    chart.theme({
+      labels: {
+        style: {
+          fill: 'red',
+        },
+      },
+    });
+    render();
+    let labels = chart.geometries[0].labelsContainer.getChildren();
+    expect((labels[0] as any).getChildByIndex(0).attr('fill')).toBe('red');
+
+    chart.theme({
+      labels: {
+        style: {
+          fill: 'red',
+        },
+      },
+      pieLabels: {
+        style: {
+          fill: 'green',
+        },
+      },
+    });
+    render();
+    labels = chart.geometries[0].labelsContainer.getChildren();
+    expect((labels[0] as any).getChildByIndex(0).attr('fill')).toBe('green');
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

**背景** label 标签色跟随了 theme 设置，存在一个默认色。在 deepMix 下，undefined 会取默认色，null 则会导致标签渲染不出，因此可以在 `fill` 为 `null` 或空字符串的时候，处理为跟随切片颜色，若用户的确不想渲染 label，可以取 `fillOpactity` 为 0，或`label: false`

- fill 为 undefined 时，跟随旧逻辑，取默认色
- fill 设置为 null 时，映射为对应块的颜色

close: #3146 