### PR TITLE
fix: #3723 dataMarker 和 slider一起使用的时候，当标记点不属于当前缩略轴显示的范围之中时，会渲染到(0, 0)点

### DIFF
--- a/src/chart/controller/annotation.ts
+++ b/src/chart/controller/annotation.ts
@@ -680,10 +680,16 @@ export default class Annotation extends Controller<BaseOption[]> {
 
       // 忽略掉一些配置
       omit(cfg, ['container']);
-      co.component.update(cfg);
-      // 对于 regionFilter/shape，因为生命周期的原因，需要额外 render
-      if (includes(ANNOTATIONS_AFTER_RENDER, option.type)) {
-        co.component.render();
+
+      if (includes(['text', 'dataMarker', 'html'], type) && (isNaN(cfg['x']) || isNaN(cfg['y']))) {
+        co.component.hide();
+      } else {
+        co.component.update(cfg);
+        co.component.show();
+        // 对于 regionFilter/shape，因为生命周期的原因，需要额外 render
+        if (includes(ANNOTATIONS_AFTER_RENDER, option.type)) {
+          co.component.render();
+        }
       }
     } else {
       // 不存在，创建

--- a/tests/bugs/3723-spec.ts
+++ b/tests/bugs/3723-spec.ts
@@ -1,0 +1,123 @@
+import 'jest-extended';
+import { Chart } from '../../src/chart';
+import { COMPONENT_TYPE } from '../../src/constant';
+import { delay } from '../util/delay';
+import { createDiv } from '../util/dom';
+
+const DATA = [
+  {
+    Time: '0:00',
+    Count: 489,
+  },
+  {
+    Time: '1:00',
+    Count: 389,
+  },
+  {
+    Time: '2:00',
+    Count: 0,
+  },
+  {
+    Time: '3:00',
+    Count: 0,
+  },
+  {
+    Time: '4:00',
+    Count: 0,
+  },
+  {
+    Time: '5:00',
+    Count: 0,
+  },
+  {
+    Time: '6:00',
+    Count: 0,
+  },
+  {
+    Time: '7:00',
+    Count: 0,
+  },
+  {
+    Time: '8:00',
+    Count: 632,
+  },
+  {
+    Time: '9:00',
+    Count: 2250,
+  },
+  {
+    Time: '10:00',
+    Count: 2858,
+  },
+  {
+    Time: '11:00',
+    Count: 3287,
+  },
+  {
+    Time: '12:00',
+    Count: 2899,
+  },
+];
+
+describe('dataMarker', () => {
+  const container = createDiv();
+
+  const chart = new Chart({
+    container,
+    autoFit: true,
+    height: 500,
+  });
+
+  chart.data(DATA);
+  chart.line().position('Time*Count');
+
+  chart.render();
+
+  it('dataMarker annotation over view', async () => {
+    chart.annotation().dataMarker({
+      position: ['9:00', 2250],
+      text: {
+        content: 'value：2250',
+        style: {
+          textAlign: 'left',
+        },
+      },
+      point: {
+        style: {
+          fill: 'red',
+          stroke: 'red',
+        },
+      },
+      line: {
+        length: 20,
+      },
+    });
+
+    chart.option('slider', {
+      start: 0,
+      end: 1,
+    });
+
+    chart.render();
+
+    let dataMarker = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.ANNOTATION)[0].component;
+
+    await delay(700);
+
+    expect(dataMarker.get('type')).toEqual('dataMarker');
+    expect(dataMarker.get('visible')).toEqual(true);
+
+    chart.option('slider', {
+      start: 0,
+      end: 0.5,
+    });
+
+    chart.render();
+
+    dataMarker = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.ANNOTATION)[0].component;
+
+    await delay(700);
+
+    expect(dataMarker.get('visible')).toEqual(false);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
fix #3723 