### PR TITLE
fix: 过滤连续图例的 value 参数，防止影响到 component legend 的 value 属性 导致交互问题

### DIFF
--- a/src/chart/controller/legend.ts
+++ b/src/chart/controller/legend.ts
@@ -341,7 +341,7 @@ export default class Legend extends Controller<AllLegendsOptions> {
    * @param legendOption
    */
   private createContinuousLegend(geometry: Geometry, attr: Attribute, scale: Scale, legendOption: any) {
-    const cfg = this.getContinuousCfg(geometry, attr, scale, legendOption);
+    const cfg = this.getContinuousCfg(geometry, attr, scale, omit(legendOption, ['value']));
     return new ContinuousLegend(cfg);
   }
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/65594180/126146685-d950452c-7e61-4ff8-a4d7-a37afa028a18.png)
