### PR TITLE
 fix: 修复 view.changeData 在重新渲染的时候 报 toFront 为 underfind 的错误

### DIFF
--- a/src/geometry/element/index.ts
+++ b/src/geometry/element/index.ts
@@ -215,8 +215,7 @@ export default class Element extends Base {
       }
       states.push(stateName);
       if (stateName === 'active' || stateName === 'selected') {
-        if (!shape || !shape?.toFront) return
-        shape.toFront();
+        shape?.toFront();
       }
     } else {
       if (index === -1) {
@@ -225,8 +224,7 @@ export default class Element extends Base {
       }
       states.splice(index, 1);
       if (stateName === 'active' || stateName === 'selected') {
-        if (!shape || !shape?.toBack) return
-        shape.toBack();
+        shape?.toBack();
       }
     }
 

--- a/src/geometry/element/index.ts
+++ b/src/geometry/element/index.ts
@@ -215,6 +215,7 @@ export default class Element extends Base {
       }
       states.push(stateName);
       if (stateName === 'active' || stateName === 'selected') {
+        if (!shape || !shape?.toFront) return
         shape.toFront();
       }
     } else {
@@ -224,6 +225,7 @@ export default class Element extends Base {
       }
       states.splice(index, 1);
       if (stateName === 'active' || stateName === 'selected') {
+        if (!shape || !shape?.toBack) return
         shape.toBack();
       }
     }


### PR DESCRIPTION

- [x]  修复 view.changeData 在重新渲染的时候 报 toFront\toBack 为 underfind 的错误
![image](https://user-images.githubusercontent.com/65594180/119483677-cc415380-bd87-11eb-9198-70ecada61653.png)
![image](https://user-images.githubusercontent.com/65594180/119483718-d7947f00-bd87-11eb-9dee-72275f14269f.png)
![image](https://user-images.githubusercontent.com/65594180/119483754-e0855080-bd87-11eb-8e7a-8327218e3d5b.png)

