### PR TITLE
feat: 主题中增加图例样式的配置，便于用户了解怎么修改

### DIFF
--- a/src/theme/util/create-by-style-sheet.ts
+++ b/src/theme/util/create-by-style-sheet.ts
@@ -99,6 +99,30 @@ function createLegendStyles(styleSheet: StyleSheet): LooseObject {
         textBaseline: 'middle',
       },
     },
+    itemStates: {
+      active: {
+        nameStyle: {
+          opacity: 0.8,
+        },
+      },
+      unchecked: {
+        nameStyle: {
+          fill: '#D8D8D8',
+        },
+        markerStyle: {
+          fill: '#D8D8D8',
+          stroke: '#D8D8D8',
+        },
+      },
+      inactive: {
+        nameStyle: {
+          fill: '#D8D8D8',
+        },
+        markerStyle: {
+          opacity: 0.2,
+        },
+      },
+    },
     flipPage: true,
     pageNavigator: {
       marker: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
legend 的状态样式写死在 `component` 中，其实是可以修改的；参考下面两个文件：
1. https://github.com/antvis/component/blob/7d74c4753ce4cc5bcb54f8f278f9ea62d6a0c6bf/src/util/theme.ts
2. https://github.com/antvis/component/blob/912fb582894be39307b508edbd0468ea7fca16d1/src/legend/category.ts#L109

closed: #3375
