### PR TITLE
fix(tooltip-tip): label tip max width 50%, and break word

### DIFF
--- a/src/interaction/action/component/tooltip/ellipsis-text.ts
+++ b/src/interaction/action/component/tooltip/ellipsis-text.ts
@@ -1,4 +1,5 @@
-import { isEqual, get } from '@antv/util';
+import { isEqual, get, deepMix } from '@antv/util';
+import { TOOLTIP_CSS_CONST } from '@antv/component';
 import { Point } from '../../../../interface';
 import Action from '../../base';
 import { HtmlTooltip } from '../../../../dependents';
@@ -86,7 +87,13 @@ export default class EllipsisText extends Action {
       region,
       visible: false,
       crosshairs: null,
-      domStyles: tooltipStyles,
+      domStyles: {
+        ...deepMix({}, tooltipStyles, {
+          // 超长的时候，tooltip tip 最大宽度为 50%，然后可以换行
+          [TOOLTIP_CSS_CONST.CONTAINER_CLASS]: { 'max-width': '50%' },
+          [TOOLTIP_CSS_CONST.TITLE_CLASS]: { 'word-break': 'break-all' },
+        }),
+      },
     });
     tooltip.init();
     tooltip.setCapture(false); // 不允许捕获事件

--- a/tests/bugs/tooltip-tip-max-width-spec.ts
+++ b/tests/bugs/tooltip-tip-max-width-spec.ts
@@ -1,0 +1,40 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+
+describe('tooltip ellipsis tip', () => {
+  it('max-width 50%', () => {
+    const Tokyo = 'TokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyoTokyo';
+    const London = 'LondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondonLondon';
+
+    const data = [
+      { month: 'Jan', city: Tokyo, temperature: 7 },
+      { month: 'Jan', city: London, temperature: 3.9 },
+      { month: 'Feb', city: Tokyo, temperature: 6.9 },
+      { month: 'Feb', city: London, temperature: 4.2 },
+    ];
+
+    const chart = new Chart({
+      container: createDiv(),
+      width: 600,
+      height: 300,
+      autoFit: true,
+    });
+
+    chart.data(data);
+    chart.line().position('month*temperature').color('city').shape('smooth').adjust('stack');
+    chart.render();
+
+    const label = chart.getController('legend').getComponents()[0].component.get('container').findById(`-legend-item-${Tokyo}-name`);
+
+    chart.emit('legend-item-name:mousemove', {
+      x: 0,
+      y: 0,
+      target: label,
+    });
+
+    // 超长 tooltip 自动换行
+    expect(document.querySelector('.g2-tooltip').getBoundingClientRect().height).toBeGreaterThan(36);
+
+    chart.destroy();
+  });
+});


### PR DESCRIPTION
- [x] 修复 tooltip tip 的样式超长问题。

![image](https://user-images.githubusercontent.com/7856674/103723685-90426780-500d-11eb-9d96-58b6ec1bc501.png)

1. tooltip  tip 最大宽度 50%
2. 超长自动换行