### PR TITLE
fix(scrollbar): Scale option tickMethod doesn't work with scrollbar

### DIFF
--- a/src/chart/controller/scrollbar.ts
+++ b/src/chart/controller/scrollbar.ts
@@ -247,6 +247,7 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
         type: cfg.type as ScaleOption['type'],
         min: cfg.min,
         max: cfg.max,
+        tickMethod: cfg.tickMethod
       });
     });
     this.view.filter(this.xScaleCfg.field, (val) => {


### PR DESCRIPTION
…llbar

The tickMethod option is drop when enable scrollbar, only min,max,type,foratter are passed.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
