### PR TITLE
fix(issue-3160): 修复饼图使用连续型图例，标签无法展示

### DIFF
--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -1188,7 +1188,11 @@ export default class Geometry extends Base {
       id = `${xVal}-${yVal}`;
     }
 
-    const groupScales = this.groupScales;
+    let groupScales = [...this.groupScales];
+    if (isEmpty(groupScales)) {
+      groupScales = get(this.getAttribute('color'), 'scales', []);
+    }
+
     for (let index = 0, length = groupScales.length; index < length; index++) {
       const groupScale = groupScales[index];
       const field = groupScale.field;

--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -1188,7 +1188,7 @@ export default class Geometry extends Base {
       id = `${xVal}-${yVal}`;
     }
 
-    let groupScales = [...this.groupScales];
+    let groupScales = this.groupScales;
     if (isEmpty(groupScales)) {
       groupScales = get(this.getAttribute('color'), 'scales', []);
     }

--- a/src/geometry/label/layout/pie/spider.ts
+++ b/src/geometry/label/layout/pie/spider.ts
@@ -112,7 +112,7 @@ export function pieSpiderLabelLayout(items: LabelItem[], labels: IGroup[], shape
 
   // step 1: adjust items to spider
   each(items, (item) => {
-    const label = get(labelsMap, item.id);
+    const label = get(labelsMap, [item.id]);
     if (!label) {
       return;
     }
@@ -177,7 +177,7 @@ export function pieSpiderLabelLayout(items: LabelItem[], labels: IGroup[], shape
     const inRight = key === RIGHT_HALF_KEY;
 
     each(half, (item) => {
-      const label: IGroup = get(labelsMap, item && item.id);
+      const label: IGroup = get(labelsMap, item && [item.id]);
       if (!label) {
         return;
       }

--- a/tests/bugs/3160-spec.ts
+++ b/tests/bugs/3160-spec.ts
@@ -1,0 +1,62 @@
+import { Chart } from '../../src';
+import { createDiv, removeDom } from '../util/dom';
+
+describe('#3160', () => {
+  const div = createDiv();
+  const chart = new Chart({
+    container: div, // 指定图表容器 ID
+    height: 300, // 指定图表高度
+    autoFit: true,
+  });
+  chart.coordinate('theta');
+
+  const data = [
+    { type: '1', item: 1, value: 0.1 },
+    { type: '2', item: 4, value: 0.4 },
+    { type: '1.3', item: 2, value: 0.2 },
+    { type: '2.5', item: 3, value: 0.3 },
+  ];
+  chart.data(data);
+
+  chart
+    .interval()
+    .position('value')
+    .color('type')
+    .label('type', { layout: { type: 'pie-spider' } })
+    .adjust('stack');
+
+  chart.render();
+
+  it('mapping color to linear scale, label render normal', () => {
+    const labels = chart.geometries[0].labelsContainer.getChildren();
+    expect(labels.length).toBe(4);
+  });
+
+  it('spider label, render normal', () => {
+    chart.clear();
+    chart
+      .interval()
+      .position('value')
+      .color('type')
+      .label('type', { layout: { type: 'pie-spider' } })
+      .adjust('stack');
+    chart.render();
+
+    const labels = chart.geometries[0].labelsContainer.getChildren();
+
+    const label1 = labels.find((l) => l.get('id') === `1-${data[0].type}`);
+    const label2 = labels.find((l) => l.get('id') === `1-${data[1].type}`);
+    const label3 = labels.find((l) => l.get('id') === `1-${data[2].type}`);
+    const label4 = labels.find((l) => l.get('id') === `1-${data[3].type}`);
+
+    // @ts-ignore
+    expect(label1.getChildren()[0].getCanvasBBox().minX).toEqual(label2.getChildren()[0].getCanvasBBox().minX);
+    // @ts-ignore
+    expect(label3.getChildren()[0].getCanvasBBox().maxX).toEqual(label4.getChildren()[0].getCanvasBBox().maxX);
+  });
+
+  afterAll(() => {
+    chart.destroy();
+    removeDom(div);
+  });
+});

--- a/tests/unit/geometry/label/layout/pie-spider-spec.ts
+++ b/tests/unit/geometry/label/layout/pie-spider-spec.ts
@@ -95,6 +95,61 @@ describe('pie-spider-label layout', () => {
     expect(label1.getBBox().y + label1.getBBox().height / 2).toEqual(center.y);
   });
 
+  it('异常情况', () => {
+    chart.clear();
+
+    let data = [
+      { item: '事例一', count: 35 },
+      { item: '事例二', count: 25 },
+      { item: '事例三', count: 20 },
+      { item: '事例四', count: 20 },
+      { item: '事例五', count: 20 },
+    ];
+    chart.data(data);
+
+    chart.coordinate({
+      type: 'theta',
+      cfg: {
+        radius: 0.5,
+      },
+    });
+
+    chart
+      .interval()
+      .adjust('stack')
+      .position('count')
+      .color('item')
+      .label('item', {
+        layout: { type: 'pie-spider' },
+      });
+
+    chart.render();
+    let labels = chart.geometries[0].labelsContainer.getChildren();
+    expect(labels.length).toBe(5);
+
+    let label1 = labels.find((l) => l.get('id') === `1-${data[0].item}`);
+    let label2 = labels.find((l) => l.get('id') === `1-${data[1].item}`);
+
+    // @ts-ignore
+    expect(label1.getChildren()[0].getCanvasBBox().minX).toEqual(label2.getChildren()[0].getCanvasBBox().minX);
+
+    data = [
+      { item: '事例.一', count: 35 },
+      { item: '事例.二', count: 25 },
+      { item: '事例三', count: 20 },
+      { item: '事例四', count: 20 },
+      { item: '事例五', count: 20 },
+    ];
+    chart.changeData(data);
+
+    labels = chart.geometries[0].labelsContainer.getChildren();
+
+    label1 = labels.find((l) => l.get('id') === `1-${data[0].item}`);
+    label2 = labels.find((l) => l.get('id') === `1-${data[1].item}`);
+    // @ts-ignore
+    expect(label1.getChildren()[0].getCanvasBBox().minX).toEqual(label2.getChildren()[0].getCanvasBBox().minX);
+  });
+
   afterAll(() => {
     chart.destroy();
     removeDom(div);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

- fix: 修复 color 字段为 linear 类型时，不会存入 groupScales，导致获取 label-id 不唯一
- fix: spider 布局，如果 labelItem 的 id 存在 ‘.' , 会因为 get 解析 key 值，导致获取错误 ，如下：

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/15646325/114275026-8d637280-9a53-11eb-9942-700c1538e3d2.png)|![image](https://user-images.githubusercontent.com/15646325/114274962-568d5c80-9a53-11eb-812b-f76497359d1b.png)|


- closed: #3160 
- closed: https://github.com/antvis/G2Plot/issues/2497
- ref: #3349
