### PR TITLE
fix(theme): remove -apple-system fontFamily for safari15 (close: #886)

### DIFF
--- a/examples/column/basic/demo/basic.ts
+++ b/examples/column/basic/demo/basic.ts
@@ -1,14 +1,14 @@
 import { Chart } from '@antv/g2';
 
 const data = [
-  { year: '1951 年', sales: 38 },
-  { year: '1952 年', sales: 52 },
-  { year: '1956 年', sales: 61 },
-  { year: '1957 年', sales: 145 },
-  { year: '1958 年', sales: 48 },
-  { year: '1959 年', sales: 38 },
-  { year: '1960 年', sales: 38 },
-  { year: '1962 年', sales: 38 },
+  { year: '1951', sales: 38 },
+  { year: '1952', sales: 52 },
+  { year: '1956', sales: 61 },
+  { year: '1957', sales: 145 },
+  { year: '1958', sales: 48 },
+  { year: '1959', sales: 38 },
+  { year: '1960', sales: 38 },
+  { year: '1962', sales: 38 },
 ];
 const chart = new Chart({
   container: 'container',
@@ -17,14 +17,6 @@ const chart = new Chart({
 });
 
 chart.data(data);
-chart.scale('sales', {
-  nice: true,
-});
-
-chart.tooltip({
-  showMarkers: false
-});
-chart.interaction('active-region');
 
 chart.interval().position('year*sales');
 

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
   "resolutions": {
     "monaco-editor": "0.21.3",
     "@babel/plugin-transform-spread": "7.12.1",
-    "d3-array": "2.12.1"
+    "d3-array": "2.12.1",
+    "normalize-url": "^4.5.1"
   }
 }

--- a/src/theme/style-sheet/dark.ts
+++ b/src/theme/style-sheet/dark.ts
@@ -81,7 +81,7 @@ export const createDarkStyleSheet = (cfg: StyleSheetCfg = {}) => {
     paletteSemanticGreen = '#30BF78',
     paletteSemanticYellow = '#FAAD14',
     paletteSequence = SINGLE_SEQUENCE,
-    fontFamily = `"-apple-system", "Segoe UI", Roboto, "Helvetica Neue", Arial,
+    fontFamily = `"Segoe UI", Roboto, "Helvetica Neue", Arial,
     "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji"`,
   } = cfg;

--- a/src/theme/style-sheet/light.ts
+++ b/src/theme/style-sheet/light.ts
@@ -81,7 +81,7 @@ export const createLightStyleSheet = (cfg: StyleSheetCfg = {}) => {
     paletteSemanticGreen = '#30BF78',
     paletteSemanticYellow = '#FAAD14',
     paletteSequence = SINGLE_SEQUENCE,
-    fontFamily = `"-apple-system", "Segoe UI", Roboto, "Helvetica Neue", Arial,
+    fontFamily = `"Segoe UI", Roboto, "Helvetica Neue", Arial,
     "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji"`,
   } = cfg;


### PR DESCRIPTION
**修复 safari15 图表绘制不出来的问题**
- 原因：Safari 升级到15之后，当 font 为 `-apple-system` 时，调用 `context.fillText` 绘制中文浏览器会崩溃。
```js
// 下面的代码在 Safari 升级到 15 之后浏览器会奔溃
const canvas = document.getElementById('container');
const context = canvas.getContext('2d');
context.font = '20px -apple-system';
context.fillText('中文 ', 10, 10);
```
- 修复方法：在主题中删除 -apple-system 这个字体