### PR TITLE
fix: correct label position for histogram

### DIFF
--- a/tests/bugs/g2plot-2081-spec.ts
+++ b/tests/bugs/g2plot-2081-spec.ts
@@ -1,0 +1,98 @@
+import DataSet from '@antv/data-set';
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+
+const data = [
+  { value: 1.2 },
+  { value: 3.4 },
+  { value: 3.7 },
+  { value: 4.3 },
+  { value: 5.2 },
+  { value: 5.8 },
+  { value: 6.1 },
+  { value: 6.5 },
+  { value: 6.8 },
+  { value: 7.1 },
+  { value: 7.3 },
+  { value: 7.7 },
+  { value: 8.3 },
+  { value: 8.6 },
+  { value: 8.8 },
+  { value: 9.1 },
+  { value: 9.2 },
+  { value: 9.4 },
+  { value: 9.5 },
+  { value: 9.7 },
+  { value: 10.5 },
+  { value: 10.7 },
+  { value: 10.8 },
+  { value: 11.0 },
+  { value: 11.0 },
+  { value: 11.1 },
+  { value: 11.2 },
+  { value: 11.3 },
+  { value: 11.4 },
+  { value: 11.4 },
+  { value: 11.7 },
+  { value: 12.0 },
+  { value: 12.9 },
+  { value: 12.9 },
+  { value: 13.3 },
+  { value: 13.7 },
+  { value: 13.8 },
+  { value: 13.9 },
+  { value: 14.0 },
+  { value: 14.2 },
+  { value: 14.5 },
+  { value: 15 },
+  { value: 15.2 },
+  { value: 15.6 },
+  { value: 16.0 },
+  { value: 16.3 },
+  { value: 17.3 },
+  { value: 17.5 },
+  { value: 17.9 },
+  { value: 18.0 },
+  { value: 18.0 },
+  { value: 20.6 },
+  { value: 21 },
+  { value: 23.4 },
+];
+
+const ds = new DataSet();
+const dv = ds.createView().source(data);
+dv.transform({
+  type: 'bin.histogram',
+  field: 'value',
+  binWidth: 4,
+  as: ['value', 'count'],
+});
+
+describe('histogram label position', () => {
+  const chart = new Chart({
+    container: createDiv(),
+    width: 500,
+    height: 400,
+  });
+
+  chart.data(dv.rows);
+  chart.scale({
+    count: {
+      nice: true,
+    },
+  });
+  chart.interval().position('value*count').label('count');
+
+  chart.render();
+
+  it('label position', () => {
+    const elements = chart.geometries[0].elements;
+    expect(elements).toHaveLength(dv.rows.length);
+    elements.forEach((element) => {
+      const shape = element.shape;
+      const label = element.labelShape[0].getFirst();
+      const shapeBBox = shape.getCanvasBBox();
+      expect(label.attr('x')).toBe((shapeBBox.minX + shapeBBox.maxX) / 2);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

修复使用interval绘制直方图情况下的 Label 的位置：x 方向取平均值，而不是最后一个对应的 X
close https://github.com/antvis/G2Plot/issues/2081

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1142242/103011007-2be6c900-4574-11eb-93d5-6d19e1aebc5c.png) | ![image](https://user-images.githubusercontent.com/1142242/103011057-402ac600-4574-11eb-9139-db55e934476d.png) |


