### PR TITLE
Feat mouse wheel scroll

### DIFF
--- a/docs/common/scrollbar-options.md
+++ b/docs/common/scrollbar-options.md
@@ -46,3 +46,14 @@
 <description> _boolean_ **optional**</description>
 
 滚动的时候是否开启动画，默认跟随图表的 animate 配置
+
+
+### options.enableMouseWheel
+
+<description> _boolean_ | _object_ **optional** </description>
+
+啟用鼠標滾輪滾動
+
+| 参数名              | 类型     | 描述                                                        |
+| ------------------- | -------- | -----------------------------------------------------------|
+| wheelSpeed          | _number_ | 滾動速度                                                    |

--- a/examples/column/basic/demo/meta.json
+++ b/examples/column/basic/demo/meta.json
@@ -13,6 +13,13 @@
       "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/e%24NnUtHbjm/a9632163-6aa8-4d53-8a2a-c1878426a51b.png"
     },
     {
+      "filename": "scrollbar.ts",
+      "title": {
+        "zh": "帶滾動條的直方圖",
+        "en": "Column chart with a scrollbar"
+      }
+    },
+    {
       "filename": "corner-radius.ts",
       "title": {
         "zh": "带倒角的柱状图",

--- a/examples/column/basic/demo/scrollbar.ts
+++ b/examples/column/basic/demo/scrollbar.ts
@@ -13,6 +13,11 @@ fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/top2000.json')
         groupBy: ['release'],
         operations: ['count'],
         type: 'aggregate',
+      })
+      .transform({
+        type: 'sort-by',
+        fields: ['release'],
+        order: 'ASC',
       });
 
     const chart = new Chart({
@@ -35,6 +40,9 @@ fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/top2000.json')
 
     chart.option('scrollbar', {
       type: 'horizontal',
+      enableMouseWheel: {
+        wheelSpeed: 2
+      }
     });
     chart.interaction('element-visible-filter');
     chart.render();

--- a/src/chart/controller/scrollbar.ts
+++ b/src/chart/controller/scrollbar.ts
@@ -53,6 +53,7 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
     super.destroy();
     this.view.off(VIEW_LIFE_CIRCLE.BEFORE_CHANGE_DATA, this.resetMeasure);
     this.view.off(VIEW_LIFE_CIRCLE.BEFORE_CHANGE_SIZE, this.resetMeasure);
+    this.cleanupViewInteractions();
   }
 
   public init() {}
@@ -66,17 +67,22 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
     if (this.option) {
       if (this.scrollbar) {
         // exist, update
-        this.scrollbar = this.updateScrollbar();
+        const config = this.getScrollbarComponentCfg()
+        this.scrollbar = this.updateScrollbar(config);
       } else {
         // not exist, create
         this.scrollbar = this.createScrollbar();
         this.scrollbar.component.on('scrollchange', this.onChangeFn);
+        if (isObject(this.option) && this.option.enableMouseWheel) {
+          this.view.interaction('plot-mousewheel-scroll');
+        }
       }
     } else {
       if (this.scrollbar) {
         // exist, destroy
         this.scrollbar.component.destroy();
         this.scrollbar = undefined;
+        this.cleanupViewInteractions();
       }
     }
   }
@@ -121,22 +127,7 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
       y += padding[0];
 
       // 默认放在 bottom
-      if (this.trackLen) {
-        this.scrollbar.component.update({
-          ...cfg,
-          x,
-          y,
-          trackLen: this.trackLen,
-          thumbLen: this.thumbLen,
-          thumbOffset: (this.trackLen - this.thumbLen) * this.ratio,
-        });
-      } else {
-        this.scrollbar.component.update({
-          ...cfg,
-          x,
-          y,
-        });
-      }
+      this.updateScrollbar({...cfg, x, y});
 
       this.view.viewBBox = this.view.viewBBox.cut(bbox, cfg.isHorizontal ? DIRECTION.BOTTOM : DIRECTION.RIGHT);
     }
@@ -266,8 +257,7 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
     };
   }
 
-  private updateScrollbar(): ComponentOption {
-    const config = this.getScrollbarComponentCfg();
+  private updateScrollbar(config): ComponentOption {
     const realConfig = this.trackLen
       ? {
           ...config,
@@ -276,6 +266,13 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
           thumbOffset: (this.trackLen - this.thumbLen) * this.ratio,
         }
       : { ...config };
+
+      if (realConfig.enableMouseWheel) {
+        this.view.interaction('plot-mousewheel-scroll');
+      } else {
+        this.cleanupViewInteractions();
+      }
+
     this.scrollbar.component.update(realConfig);
 
     return this.scrollbar;
@@ -304,7 +301,7 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
 
   private getScrollbarComponentCfg() {
     const { coordinateBBox, viewBBox } = this.view;
-    const { type, padding, width, height, style } = this.getValidScrollbarCfg();
+    const { type, padding, width, height, style, enableMouseWheel } = this.getValidScrollbarCfg();
     const isHorizontal = type !== 'vertical';
     const [paddingTop, paddingRight, paddingBottom, paddingLeft] = padding;
     const position = isHorizontal
@@ -333,6 +330,7 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
       thumbLen,
       thumbOffset: 0,
       theme: this.getScrollbarTheme(style),
+      enableMouseWheel
     };
   }
 
@@ -348,6 +346,7 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
       padding: [0, 0, 0, 0],
       animate: true,
       style: {},
+      enableMouseWheel: false,
     };
     if (isObject(this.option)) {
       cfg = { ...cfg, ...this.option };
@@ -358,5 +357,9 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
     }
 
     return cfg;
+  }
+
+  private cleanupViewInteractions() {
+    this.view.removeInteraction('plot-mousewheel-scroll');
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,7 @@ import ViewDrag from './interaction/action/view/drag';
 import ViewMove from './interaction/action/view/move';
 import ScaleTranslate from './interaction/action/view/scale-translate';
 import ScaleZoom from './interaction/action/view/scale-zoom';
+import MousewheelScroll from './interaction/action/view/mousewheel-scroll';
 
 registerAction('tooltip', TooltipAction);
 registerAction('sibling-tooltip', SiblingTooltip);
@@ -286,6 +287,8 @@ registerAction('reset-button', ButtonAction, {
   name: 'reset-button',
   text: 'reset',
 });
+
+registerAction('mousewheel-scroll', MousewheelScroll);
 
 // 注册默认的 Interaction 交互行为
 import { registerInteraction } from './core';
@@ -615,6 +618,10 @@ registerInteraction('view-zoom', {
 registerInteraction('sibling-tooltip', {
   start: [{ trigger: 'plot:mousemove', action: 'sibling-tooltip:show' }],
   end: [{ trigger: 'plot:mouseleave', action: 'sibling-tooltip:hide' }],
+});
+
+registerInteraction('plot-mousewheel-scroll', {
+  start: [{ trigger: 'plot:mousewheel', action: 'mousewheel-scroll:scroll' }],
 });
 
 // 让 TS 支持 View 原型上添加的创建 Geometry 方法的智能提示

--- a/src/interaction/action/view/mousewheel-scroll.ts
+++ b/src/interaction/action/view/mousewheel-scroll.ts
@@ -1,0 +1,59 @@
+import { clamp, get, isObject, size, valuesOfKey } from "@antv/util";
+import { COMPONENT_TYPE } from "../../../constant";
+import { Action } from '..';
+import { LooseObject, ScrollbarOption } from "../../../interface";
+
+
+function isWheelDown(event: LooseObject) {
+  const wheelEvent = event.gEvent.originalEvent as WheelEvent;
+  return wheelEvent.deltaY > 0;
+}
+
+const DEFAULT_WHEELSPEED = 1;
+const DEFAULT_CFG = {
+  wheelSpeed: DEFAULT_WHEELSPEED
+};
+
+class MousewheelScroll extends Action {
+  protected wheelSpeed = DEFAULT_WHEELSPEED;
+
+  init() {
+    const mouseWheelCfg = this.getMousewheelCfg();
+    if (mouseWheelCfg) {
+      this.wheelSpeed = mouseWheelCfg.wheelSpeed || DEFAULT_WHEELSPEED;
+    }
+  }
+
+  private getMousewheelCfg()  {
+    const { view } = this.context;
+    const scrollbarCfg: ScrollbarOption =  view.getOptions().scrollbar;
+    return (isObject(scrollbarCfg) && isObject(scrollbarCfg.enableMouseWheel)) ?
+      scrollbarCfg.enableMouseWheel : DEFAULT_CFG;
+  }
+
+  public scroll() {
+    const { view, event } = this.context;
+    const scrollbarController = view.getController('scrollbar');
+    const scrollbarComponent = scrollbarController?.getComponents().find((co) => co.type === COMPONENT_TYPE.SCROLLBAR).component;
+    if (scrollbarComponent) {
+      const xScale = view.getXScale();
+      const data = view.getOptions().data;
+      const dataSize = size(valuesOfKey(data, xScale.field));
+      const step = size(xScale.values);
+      const { thumbOffset, thumbLen, trackLen } = scrollbarComponent.cfg;
+
+      const currentRatio = clamp(thumbOffset / (trackLen - thumbLen), 0, 1);
+      const currentStart = Math.floor((dataSize - step) * currentRatio);
+
+      const nextStart = currentStart + (isWheelDown(event) ? this.wheelSpeed : -this.wheelSpeed);
+      const correction = this.wheelSpeed / (dataSize - step) / 10000;
+      const nextRatio = clamp(nextStart / (dataSize - step) + correction, 0, 1);
+
+      scrollbarComponent.emit('scrollchange', {
+        ratio: nextRatio,
+      });
+    }
+  }
+}
+
+export default MousewheelScroll;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1517,6 +1517,10 @@ export interface EventCfg {
  */
 export type SliderOption = SliderCfg | boolean;
 
+export interface MouseWheelScrollCfg {
+  wheelSpeed?: number
+}
+
 /** 滚动条组件配置项 */
 export interface ScrollbarCfg {
   /** 滚动条类型，默认 horizontal  */
@@ -1542,6 +1546,7 @@ export interface ScrollbarCfg {
     // 是否圆角，'round'
     lineCap?: string;
   };
+  enableMouseWheel?: MouseWheelScrollCfg | boolean;
 }
 
 /** 滚动条配置 */

--- a/tests/unit/chart/controller/scrollbar-spec.ts
+++ b/tests/unit/chart/controller/scrollbar-spec.ts
@@ -6,6 +6,9 @@ import { Scrollbar as ScrollbarComponent } from '../../../../src/dependents';
 import { BBox } from '../../../../src/util/bbox';
 import { delay } from '../../../util/delay';
 import { near } from '../../../util/math';
+import Context from '../../../../src/interaction/context';
+import MousewheelScroll from '../../../../src/interaction/action/view/mousewheel-scroll';
+import { getClientPoint, simulateMouseEvent } from '../../../util/simulate';
 
 describe('Scrollbar', () => {
   const container = createDiv();
@@ -343,6 +346,50 @@ describe('Scrollbar', () => {
 
     chart.destroy();
   });
+
+  it('scrollbar /w mouse wheel scrolling enabled', async () => {
+    const chart = new Chart({
+      container,
+      height: 400,
+      width: 360,
+    });
+    chart.animate(false);
+    chart.data(salesBySubCategory);
+    chart.axis('subCategory', {
+      label: {
+        autoHide: true,
+        autoRotate: false,
+      },
+    });
+    chart.option('scrollbar', {
+      type: 'horizontal',
+      categorySize: 32,
+      enableMouseWheel: {
+        wheelSpeed: 2
+      }
+    });
+    chart.scale('sales', {
+      nice: true,
+      formatter: (v) => `${Math.floor(v / 10000)}万`,
+    });
+    chart.interval().position('subCategory*sales').label('sales');
+
+    chart.render();
+
+    expect(chart.interactions['plot-mousewheel-scroll']).toBeDefined();
+
+    const spy = jest.spyOn(MousewheelScroll.prototype, 'scroll');
+    const canvas = chart.canvas;
+    const el = canvas.get('el');
+    simulateMouseEvent(el, 'mousewheel', getClientPoint(canvas, 180, 200));
+
+    expect(spy).toHaveBeenCalled();
+
+    chart.option('scrollbar', {enableMouseWheel: false});
+    await delay(500);
+    expect(chart.interactions['plot-mousewheel-scroll']).toBeUndefined();
+    chart.destroy();
+  })
 
   afterAll(() => {
     removeDom(container);

--- a/tests/unit/chart/controller/scrollbar-spec.ts
+++ b/tests/unit/chart/controller/scrollbar-spec.ts
@@ -296,8 +296,8 @@ describe('Scrollbar', () => {
     expect(scrollbarBBox.width).toBe(coordinateBBox.width);
     expect(near(xAxisBBox.maxY, 392 - 16)).toBe(true);
     expect(scrollbar.component.get('trackLen')).toBe(coordinateBBox.width);
-    // @ts-ignore
-    expect(chart.filteredData.length).toBe(9);
+    // 32 - default category size
+    expect(chart.getData().length).toBe(Math.floor(coordinateBBox.width/32));
 
     chart.destroy();
   });
@@ -338,8 +338,8 @@ describe('Scrollbar', () => {
     // initial state
     expect(scrollbarBBox.height).toBe(8);
     expect(scrollbar.component.get('trackLen')).toBe(coordinateBBox.width);
-    // @ts-ignore
-    expect(chart.filteredData.length).toBe(9);
+    // 32 - default category size
+    expect(chart.getData().length).toBe(Math.floor(coordinateBBox.width/32));
 
     chart.destroy();
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->
A new action was created to implement a scrolling behavior via a mouse wheel. An interaction was registered to utilize this action on plot:mousewheel event.
This behaviour can be configured in the scrollbar's option, by setting enableMouseWheel parameter to true:
```javascript
scrollbar: {
   type: "horizontal",
   enableMouseWheel: true
}
```
or to an object if you want to set a wheel speed (default wheel speed is 1):
```javascript
scrollbar: {
   type: "horizontal",
   enableMouseWheel: {
      wheelSpeed: 5
   }
}
```
I admit that just registering an interaction and explicitly adding it to the chart's interactions (like it is done for a chart scaling) is a more concise way of setting a desired behaviour, since there is no need to modify Scrollbar controller itself in that case: 
```javascript
chart.interaction('plot-mousewheel-scroll');
```
Unfortunately I didn't find any way to specify a wheel speed other than adding a parameter to the scrollbar option, which makes no sense if you don't add the interaction.
Please, provide a feedback.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
