### PR TITLE
ci(cache): add cache support for github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,55 +1,36 @@
 name: build
 
-on: ["push", "pull_request"]
+on: [ "push", "pull_request" ]
 
 jobs:
-  lint:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-      - name: npm install
-        run: |
-          npm install
-      - name: lint
-        run: |
-          npm run lint
-
   build:
     runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-      - name: npm install
-        run: |
-          npm install
-      - name: build
-        run: |
-          npm run build
 
-  test:
-    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js 12
-        uses: actions/setup-node@v1
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.5
         with:
-          node-version: 12.x
-      - name: npm install
+          node-version: '12'
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./node_modules
+          key: ${{ runner.os }}-build-cache-node-modules-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            cache-node-modules-
+
+      - name: Run ci
         run: |
           npm install
-      - name: test
-        run: |
-          npm run coverage
-        env:
-          CI: true
-      - name: Coveralls
+          npm run ci
+      - name: coverall
+        if: success()
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "testEnvironment": "jest-electron/environment",
     "testTimeout": 30000,
     "preset": "ts-jest",
-    "collectCoverage": false,
+    "collectCoverage": true,
     "collectCoverageFrom": [
       "src/**/*.{js,ts}",
       "!**/node_modules/**",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:cjs": "rimraf ./lib && tsc --module commonjs --outDir lib",
     "build:esm": "rimraf ./esm && tsc --module ESNext --outDir esm",
     "build": "run-p build:*",
-    "ci": "run-s lint build coverage",
+    "ci": "run-s lint test build",
     "prepublishOnly": "npm run ci",
     "prepare": "husky install",
     "changelog": "generate-changelog"


### PR DESCRIPTION
- [x] 添加 ci 缓存支持

PS. 旧的 ci 模板不适合缓存,我做了一些修改（缓存机制是作为action 基于**一个**job 的，那么相应的 action 得复制三遍，代码太丑O(∩_∩)O~）

**当前 v5 版本效率 x2**