### PR TITLE
update type-only import

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -48,7 +48,7 @@ export { registerAnimation, getAnimation } from './animate/animation';
 export { LAYER, DIRECTION } from './constant';
 
 // 因为 typescript 部分版本不支持 export * as 语法。
-import * as Types from './interface';
+import type * as Types from './interface';
 export { Types };
 
 export { IGroup, ShapeAttrs, Coordinate, Scale, ScaleConfig } from './dependents';


### PR DESCRIPTION
Such they could be auto erased from the output, otherwise, bundlers like rollup will throw an error.

### Current
Currently `src/interface.ts` was compiled to the following(cjs):

```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
//# sourceMappingURL=interface.js.map
```

Not only this is useless also will causes rollup error when use @antv/g2 as dependency, `require('./interface')` from `src/core.js`

```
'default' is not exported by interface.js (imported by core.js)
```

### Fix
Change `import * as Types from './interface'` to `import type * as Types from './interface';`, the entire `interface.ts` would be auto erased from the output and everything works as expected.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
