### PR TITLE
feat(mask): mask 交互支持配置样式

### DIFF
--- a/src/interaction/action/mask/base.ts
+++ b/src/interaction/action/mask/base.ts
@@ -1,4 +1,4 @@
-import { each } from '@antv/util';
+import { deepMix, each } from '@antv/util';
 import Action from '../base';
 import { LooseObject } from '../../../interface';
 
@@ -77,7 +77,7 @@ abstract class MaskBase extends Action {
   /**
    * 开始
    */
-  public start() {
+  public start(arg?: { maskStyle: LooseObject }) {
     this.starting = true;
     // 开始时，保证移动结束
     this.moving = false;
@@ -87,7 +87,7 @@ abstract class MaskBase extends Action {
       // 开始时设置 capture: false，可以避免创建、resize 时触发事件
       this.maskShape.set('capture', false);
     }
-    this.updateMask();
+    this.updateMask(arg?.maskStyle);
     this.emitEvent('start');
   }
 
@@ -119,8 +119,8 @@ abstract class MaskBase extends Action {
     this.preMovePoint = currentPoint;
   }
 
-  protected updateMask() {
-    const attrs = this.getMaskAttrs();
+  protected updateMask(maskStyle?: LooseObject) {
+    const attrs = deepMix({}, this.getMaskAttrs(), maskStyle);
     this.maskShape.attr(attrs);
   }
 

--- a/tests/unit/interaction/action/mask-spec.ts
+++ b/tests/unit/interaction/action/mask-spec.ts
@@ -86,7 +86,7 @@ describe('test mask', () => {
         x: 100,
         y: 100,
       };
-      maskAction.start();
+      maskAction.start({ maskStyle: { fill: 'red' } });
 
       context.event = {
         x: 200,
@@ -104,6 +104,7 @@ describe('test mask', () => {
         y: 160,
       };
       maskAction.move();
+      expect(maskShape.attr('fill')).toBe('red');
       expect(maskShape.attr('x')).toBe(110);
       expect(maskShape.attr('y')).toBe(110);
       expect(maskShape.attr('width')).toBe(100);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

close: #3456 

带 mask 的交互支持配置 maskStyle，使用方式如下：

```ts
chart.interaction('element-range-highlight', {
  start: [
    {
      trigger: 'plot:mousedown',
      isEnable(context) {
        // 不要点击在 mask 上重新开始
        return !context.isInShape('mask');
      },
      action: ['rect-mask:start', 'rect-mask:show'],
      // 对应第一个action的参数
      arg: [{ maskStyle: { fill: 'rgba(255,0,0,0.15)' } }]
    },
    {
      trigger: 'mask:dragstart',
      action: ['rect-mask:moveStart'],
    },
  ],
});
```
