### PR TITLE
wip: fix(issue-3476): 柱状图 xField 等于 colorField 时候，x 轴没有过滤

### DIFF
--- a/src/chart/controller/scrollbar.ts
+++ b/src/chart/controller/scrollbar.ts
@@ -229,7 +229,8 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
   private changeViewData([startIdx, endIdx]: [number, number], render?: boolean): void {
     const { type } = this.getValidScrollbarCfg();
     const isHorizontal = type !== 'vertical';
-    const values = valuesOfKey(this.data, this.xScaleCfg.field);
+    const xField = this.xScaleCfg.field;
+    const values = valuesOfKey(this.data, xField);
     const xValues = isHorizontal ? values : values.reverse();
     this.yScalesCfg.forEach((cfg) => {
       this.view.scale(cfg.field, {
@@ -239,10 +240,18 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
         max: cfg.max,
       });
     });
-    this.view.filter(this.xScaleCfg.field, (val) => {
+    this.view.filter(xField, (val) => {
       const idx = xValues.indexOf(val);
       return idx > -1 ? isBetween(idx, startIdx, endIdx) : true;
     });
+
+    const groupFields = this.view.getGroupScales().map((s) => s.field);
+    if (groupFields.indexOf(xField) !== -1) {
+      this.view.scale(xField, {
+        values: values.slice(startIdx, endIdx),
+      });
+    }
+
     this.view.render(true);
   }
 

--- a/src/chart/controller/scrollbar.ts
+++ b/src/chart/controller/scrollbar.ts
@@ -233,12 +233,14 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
     const values = valuesOfKey(this.data, xField);
     const xValues = isHorizontal ? values : values.reverse();
     this.yScalesCfg.forEach((cfg) => {
-      this.view.scale(cfg.field, {
-        formatter: cfg.formatter,
-        type: cfg.type as ScaleOption['type'],
-        min: cfg.min,
-        max: cfg.max,
-      });
+      if (cfg) {
+        this.view.scale(cfg.field, {
+          formatter: cfg.formatter,
+          type: cfg.type as ScaleOption['type'],
+          min: cfg.min,
+          max: cfg.max,
+        });
+      }
     });
     this.view.filter(xField, (val) => {
       const idx = xValues.indexOf(val);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

close: #3476

暂时还没有确定除了 colorField 之外的 groupFields 是否有问题

| Before | After |
| --- | --- |
|![](https://gw.alipayobjects.com/zos/antfincdn/w8MIi6N2Ba/gundongtiao.gif)| ![](https://gw.alipayobjects.com/zos/antfincdn/3sA9XnUM9R/gundongtiao-2.gif) 图例不正确了 |
