### PR TITLE
refactor(funnel): annotation 位置添加center，支持在漏斗图中正常显示

### DIFF
--- a/examples/funnel/funnel/demo/basic.ts
+++ b/examples/funnel/funnel/demo/basic.ts
@@ -90,7 +90,7 @@ chart.on('beforepaint', () => {
       top: true,
       position: {
         action: obj.action,
-        percent: 'median',
+        percent: 'center',
       },
       content: +obj.percent * 100 + '%', // 显示的文本内容
       style: {

--- a/src/util/annotation.ts
+++ b/src/util/annotation.ts
@@ -15,6 +15,8 @@ export function getNormalizedValue(val: number | string, scale: Scale) {
   switch (val) {
     case 'start':
       return 0;
+    case 'center':
+      return 0.5;
     case 'end':
       return 1;
     case 'median': {

--- a/tests/unit/util/annotation-spec.ts
+++ b/tests/unit/util/annotation-spec.ts
@@ -28,6 +28,7 @@ describe('util annotation', () => {
     });
 
     expect(getNormalizedValue('start', scale)).toEqual(0);
+    expect(getNormalizedValue('center', scale)).toEqual(0.5);
     expect(getNormalizedValue('end', scale)).toEqual(1);
     expect(near(getNormalizedValue('mean', scale), 0.055999999999999994)).toBe(true);
     expect(getNormalizedValue('median', scale)).toEqual(0.065);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

漏斗图中annotation使用position: 'median' 来控制位置，当中位数不为0.5时，将会导致annotation位置偏移，因此提供了position: 'center' 选项

before:
![image](https://user-images.githubusercontent.com/25787943/132678505-c31b7ce4-2590-4481-94e9-4beca4286da1.png)

after:
![image](https://user-images.githubusercontent.com/25787943/132678516-385b11a3-9d6f-41e9-b1ba-24b699f58ac2.png)
