### PR TITLE
fix(funnel): pyramid shape 最下面一层的 label 绘制不对齐

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2",
-  "version": "4.1.24",
+  "version": "4.1.25",
   "description": "the Grammar of Graphics in Javascript",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/src/geometry/shape/interval/pyramid.ts
+++ b/src/geometry/shape/interval/pyramid.ts
@@ -9,7 +9,7 @@ import { getFunnelPath, getRectPoints } from './util';
 registerShape('interval', 'pyramid', {
   getPoints(shapePoint: ShapePoint) {
     shapePoint.size = shapePoint.size * 2; // 漏斗图的 size 是柱状图的两倍
-    return getRectPoints(shapePoint, true);
+    return getRectPoints(shapePoint);
   },
   draw(cfg: ShapeInfo, container: IGroup) {
     const style = getStyle(cfg, false, true);

--- a/src/geometry/shape/interval/util.ts
+++ b/src/geometry/shape/interval/util.ts
@@ -41,23 +41,11 @@ export function getRectPoints(pointInfo: ShapePoint, isPyramid = false): Point[]
     { x: xMin, y: yMax },
   ];
 
-  if (isPyramid) {
-    // 绘制尖底漏斗图
-    // 金字塔漏斗图的关键点
-    // 1
-    // |   2
-    // 0
-    points.push({
-      x: xMax,
-      y: (yMax + yMin) / 2,
-    });
-  } else {
-    // 矩形的四个关键点，结构如下（左下角顺时针连接）
-    // 1 ---- 2
-    // |      |
-    // 0 ---- 3
-    points.push({ x: xMax, y: yMax }, { x: xMax, y: yMin });
-  }
+  // 矩形的四个关键点，结构如下（左下角顺时针连接）
+  // 1 ---- 2
+  // |      |
+  // 0 ---- 3
+  points.push({ x: xMax, y: yMax }, { x: xMax, y: yMin });
 
   return points;
 }
@@ -246,8 +234,7 @@ export function getFunnelPath(points: Point[], nextPoints: Point[], isPyramid: b
     path.push(
       ['M', points[0].x, points[0].y],
       ['L', points[1].x, points[1].y],
-      ['L', points[2].x, points[2].y],
-      ['L', points[2].x, points[2].y],
+      ['L', (points[2].x + points[3].x) / 2, (points[2].y + points[3].y) / 2],
       ['Z']
     );
   } else {

--- a/src/geometry/shape/interval/util.ts
+++ b/src/geometry/shape/interval/util.ts
@@ -11,7 +11,7 @@ import { Point, ShapeInfo, ShapePoint } from '../../../interface';
  * @param [isPyramid] 是否为尖底漏斗图
  * @returns rect points 返回矩形四个顶点信息
  */
-export function getRectPoints(pointInfo: ShapePoint, isPyramid = false): Point[] {
+export function getRectPoints(pointInfo: ShapePoint): Point[] {
   const { x, y, y0, size } = pointInfo;
   // 有 4 种情况，
   // 1. x, y 都不是数组

--- a/tests/bugs/funnel-pyramid-spec.ts
+++ b/tests/bugs/funnel-pyramid-spec.ts
@@ -1,0 +1,71 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+import { flatten } from '@antv/util';
+import IntervalLabel from "../../src/geometry/label/interval";
+
+describe('pyramid funnel ', () => {
+
+  it('should render label middle', () => {
+    const data = [
+      { action: '浏览网站', pv: 50000 },
+      { action: '放入购物车', pv: 35000 },
+      { action: '生成订单', pv: 25000 },
+      { action: '支付订单', pv: 15000 },
+      { action: '完成交易', pv: 10000 },
+    ];
+
+    const chart = new Chart({
+      container: createDiv(),
+      width: 600,
+      height: 500,
+      padding: [20, 120, 95],
+    });
+    chart.data(data);
+    chart.axis(false);
+    chart
+      .coordinate('rect')
+      .transpose()
+      .scale(1, -1);
+
+    const interval = chart
+      .interval()
+      .adjust('symmetric')
+      .position('action*pv')
+      .shape('pyramid')
+      .color('action', ['#0050B3', '#1890FF', '#40A9FF', '#69C0FF', '#BAE7FF'])
+      .label(
+        'action*pv',
+        {
+          position: 'middle',
+          labelLine: {
+            style: {
+              lineWidth: 1,
+              stroke: 'rgba(0, 0, 0, 0.15)',
+            },
+          },
+        }
+      )
+
+    chart.render();
+
+    // 生成映射数据
+    // @ts-ignore
+    const beforeMappingData = interval.beforeMappingData;
+    // @ts-ignore
+    const dataArray = interval.beforeMapping(beforeMappingData);
+
+    // @ts-ignore
+    const mappingArray = flatten(dataArray.map(d => interval.mapping(d)));
+    const gLabels = new IntervalLabel(interval);
+    // @ts-ignore
+    const labelItems = gLabels.getLabelItems(mappingArray);
+
+    console.log(labelItems)
+    expect(labelItems[0].x).toBe(300);
+    expect(labelItems[0].y).toBe(58.5);
+    expect(labelItems[2].x).toBe(300);
+    expect(labelItems[2].y).toBe(212.5);
+    expect(labelItems[4].x).toBe(300);
+    expect(labelItems[4].y).toBe(366.5);
+  })
+});

--- a/tests/bugs/funnel-pyramid-spec.ts
+++ b/tests/bugs/funnel-pyramid-spec.ts
@@ -60,12 +60,13 @@ describe('pyramid funnel ', () => {
     // @ts-ignore
     const labelItems = gLabels.getLabelItems(mappingArray);
 
-    console.log(labelItems)
     expect(labelItems[0].x).toBe(300);
     expect(labelItems[0].y).toBe(58.5);
     expect(labelItems[2].x).toBe(300);
     expect(labelItems[2].y).toBe(212.5);
     expect(labelItems[4].x).toBe(300);
     expect(labelItems[4].y).toBe(366.5);
+
+    chart.destroy();
   })
 });

--- a/tests/unit/geometry/label/chart/funnel-spec.ts
+++ b/tests/unit/geometry/label/chart/funnel-spec.ts
@@ -108,7 +108,7 @@ describe('Funnel chart label', () => {
     expect(labelItems[0].y).toBe(3.75);
     expect(labelItems[2].x).toBe(140);
     expect(labelItems[2].y).toBe(78.75);
-    expect(labelItems[4].x).toBe(116);
+    expect(labelItems[4].x).toBe(122);
     expect(labelItems[4].y).toBe(150);
   });
 

--- a/tests/unit/geometry/shape/interval-spec.ts
+++ b/tests/unit/geometry/shape/interval-spec.ts
@@ -137,7 +137,7 @@ describe('Interval shapes', () => {
       });
       expect(shapePath.length).toBe(6);
       expect(hapePathTypes).toEqual(['M', 'L', 'L', 'L', 'L', 'Z']);
-      
+
       // lineCap:'round'
       const lineCapRoundShapePath = lineCapRoundShape.attr('path');
       let lineCapRoundShapePathTypes = [];
@@ -162,7 +162,7 @@ describe('Interval shapes', () => {
       canvas.draw();
       const path2 = rectWithCornerRadiusShape.attr('path');
       let path2Types = [];
-      path2.forEach((path) =>  path2Types.push(path[0]));
+      path2.forEach((path) => path2Types.push(path[0]));
       expect(path2.length).toBe(10);
       expect(path2Types).toEqual(['M', 'A', 'L', 'A', 'L', 'A', 'L', 'A', 'L', 'Z']);
 
@@ -180,7 +180,7 @@ describe('Interval shapes', () => {
       canvas.draw();
       const path3 = rectWithCornerRadiusShape1.attr('path');
       let path3Types = [];
-      path3.forEach((path) =>  path3Types.push(path[0]));
+      path3.forEach((path) => path3Types.push(path[0]));
       expect(path3.length).toBe(8);
       expect(path3Types).toEqual(['M', 'A', 'L', 'A', 'L', 'L', 'L', 'Z']);
     });
@@ -555,7 +555,8 @@ describe('Interval shapes', () => {
       expect(points).toEqual([
         { x: 0.2, y: 0.6 },
         { x: 0.2, y: 0.8 },
-        { x: 0.3, y: 0.7 },
+        { x: 0.3, y: 0.8 },
+        { x: 0.3, y: 0.6 },
       ]);
     });
 
@@ -584,7 +585,7 @@ describe('Interval shapes', () => {
 
       const path = shape.attr('path');
       expect(shape.attr('fill')).toEqual(Theme.defaultColor);
-      expect(path).toEqual([['M', 100, 200], ['L', 100, 100], ['L', 150, 150], ['L', 150, 150], ['Z']]);
+      expect(path).toEqual([['M', 100, 200], ['L', 100, 100], ['L', 150, 150], ['Z']]);
     });
 
     it('draw, nextPoints is not null', () => {


### PR DESCRIPTION
**漏斗图最下面一层的绘制问题**

出现问题的原因应该是 registerShape 的 getPoints 对于 pyramid 的最下面一层只返回了一个点，导致布局计算错误。所以解决办法就是 getPoints 的方法不论是不是 pyramid 都返回相同的 points，只是在渲染的时候区别一下就好。

<img width="563" alt="截屏2021-08-23 下午4 03 32" src="https://user-images.githubusercontent.com/49330279/130413539-987a3fcb-e507-4dc1-a28e-f49655be9eb3.png">


