### PR TITLE
先执行交互的destroy,在置空view等上下文信息

### DIFF
--- a/src/interaction/context.ts
+++ b/src/interaction/context.ts
@@ -138,12 +138,12 @@ export default class Context implements IInteractionContext {
    * 销毁
    */
   public destroy() {
-    this.view = null;
-    this.event = null;
     // 先销毁 action 再清空，一边遍历，一边删除，所以数组需要更新引用
     each(this.actions.slice(), (action) => {
       action.destroy();
     });
+    this.view = null;
+    this.event = null;
     this.actions = null;
     this.cacheMap = null;
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. [-->
动态移除交互时,action在销毁时需要执行一些操作,比如移除element的状态等,但是在调用action的destroy方法前,content下的view已经被置空了
所以修改了一下代码顺序