### PR TITLE
style(geometry): removed double slash in path

### DIFF
--- a/src/geometry/label/layout/limit-in-plot.ts
+++ b/src/geometry/label/layout/limit-in-plot.ts
@@ -1,7 +1,7 @@
 import { each, pick } from '@antv/util';
 import { BBox, IGroup, IShape } from '../../../dependents';
 import { getCoordinateBBox } from '../../../util/coordinate';
-import { getEllipsisText } from '../../..//util/text';
+import { getEllipsisText } from '../../../util/text';
 import { translate } from '../../../util/transform';
 import { LabelItem } from '../interface';
 


### PR DESCRIPTION
- [x] commit message follows commit guidelines

##### Description of change
The double slash in the path was causing jspm.dev to not be able to build the library. It's a simple fix that shouldn't introduce any bugs or breaking changes.