### PR TITLE
fix: 图例类型定义, 除了 marker 其它继承 component

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -20,6 +20,7 @@ import {
   ICanvas,
   IGroup,
   IShape,
+  CategoryLegendCfg,
   LegendBackgroundCfg,
   LegendItemNameCfg,
   LegendItemValueCfg,
@@ -912,7 +913,7 @@ export interface G2LegendTitleCfg extends LegendTitleCfg {
 /**
  * 图例项配置
  */
-export interface LegendCfg {
+export interface LegendCfg extends Omit<CategoryLegendCfg, 'marker'> {
   /**
    * 是否为自定义图例，当该属性为 true 时，需要声明 items 属性。
    */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

controller 层会透传 legendOption 给 component，所以类型定义可以继承

| Before | After |
|---|---|
|![image](https://user-images.githubusercontent.com/15646325/136492770-f3020483-d518-4192-bf2a-f4dc45c505af.png)|![image](https://user-images.githubusercontent.com/15646325/136492782-723823bf-2797-420d-948a-58c5dd58d01b.png)|
