### PR TITLE
feat(active-region): 支持配置底色样式，全局统一注册一个 配置样式

### DIFF
--- a/src/chart/view.ts
+++ b/src/chart/view.ts
@@ -738,7 +738,7 @@ export class View extends Base {
    * ```ts
    * view.interaction('my-interaction', { extra: 'hello world' });
    * ```
-   * 详细文档可以参考：https://g2.antv.vision/zh/docs/manual/tutorial/interaction
+   * 详细文档可以参考：https://g2.antv.vision/zh/docs/api/general/interaction
    * @param name interaction name
    * @param cfg interaction config
    * @returns

--- a/src/interaction/action/active-region.ts
+++ b/src/interaction/action/active-region.ts
@@ -1,9 +1,14 @@
-import { each, head, isEqual, last } from '@antv/util';
-import { IShape } from '../../dependents';
+import { each, head, isEqual, last, get } from '@antv/util';
+import { IShape, ShapeAttrs } from '../../dependents';
 import Element from '../../geometry/element/';
 import { LooseObject } from '../../interface';
 import { getAngle, getSectorPath } from '../../util/graphics';
 import Action from './base';
+
+const DEFAULT_REGION_PATH_STYLE = {
+  fill: '#CCD6EC',
+  opacity: 0.3,
+};
 
 /**
  * 背景框的 Action
@@ -14,8 +19,9 @@ class ActiveRegion extends Action {
   private regionPath: IShape;
   /**
    * 显示
+   * @param {ShapeAttrs} style region-path 的样式
    */
-  public show() {
+  public show(args?: { style: ShapeAttrs }) {
     const view = this.context.view;
     const ev = this.context.event;
     const tooltipItems = view.getTooltipItems({
@@ -119,14 +125,14 @@ class ActiveRegion extends Action {
           this.regionPath.attr('path', path);
           this.regionPath.show();
         } else {
+          const style = get(args, 'style', DEFAULT_REGION_PATH_STYLE);
           this.regionPath = backgroundGroup.addShape({
             type: 'path',
             name: 'active-region',
             capture: false,
             attrs: {
+              ...style,
               path,
-              fill: '#CCD6EC',
-              opacity: 0.3,
             },
           });
         }

--- a/tests/unit/interaction/action/active-region-spec.ts
+++ b/tests/unit/interaction/action/active-region-spec.ts
@@ -74,10 +74,10 @@ describe('test active region', () => {
     expect(regionShape.attr('fill')).toBe('#CCD6EC');
     chart.emit('plot:mouseleave', {});
 
-    // 覆盖注册, 且需要 chart 重新绑定交互
+    // 方式1: 覆盖注册, 且需要 chart 重新绑定交互
     registerInteraction('active-region', {
       start: [
-        { trigger: 'plot:mousemove', action: 'active-region:show', arg: { style: { fill: 'rgba(255,0,0,0.25' } } },
+        { trigger: 'plot:mousemove', action: 'active-region:show', arg: { style: { fill: 'rgba(255,0,0,0.25)' } } },
       ],
       end: [{ trigger: 'plot:mouseleave', action: 'active-region:hide' }],
     });
@@ -87,9 +87,43 @@ describe('test active region', () => {
       return el.get('name') === 'active-region';
     })[0];
     expect(regionShape2.get('visible')).toBe(true);
-    expect(regionShape2.attr('fill')).toBe('rgba(255,0,0,0.25');
+    expect(regionShape2.attr('fill')).toBe('rgba(255,0,0,0.25)');
     chart.emit('plot:mouseleave', {});
     expect(regionShape2.get('visible')).toBe(false);
+
+    chart.removeInteraction('active-region');
+    // multiple actions with args
+    registerInteraction('custom', {
+      start: [{ trigger: 'plot:mousemove', action: ['tooltip:show', 'active-region:show'] }],
+      end: [{ trigger: 'plot:mouseleave', action: 'active-region:hide' }],
+    });
+
+    chart.interaction('custom', {
+      start: [
+        {
+          trigger: 'plot:mousemove',
+          action: ['tooltip:show', 'active-region:show'],
+          arg: [null, { style: { fill: 'blue' } }],
+        },
+      ],
+    });
+    chart.emit('plot:mousemove', point);
+    const regionShape3 = chart.backgroundGroup.findAll((el) => {
+      return el.get('name') === 'active-region';
+    })[0];
+    // @ts-ignore
+    expect(chart.getController('tooltip').isVisible()).toBe(true);
+    expect(regionShape3.attr('fill')).toBe('blue');
+    chart.emit('plot:mouseleave', {});
+    chart.removeInteraction('custom');
+
+    // 方式2: 重新绑定交互，且传入参数
+    chart.interaction('active-region', {
+      start: [{ trigger: 'plot:mousemove', action: 'active-region:show', arg: { style: { fill: 'pink' } } }],
+    });
+    chart.emit('plot:mousemove', point);
+    expect(chart.backgroundGroup.findAll((el) => el.get('name') === 'active-region')[0].attr('fill')).toBe('pink');
+    chart.emit('plot:mouseleave', {});
   });
 
   it('change trigger', () => {

--- a/tests/unit/interaction/action/active-region-spec.ts
+++ b/tests/unit/interaction/action/active-region-spec.ts
@@ -1,4 +1,4 @@
-import { Chart } from '../../../../src/index';
+import { Chart, registerInteraction } from '../../../../src/index';
 import { isPointInCoordinate } from '../../../../src/util/coordinate';
 import { createDiv } from '../../../util/dom';
 
@@ -65,6 +65,31 @@ describe('test active region', () => {
     expect(regionShape.get('visible')).toBe(true);
     chart.emit('plot:mouseleave', {});
     expect(regionShape.get('visible')).toBe(false);
+  });
+
+  it('region-path style', () => {
+    const point = chart.getXY({ year: '1999', value: 3 });
+    chart.emit('plot:mousemove', point);
+    expect(regionShape.get('visible')).toBe(true);
+    expect(regionShape.attr('fill')).toBe('#CCD6EC');
+    chart.emit('plot:mouseleave', {});
+
+    // 覆盖注册, 且需要 chart 重新绑定交互
+    registerInteraction('active-region', {
+      start: [
+        { trigger: 'plot:mousemove', action: 'active-region:show', arg: { style: { fill: 'rgba(255,0,0,0.25' } } },
+      ],
+      end: [{ trigger: 'plot:mouseleave', action: 'active-region:hide' }],
+    });
+    chart.interaction('active-region');
+    chart.emit('plot:mousemove', point);
+    const regionShape2 = chart.backgroundGroup.findAll((el) => {
+      return el.get('name') === 'active-region';
+    })[0];
+    expect(regionShape2.get('visible')).toBe(true);
+    expect(regionShape2.attr('fill')).toBe('rgba(255,0,0,0.25');
+    chart.emit('plot:mouseleave', {});
+    expect(regionShape2.get('visible')).toBe(false);
   });
 
   it('change trigger', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->
目前建议全局使用统一的 active-region 交互样式，因此需要先注册交互，再进行使用

使用方式 1⃣️：
```ts
// 覆盖注册, 且需要 chart 重新绑定交互. 或者不进行覆盖，使用新的 interaction name
registerInteraction('active-region', {
  start: [
    { trigger: 'plot:mousemove', action: 'active-region:show', arg: { style: { fill: 'rgba(255,0,0,0.25' } } },
  ],
  end: [{ trigger: 'plot:mouseleave', action: 'active-region:hide' }],
});

chart.interaction('active-region');
```

使用方式 2⃣️：
```ts
// 方式2: 重新绑定交互，且传入参数
chart.interaction('active-region', {
  start: [{ trigger: 'plot:mousemove', action: 'active-region:show', arg: { style: { fill: 'pink' } } }],
});
```

使用方式 2⃣️（多 actions）：
```ts
// multiple actions with args
registerInteraction('custom', {
  start: [{ trigger: 'plot:mousemove', action: ['tooltip:show', 'active-region:show'] }],
  end: [{ trigger: 'plot:mouseleave', action: 'active-region:hide' }],
});

chart.interaction('custom', {
  start: [
    {
      trigger: 'plot:mousemove',
      action: ['tooltip:show', 'active-region:show'],
      arg: [null, { style: { fill: 'blue' } }],
    },
  ],
});
```



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
