### PR TITLE
refactor(padding): 分面图 padding 支持回调方法对内边距进行单独设置

### DIFF
--- a/docs/common/facet-cfg.md
+++ b/docs/common/facet-cfg.md
@@ -9,9 +9,9 @@
 
 #### FacetCfg.padding
 
-<description> _number | number[] | 'auto'_ **optional**</description>
+<description> _number | number[] | 'auto' | ((index: number)=> number | number[])_ **optional**</description>
 
-每个 facet 的内边距，设置方式参考 css 盒模型。
+每个 facet 的内边距，设置方式参考 css 盒模型。可通过回调方法分别设置每个 facet 的内边距。
 
 #### FacetCfg.showTitle
 

--- a/src/facet/facet.ts
+++ b/src/facet/facet.ts
@@ -1,8 +1,8 @@
-import { deepMix, each, every, get, isNil, isNumber } from '@antv/util';
+import { deepMix, each, every, get, isNil, isNumber, isFunction } from '@antv/util';
 import { LAYER } from '../constant';
 import { IGroup } from '../dependents';
 import { AxisCfg, Condition, Datum, FacetCfg, FacetData, FacetDataFilter, Region } from '../interface';
-
+import { ViewPadding } from '../interface';
 import View from '../chart/view';
 import { getAxisOption } from '../util/axis';
 
@@ -109,12 +109,12 @@ export abstract class Facet<C extends FacetCfg<FacetData> = FacetCfg<FacetData>,
    * 根据 facet 生成 view，可以给上层自定义使用
    * @param facet
    */
-  protected facetToView(facet: F): View {
+  protected facetToView(facet: F, index: number): View {
     const { region, data, padding = this.cfg.padding } = facet;
 
     const view = this.view.createView({
       region,
-      padding,
+      padding: this.parsePadding(padding, index),
     });
 
     // 设置分面的数据
@@ -153,8 +153,8 @@ export abstract class Facet<C extends FacetCfg<FacetData> = FacetCfg<FacetData>,
    */
   private createFacetViews(): View[] {
     // 使用分面数据 创建分面 view
-    return this.facets.map((facet): View => {
-      return this.facetToView(facet);
+    return this.facets.map((facet, index): View => {
+      return this.facetToView(facet, index);
     });
   }
 
@@ -194,6 +194,14 @@ export abstract class Facet<C extends FacetCfg<FacetData> = FacetCfg<FacetData>,
       if (isNumber(s)) return s / (idx === 0 ? width : height);
       else return parseFloat(s) / 100;
     });
+  }
+
+  /**
+   * 解析 padding
+   */
+  private parsePadding(padding: ViewPadding | ((idx: number) => ViewPadding), index: number) {
+    if (isFunction(padding)) return padding(index);
+    else return padding;
   }
 
   // 其他一些提供给子类使用的方法

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1668,7 +1668,7 @@ export interface FacetCfg<D> {
   /** 分面 view 之间的间隔， 百分比或像素值 */
   readonly spacing?: [number | string, number | string];
   /** facet view padding。 */
-  readonly padding?: ViewPadding;
+  readonly padding?: ViewPadding | ((index: number) => ViewPadding);
   /** 是否显示标题。 */
   readonly showTitle?: boolean;
   /** facet 数据划分维度。 */

--- a/tests/unit/facet/matrix/index-spec.ts
+++ b/tests/unit/facet/matrix/index-spec.ts
@@ -138,4 +138,110 @@ describe('facet matrix', () => {
     // @ts-ignore
     expect(chart.views[12].annotation().option[1].style.fill).toBe('red');
   });
+
+  it('padding', () => {
+    chart.facet('matrix', {
+      fields: ['SepalLength', 'SepalWidth', 'PetalLength', 'PetalWidth'],
+      padding: 10,
+      eachView(view, facet) {
+        if (facet.rowIndex === facet.columnIndex) {
+          // 对角线的图形，做数据封箱之后绘制图形
+          const dv = new DataSet.DataView();
+          dv.source(facet.data).transform({
+            type: 'bin.histogram',
+            field: facet.columnField, // 对应数轴上的一个点
+            bins: 30, // 分箱个数
+            as: [facet.columnField, 'count'],
+            groupBy: ['Species'],
+          });
+          view.data(dv.rows);
+
+          view
+            .interval()
+            .position(facet.columnField + '*count')
+            .color('Species', COLOR)
+            .adjust('stack')
+            .style({ opacity: 0.85 });
+        } else {
+          view
+            .point()
+            .position([facet.columnField, facet.rowField])
+            .color('Species', COLOR)
+            .shape('circle')
+            .style({ opacity: 0.3 })
+            .size(3);
+        }
+      },
+    });
+
+    chart.render();
+
+    const { viewBBox: vB0 } = chart.views[0];
+    const { coordinateBBox: cB0 } = chart.views[0];
+    expect(vB0.x).toBe(cB0.x - 10);
+    expect(vB0.y).toBe(cB0.y - 10);
+    expect(vB0.width).toBe(cB0.width + 10 * 2);
+    expect(vB0.height).toBe(cB0.height + 10 * 2);
+
+    const { viewBBox: vB1 } = chart.views[1];
+    const { coordinateBBox: cB1 } = chart.views[1];
+    expect(vB1.x).toBe(cB1.x - 10);
+    expect(vB1.y).toBe(cB1.y - 10);
+    expect(vB1.width).toBe(cB1.width + 10 * 2);
+    expect(vB1.height).toBe(cB1.height + 10 * 2);
+  });
+
+  it('padding callback', () => {
+    chart.facet('matrix', {
+      fields: ['SepalLength', 'SepalWidth', 'PetalLength', 'PetalWidth'],
+      padding: (idx) => idx * 10,
+      eachView(view, facet) {
+        if (facet.rowIndex === facet.columnIndex) {
+          // 对角线的图形，做数据封箱之后绘制图形
+          const dv = new DataSet.DataView();
+          dv.source(facet.data).transform({
+            type: 'bin.histogram',
+            field: facet.columnField, // 对应数轴上的一个点
+            bins: 30, // 分箱个数
+            as: [facet.columnField, 'count'],
+            groupBy: ['Species'],
+          });
+          view.data(dv.rows);
+
+          view
+            .interval()
+            .position(facet.columnField + '*count')
+            .color('Species', COLOR)
+            .adjust('stack')
+            .style({ opacity: 0.85 });
+        } else {
+          view
+            .point()
+            .position([facet.columnField, facet.rowField])
+            .color('Species', COLOR)
+            .shape('circle')
+            .style({ opacity: 0.3 })
+            .size(3);
+        }
+      },
+    });
+
+    chart.render();
+
+    // index: 0 -> padding: 0
+    const { viewBBox: vB0 } = chart.views[0];
+    const { coordinateBBox: cB0 } = chart.views[0];
+    expect(vB0.x).toBe(cB0.x);
+    expect(vB0.y).toBe(cB0.y);
+    expect(vB0.width).toBe(cB0.width);
+    expect(vB0.height).toBe(cB0.height);
+
+    // index: 1 -> padding: 10
+    const { viewBBox: vB1 } = chart.views[1];
+    const { coordinateBBox: cB1 } = chart.views[1];
+    expect(vB1.x).toBe(cB1.x - 10);
+    expect(vB1.y).toBe(cB1.y - 10);
+    expect(vB1.width).toBe(cB1.width + 10 * 2);
+    expect(vB1.height).toBe(cB1.height + 10 * 2);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
分面图 padding 支持回调方法对内边距进行单独设置
```ts
(index: number) => padding  // index 为子图索引
```