### PR TITLE
fix: 修复element设置层级zIndex的时候，需要考虑zIndexReversed

### DIFF
--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -259,7 +259,7 @@ export default class Geometry<S extends ShapePoint = ShapePoint> extends Base {
   /** 多层饼图/环图占比 */
   protected multiplePieWidthRatio: number;
   /** elements 的 zIndex 默认按顺序提升，通过 zIndexReversed 可以反序，从而数据越前，层级越高 */
-  protected zIndexReversed?: boolean;
+  public zIndexReversed?: boolean;
 
   /** 虚拟 Group，用于图形更新 */
   private offscreenGroup: IGroup;
@@ -1545,6 +1545,7 @@ export default class Geometry<S extends ShapePoint = ShapePoint> extends Base {
       const element = this.createElement(mappingDatum, i, isUpdate);
       this.elements[i] = element;
       this.elementsMap[key] = element;
+      element.shape.setZIndex(this.zIndexReversed ? this.elements.length - i : i);
     }
 
     // 更新 element
@@ -1561,6 +1562,7 @@ export default class Geometry<S extends ShapePoint = ShapePoint> extends Base {
       }
       this.elements[i] = element;
       this.elementsMap[key] = element;
+      element.shape.setZIndex(this.zIndexReversed ? this.elements.length - i : i);
     }
 
     // 销毁被删除的 elements
@@ -1569,15 +1571,6 @@ export default class Geometry<S extends ShapePoint = ShapePoint> extends Base {
       // 更新动画配置，用户有可能在更新之前有对动画进行配置操作
       element.animate = this.animateOption;
       element.destroy();
-    }
-
-    const length = this.elements.length;
-    for (let i = 0; i < length; i++) {
-      // 若 zIndexReversed, 则对 elements 的 zIndex 进行反序；否则按序设置 zIndex
-      const shape = this.elements[i].shape;
-      if (shape) {
-        shape.setZIndex(this.zIndexReversed ? length - i : i);
-      }
     }
   }
 

--- a/src/geometry/element/index.ts
+++ b/src/geometry/element/index.ts
@@ -229,7 +229,11 @@ export default class Element extends Base {
       }
       states.splice(index, 1);
       if (stateName === 'active' || stateName === 'selected') {
-        shape.setZIndex(this.elementIndex);
+        if (this.geometry.zIndexReversed) {
+          shape.setZIndex(this.geometry.elements.length - this.elementIndex);
+        } else {
+          shape.setZIndex(this.elementIndex);
+        }
       }
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
连通 #3671 , 可以解决的问题：
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/15646325/137612538-2c6e8860-5007-4032-81ae-92d52b51d3d7.png)|![image](https://user-images.githubusercontent.com/15646325/137612560-d7463de0-3f03-4b45-8a41-e8ffdda646e2.png)交互之后，可以返回原位|
