### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ $ git checkout -b branch-name
 # Run the test after you finish your modification. Add new test cases or change old ones if you feel necessary
 $ npm test
 
-# If your modification pass the tests, congradulations it's time to push your work back to us. Notice that the commit message should be wirtten in the following format.
+# If your modification pass the tests, congratulations it's time to push your work back to us. Notice that the commit message should be written in the following format.
 $ git add . # git add -u to delete files
 $ git commit -m "fix(role): role.use must xxx"
 $ git push origin branch-name
@@ -32,11 +32,11 @@ $ git push origin branch-name
 
 Then you can create a Pull Request at [G2](https://github.com/antvis/g2/pulls).
 
-No one can garantee how much will be remembered about certain PR after some time. To make sure we can easily recap what happened previously, please provide the following information in your PR.
+No one can guarantee how much will be remembered about certain PR after some time. To make sure we can easily recap what happened previously, please provide the following information in your PR.
 
 1. Need: What function you want to achieve (Generally, please point out which issue is related).
 2. Updating Reason: Different with issue. Briefly describe your reason and logic about why you need to make such modification.
-3. Related Testing: Briefly descirbe what part of testing is relevant to your modification.
+3. Related Testing: Briefly describe what part of testing is relevant to your modification.
 4. User Tips: Notice for scale users. You can skip this part, if the PR is not about update in API or potential compatibility problem.
 
 ### Style Guide
@@ -78,7 +78,7 @@ Use succinct words to describe what did you do in the commit change.
 
 （4）body
 
-Feel free to add more content in the body, if you think subject is not self-explanatory enough, such as what it is the purpose or reasone of you commit.
+Feel free to add more content in the body, if you think subject is not self-explanatory enough, such as what it is the purpose or reason of you commit.
 
 （5）footer
 
@@ -103,7 +103,7 @@ BREAKING CHANGE:
   Breaks foo.bar api, foo.baz should be used instead
 ```
 
-Look at [these files](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit) for more detials.
+Look at [these files](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit) for more details.
 
 ## Release
 


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.md

Fixes:
- Should read `written` rather than `wirtten`.
- Should read `reason` rather than `reasone`.
- Should read `guarantee` rather than `garantee`.
- Should read `details` rather than `detials`.
- Should read `describe` rather than `descirbe`.
- Should read `congratulations` rather than `congradulations`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md