### PR TITLE
fix: 修复数据为 0 时动画更新出错

### DIFF
--- a/src/animate/animation/sector-path-update.ts
+++ b/src/animate/animation/sector-path-update.ts
@@ -128,6 +128,11 @@ export function sectorPathUpdate(shape: IShape, animateCfg: GAnimateCfg, cfg: An
   const center = coordinate.getCenter();
   const diffStartAngle = curStartAngle - preStartAngle;
   const diffEndAngle = curEndAngle - preEndAngle;
+  // 没有 diff 时直接返回最终 attrs，不需要额外动画
+  if (diffStartAngle === 0 && diffEndAngle === 0) {
+    shape.attr('path', path);
+    return;
+  }
 
   shape.animate(
     (ratio) => {

--- a/tests/bugs/charts-574-spec.ts
+++ b/tests/bugs/charts-574-spec.ts
@@ -22,7 +22,6 @@ describe('574', () => {
 
     chart.interval().adjust('stack').position('value').color('type', ['blue', 'green', 'yellow']);
     chart.render();
-    console.log(chart.geometries[0].elements[0].shape);
     const fn = jest.fn();
     chart.geometries[0].elements[2].shape.animate = fn;
     chart.changeData([

--- a/tests/bugs/charts-574-spec.ts
+++ b/tests/bugs/charts-574-spec.ts
@@ -1,0 +1,40 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+
+describe('574', () => {
+  it('574', () => {
+    const data = [
+      { type: '一线城市', value: 20 },
+      { type: '二线城市', value: 0 },
+      { type: '三线城市', value: 10 },
+    ];
+    const chart = new Chart({
+      container: createDiv(),
+      width: 600,
+      height: 300,
+      autoFit: true,
+    });
+    chart.data(data);
+
+    chart.coordinate('theta', {
+      radius: 0.75,
+    });
+
+    chart.interval().adjust('stack').position('value').color('type', ['blue', 'green', 'yellow']);
+    chart.render();
+    console.log(chart.geometries[0].elements[0].shape);
+    const fn = jest.fn();
+    chart.geometries[0].elements[2].shape.animate = fn;
+    chart.changeData([
+      { type: '一线城市', value: 20 },
+      { type: '三线城市', value: 10 },
+    ]);
+    expect(fn).not.toBeCalled();
+    chart.changeData([
+      { type: '一线城市', value: 20 },
+      { type: '三线城市', value: 15 },
+    ]);
+    expect(fn).toBeCalled();
+    chart.destroy();
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
饼图存在空数据时 sector-path-update 会导致动画超出画布。

| before | after |
| -------- | ------ |
|  <img src="https://user-images.githubusercontent.com/31396322/114974044-3ecf3180-9eb4-11eb-8716-fc0f9c335ae6.png" width="300" />  |  <img src="https://user-images.githubusercontent.com/31396322/114974107-5a3a3c80-9eb4-11eb-8029-406afb0f7c03.png" width="300" /> 
 |