### PR TITLE
fix: crash on safari 15 when fillText with unicode

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
   "resolutions": {
     "monaco-editor": "0.21.3",
     "@babel/plugin-transform-spread": "7.12.1",
-    "d3-array": "2.12.1"
+    "d3-array": "2.12.1",
+    "normalize-url": "^4.5.1"
   }
 }

--- a/src/theme/style-sheet/dark.ts
+++ b/src/theme/style-sheet/dark.ts
@@ -81,7 +81,7 @@ export const createDarkStyleSheet = (cfg: StyleSheetCfg = {}) => {
     paletteSemanticGreen = '#30BF78',
     paletteSemanticYellow = '#FAAD14',
     paletteSequence = SINGLE_SEQUENCE,
-    fontFamily = `"-apple-system", "Segoe UI", Roboto, "Helvetica Neue", Arial,
+    fontFamily = `"Segoe UI", Roboto, "Helvetica Neue", Arial,
     "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji"`,
   } = cfg;

--- a/src/theme/style-sheet/light.ts
+++ b/src/theme/style-sheet/light.ts
@@ -81,7 +81,7 @@ export const createLightStyleSheet = (cfg: StyleSheetCfg = {}) => {
     paletteSemanticGreen = '#30BF78',
     paletteSemanticYellow = '#FAAD14',
     paletteSequence = SINGLE_SEQUENCE,
-    fontFamily = `"-apple-system", "Segoe UI", Roboto, "Helvetica Neue", Arial,
+    fontFamily = `"Segoe UI", Roboto, "Helvetica Neue", Arial,
     "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji"`,
   } = cfg;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] 官网在 safari 15 打不开，因为 normalize-url 代码导致的
- [x] 图表在 safari 15 崩溃，因为 ios 新系统对于 -apple-system 字体对中文支持有问题
- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
