### PR TITLE
fix: 修复实心的 shape 设置空心的 marker，会导致marker.style设置不生效

### DIFF
--- a/docs/common/marker-cfg.md
+++ b/docs/common/marker-cfg.md
@@ -2,8 +2,8 @@
 
 | 参数名  | 类型                  | 默认值 | 描述                                                                     |
 | ------- | --------------------- | ------ | ------------------------------------------------------------------------ |
-| symbol  | *string \| function*  | -      | 配置图例 marker 的 symbol 形状，详见 [marker.symbol 配置](#markersymbol) |
-| style   | [ShapeAttrs](/zh/docs/api/shape/shape-attrs)   | -      | 图例项 marker 的配置项                                                   |
+| symbol  | _string \| function_  | -      | 配置图例 marker 的 symbol 形状，详见 [marker.symbol 配置](#markersymbol) |
+| style   | _ShapeAttrs \| ((style: ShapeAttrs) => ShapeAttrs)_  | -      | 图例项 marker 的配置项, 详见 [ShapeAttrs](/zh/docs/api/shape/shape-attrs)                                             |
 | spacing | number                | -      | 图例项 marker 同后面 name 的间距                                         |
 
 #### marker.symbol

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -877,6 +877,7 @@ export interface ComponentOption {
 export interface MarkerCfg extends LegendMarkerCfg {
   /** 配置图例 marker 的 symbol 形状。 */
   symbol?: Marker | MarkerCallback;
+  style?: ShapeAttrs | ((style: ShapeAttrs) => ShapeAttrs);
 }
 
 /** Legend item 各个图例项的数据结构 */
@@ -1207,7 +1208,7 @@ export type TooltipItem = {
   readonly color: string;
   /** tooltip item 中图标类型 */
   readonly marker: string;
-}
+};
 
 /** chart.tooltip() 接口配置属性 */
 export interface TooltipCfg {

--- a/src/util/legend.ts
+++ b/src/util/legend.ts
@@ -1,24 +1,51 @@
 import { LegendMarkerCfg } from '@antv/component';
-import { deepMix, isString, each } from '@antv/util';
+import { ShapeAttrs } from '@antv/g-svg';
+import { deepMix, isString, each, get, isFunction } from '@antv/util';
 import View from '../chart/view';
 import { DIRECTION } from '../constant';
 import { Attribute, Tick } from '../dependents';
 import Geometry from '../geometry/base';
-import { LegendItem } from '../interface';
+import { LegendItem, MarkerCfg } from '../interface';
 import { getMappingValue } from './attr';
+import { omit } from './helper';
 import { MarkerSymbols } from './marker';
 
 /** 线条形 marker symbol */
 const STROKES_SYMBOLS = ['line', 'cross', 'tick', 'plus', 'hyphen'];
 
+/**
+ * 处理用户配置的 marker style
+ * @param markerStyle
+ * @param userMarker.style
+ * @returns {ShapeAttrs} newStyle
+ */
+function handleUserMarkerStyle(markerStyle: ShapeAttrs, style: MarkerCfg['style']): ShapeAttrs {
+  if (isFunction(style)) {
+    return style(markerStyle);
+  }
+  return deepMix({}, markerStyle, style);
+}
+
+/**
+ * 根据 marker 是否为线条形 symbol, 来调整下样式
+ * @param symbol
+ * @param style
+ * @param color
+ */
 function adpatorMarkerStyle(marker: LegendMarkerCfg, color: string) {
   const symbol = marker.symbol;
   if (isString(symbol) && STROKES_SYMBOLS.indexOf(symbol) !== -1) {
-    marker.style = deepMix({}, marker.style, { lineWidth: 1, stroke: color, fill: null });
+    const lineWidth = get(marker.style, 'lineWidth', 1);
+    const stroke = get(marker.style, 'stroke', color);
+    return deepMix({}, marker.style, { lineWidth, stroke, fill: null });
   }
 }
 
-function setMarkerSymbol(marker) {
+/**
+ * 设置 marker 的 symbol，将 字符串的 symbol 转换为真正的绘制命令
+ * @param marker
+ */
+function setMarkerSymbol(marker: LegendMarkerCfg): void {
   const symbol = marker.symbol;
   if (isString(symbol) && MarkerSymbols[symbol]) {
     marker.symbol = MarkerSymbols[symbol];
@@ -34,6 +61,11 @@ function setMarkerSymbol(marker) {
 export function getLegendLayout(direction: DIRECTION): 'vertical' | 'horizontal' {
   return direction.startsWith(DIRECTION.LEFT) || direction.startsWith(DIRECTION.RIGHT) ? 'vertical' : 'horizontal';
 }
+
+/** item of @antv/component legend  */
+type ComponentLegendItem = Omit<LegendItem, 'marker'> & {
+  marker: any;
+};
 
 /**
  * @ignore
@@ -51,7 +83,7 @@ export function getLegendItems(
   attr: Attribute,
   themeMarker: object,
   userMarker
-): any[] {
+): ComponentLegendItem[] {
   const scale = attr.getScale(attr.type);
   if (scale.isCategory) {
     const field = scale.field;
@@ -81,9 +113,12 @@ export function getLegendItems(
         isInPolar,
       });
       // the marker configure order should be ensure
-      marker = deepMix({}, themeMarker, marker, userMarker);
-
+      marker = deepMix({}, themeMarker, marker, omit({ ...userMarker }, ['style']));
       adpatorMarkerStyle(marker, color);
+      if (userMarker && userMarker.style) {
+        // handle user's style settings
+        marker.style = handleUserMarkerStyle(marker.style, userMarker.style);
+      }
       setMarkerSymbol(marker);
 
       return { id: value, name, value, marker, unchecked };
@@ -93,6 +128,7 @@ export function getLegendItems(
 }
 
 /**
+ *
  * @ignore
  * custom legend 的 items 获取
  * @param themeMarker

--- a/src/util/legend.ts
+++ b/src/util/legend.ts
@@ -1,9 +1,8 @@
 import { LegendMarkerCfg } from '@antv/component';
-import { ShapeAttrs } from '@antv/g-svg';
 import { deepMix, isString, each, get, isFunction } from '@antv/util';
 import View from '../chart/view';
 import { DIRECTION } from '../constant';
-import { Attribute, Tick } from '../dependents';
+import { Attribute, ShapeAttrs, Tick } from '../dependents';
 import Geometry from '../geometry/base';
 import { LegendItem, MarkerCfg } from '../interface';
 import { getMappingValue } from './attr';

--- a/src/util/legend.ts
+++ b/src/util/legend.ts
@@ -32,12 +32,13 @@ function handleUserMarkerStyle(markerStyle: ShapeAttrs, style: MarkerCfg['style'
  * @param style
  * @param color
  */
-function adpatorMarkerStyle(marker: LegendMarkerCfg, color: string) {
+function adpatorMarkerStyle(marker: LegendMarkerCfg, color: string): void {
   const symbol = marker.symbol;
   if (isString(symbol) && STROKES_SYMBOLS.indexOf(symbol) !== -1) {
-    const lineWidth = get(marker.style, 'lineWidth', 1);
-    const stroke = get(marker.style, 'stroke', color);
-    return deepMix({}, marker.style, { lineWidth, stroke, fill: null });
+    const markerStyle = get(marker, 'style', {});
+    const lineWidth = get(markerStyle, 'lineWidth', 1);
+    const stroke = markerStyle.stroke || markerStyle.fill || color;
+    marker.style = deepMix({}, marker.style, { lineWidth, stroke, fill: null });
   }
 }
 

--- a/tests/unit/util/legend-spec.ts
+++ b/tests/unit/util/legend-spec.ts
@@ -1,6 +1,8 @@
-import { DIRECTION } from '../../../src';
+import { deepMix } from '@antv/util';
+import { Chart, DIRECTION } from '../../../src';
 import { LegendItem } from '../../../src/interface';
-import { getCustomLegendItems, getLegendLayout } from '../../../src/util/legend';
+import { getCustomLegendItems, getLegendItems, getLegendLayout } from '../../../src/util/legend';
+import { createDiv } from '../../util/dom';
 
 describe('util legend', () => {
   it('getLegendLayout', () => {
@@ -38,5 +40,79 @@ describe('util legend', () => {
       { name: 'a', value: 'aa', marker: { symbol: 'circle', spacing: 8, style: { fill: 'green', r: 5 } } },
       { name: 'b', value: 'bb', marker: { symbol: 'square', spacing: 8, style: { fill: 'red', r: 6 } } },
     ]);
+  });
+
+  it('getLegendItems, userMarker style works', () => {
+    const chart = new Chart({
+      container: createDiv(),
+    });
+    chart.data([
+      { city: '杭州', value: 10 },
+      { city: '广州', value: 10 },
+    ]);
+    chart.interval().position('city*value').color('city');
+    chart.render();
+
+    const geometry = chart.geometries[0];
+    const attr = geometry.getGroupAttributes()[0];
+    let items = getLegendItems(chart, geometry, attr, {}, {});
+    expect(items.length).toBe(2);
+    expect(items[0].marker.style.fill).toBe(chart.getTheme().colors10[0]);
+
+    chart.render();
+    items = getLegendItems(
+      chart,
+      geometry,
+      attr,
+      {},
+      {
+        symbol: 'hyphen',
+        style: {
+          lineWidth: 2,
+          stroke: 'red',
+        },
+      }
+    );
+    expect(items[0].marker.style.stroke).toBe('red');
+    expect(items[0].marker.style.lineWidth).toBe(2);
+  });
+
+  it('getLegendItems, callback to set color', () => {
+    const chart = new Chart({
+      container: createDiv(),
+    });
+    chart.data([
+      { city: '杭州', value: 10 },
+      { city: '广州', value: 10 },
+    ]);
+    chart.interval().position('city*value').color('city');
+    chart.render();
+
+    const geometry = chart.geometries[0];
+    const attr = geometry.getGroupAttributes()[0];
+    let items = getLegendItems(chart, geometry, attr, {}, {});
+    expect(items.length).toBe(2);
+    expect(items[0].marker.style.fill).toBe(chart.getTheme().colors10[0]);
+
+    chart.render();
+    items = getLegendItems(
+      chart,
+      geometry,
+      attr,
+      {
+        style: {
+          lineWidth: 4,
+        },
+      },
+      {
+        symbol: 'hyphen',
+        style: (s) =>
+          deepMix({}, s, {
+            stroke: 'red',
+          }),
+      }
+    );
+    expect(items[0].marker.style.stroke).toBe('red');
+    expect(items[0].marker.style.lineWidth).toBe(4);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
| **config** | **4.1.9** |**4.1.10** |
| --- | --- | --- |
| `chart.legend({ marker: { symbol: 'hyphen',  style: { lineWidth: 2, stroke: 'red'  } } })` | ![image](https://user-images.githubusercontent.com/15646325/106421546-de754a00-6497-11eb-9797-9583936ce323.png)| ![image](https://user-images.githubusercontent.com/15646325/106422729-0e255180-649a-11eb-810c-9310742a5c32.png) |
| **旧写法：** `chart.legend({ marker: { symbol: 'square', style: { stroke: '#ddd', fill: null } }})`  **新写法：** `chart.legend({ marker: { symbol: 'square', style:  ({ fill, ...args }) => ({ ...args, lineWidth: 1, stroke: fill, fill: null }) }})`  |  ![image](https://user-images.githubusercontent.com/15646325/106422986-84c24f00-649a-11eb-836b-669f2dcc89ce.png) interval 设置空心的图例 marker，描边色无法对应 | ![image](https://user-images.githubusercontent.com/15646325/106423139-ce129e80-649a-11eb-9123-bb04118cab2c.png)  通过回调的方式设置 |
