### PR TITLE
fix(slider,scrollbar): 滚动条和缩略轴 在xScale 为线性时筛选错误的问题

### DIFF
--- a/src/chart/controller/scrollbar.ts
+++ b/src/chart/controller/scrollbar.ts
@@ -55,7 +55,7 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
     this.view.off(VIEW_LIFE_CIRCLE.BEFORE_CHANGE_SIZE, this.resetMeasure);
   }
 
-  public init() {}
+  public init() { }
 
   /**
    * 渲染
@@ -239,14 +239,12 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
   private changeViewData([startIdx, endIdx]: [number, number], render?: boolean): void {
     const { type } = this.getValidScrollbarCfg();
     const isHorizontal = type !== 'vertical';
-    let values = valuesOfKey(this.data, this.xScaleCfg.field);
+    const values = valuesOfKey(this.data, this.xScaleCfg.field);
 
     // 如果是 xScale 数值类型，则进行排序
-    if (this.view.getXScale().isLinear) {
-      values = values.sort();
-    }
+    const xScaleValues = this.view.getXScale().isLinear ? values.sort() : values;
 
-    const xValues = isHorizontal ? values : values.reverse();
+    const xValues = isHorizontal ? xScaleValues : xScaleValues.reverse();
     this.yScalesCfg.forEach((cfg) => {
       this.view.scale(cfg.field, {
         formatter: cfg.formatter,

--- a/src/chart/controller/scrollbar.ts
+++ b/src/chart/controller/scrollbar.ts
@@ -239,7 +239,13 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
   private changeViewData([startIdx, endIdx]: [number, number], render?: boolean): void {
     const { type } = this.getValidScrollbarCfg();
     const isHorizontal = type !== 'vertical';
-    const values = valuesOfKey(this.data, this.xScaleCfg.field);
+    let values = valuesOfKey(this.data, this.xScaleCfg.field);
+
+    // 如果是 xScale 数值类型，则进行排序
+    if (this.view.getXScale().isLinear) {
+      values = values.sort();
+    }
+
     const xValues = isHorizontal ? values : values.reverse();
     this.yScalesCfg.forEach((cfg) => {
       this.view.scale(cfg.field, {
@@ -280,11 +286,11 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
     const config = this.getScrollbarComponentCfg();
     const realConfig = this.trackLen
       ? {
-          ...config,
-          trackLen: this.trackLen,
-          thumbLen: this.thumbLen,
-          thumbOffset: (this.trackLen - this.thumbLen) * this.ratio,
-        }
+        ...config,
+        trackLen: this.trackLen,
+        thumbLen: this.thumbLen,
+        thumbOffset: (this.trackLen - this.thumbLen) * this.ratio,
+      }
       : { ...config };
     this.scrollbar.component.update(realConfig);
 
@@ -319,13 +325,13 @@ export default class Scrollbar extends Controller<ScrollbarOption> {
     const [paddingTop, paddingRight, paddingBottom, paddingLeft] = padding;
     const position = isHorizontal
       ? {
-          x: coordinateBBox.minX + paddingLeft,
-          y: viewBBox.maxY - height - paddingBottom,
-        }
+        x: coordinateBBox.minX + paddingLeft,
+        y: viewBBox.maxY - height - paddingBottom,
+      }
       : {
-          x: viewBBox.maxX - width - paddingRight,
-          y: coordinateBBox.minY + paddingTop,
-        };
+        x: viewBBox.maxX - width - paddingRight,
+        y: coordinateBBox.minY + paddingTop,
+      };
     const step = this.getStep();
     const cnt = this.getCnt();
     const trackLen = isHorizontal

--- a/src/chart/controller/slider.ts
+++ b/src/chart/controller/slider.ts
@@ -272,7 +272,13 @@ export default class Slider extends Controller<SliderOption> {
     const data = this.view.getOptions().data;
     const xScale = this.view.getXScale();
     const isHorizontal = true;
-    const values = valuesOfKey(data, xScale.field);
+    let values = valuesOfKey(data, xScale.field);
+ 
+    // 如果是 xScale 数值类型，则进行排序
+    if (xScale.isLinear) {
+      values = values.sort();
+    }
+
     const xValues = isHorizontal ? values : values.reverse();
     const dataSize = size(data);
 
@@ -313,7 +319,13 @@ export default class Slider extends Controller<SliderOption> {
       return;
     }
     const isHorizontal = true;
-    const values = valuesOfKey(data, xScale.field);
+    let values = valuesOfKey(data, xScale.field);
+
+    // 如果是 xScale 数值类型，则进行排序
+    if (xScale.isLinear) {
+      values = values.sort();
+    }
+  
     const xValues = isHorizontal ? values : values.reverse();
     const xTickCount = size(xValues);
 

--- a/src/chart/controller/slider.ts
+++ b/src/chart/controller/slider.ts
@@ -319,14 +319,12 @@ export default class Slider extends Controller<SliderOption> {
       return;
     }
     const isHorizontal = true;
-    let values = valuesOfKey(data, xScale.field);
+    const values = valuesOfKey(data, xScale.field);
 
     // 如果是 xScale 数值类型，则进行排序
-    if (xScale.isLinear) {
-      values = values.sort();
-    }
+    const xScaleValues = this.view.getXScale().isLinear ? values.sort() : values;
   
-    const xValues = isHorizontal ? values : values.reverse();
+    const xValues = isHorizontal ? xScaleValues : xScaleValues.reverse();
     const xTickCount = size(xValues);
 
     const minIndex = Math.floor(min * (xTickCount - 1));

--- a/tests/bugs/scrollbar-xscale-linear-spec.ts
+++ b/tests/bugs/scrollbar-xscale-linear-spec.ts
@@ -1,0 +1,51 @@
+import { Chart } from '../../src';
+import { delay } from '../util/delay';
+import { createDiv, removeDom } from '../util/dom';
+
+const Data = [
+  { year: 1999, value: 13 },
+  { year: 1992, value: 4 },
+  { year: 1993, value: 3.5 },
+  { year: 1994, value: 5 },
+  { year: 1995, value: 4.9 },
+  { year: 1996, value: 6 },
+  { year: 1997, value: 7 },
+  { year: 1998, value: 9 },
+  { year: 1991, value: 3 },
+];
+
+describe('Scrollbar', () => {
+  const div = createDiv();
+
+  const chart = new Chart({
+    container: div,
+    height: 500,
+    width: 300,
+  });
+
+  chart.data(Data);
+
+  chart.option('scrollbar', {});
+
+  chart.interval().position('year*value');
+  chart.render();
+
+  it('xScale linear', async () => {
+    const scrollbar = chart.getController('scrollbar');
+
+    await delay(1);
+    scrollbar.setValue(0);
+    // @ts-ignore
+    expect(chart.filteredData.find(data => data['year'] === 1991)).toEqual({ year: 1991, value: 3 });
+
+    await delay(1);
+    scrollbar.setValue(1);
+    // @ts-ignore
+    expect(chart.filteredData.find(data => data['year'] === 1999)).toEqual({ year: 1999, value: 13 });
+  });
+
+  afterAll(() => {
+    chart.destroy();
+    removeDom(div);
+  });
+});

--- a/tests/bugs/slider-xscale-linear-spec.ts
+++ b/tests/bugs/slider-xscale-linear-spec.ts
@@ -1,0 +1,47 @@
+import { COMPONENT_TYPE } from '../../src/constant';
+import { Chart } from '../../src/index';
+import { delay } from '../util/delay';
+import { createDiv, removeDom } from '../util/dom';
+
+const Data = [
+  { year: 1999, value: 13 },
+  { year: 1992, value: 4 },
+  { year: 1993, value: 3.5 },
+  { year: 1994, value: 5 },
+  { year: 1995, value: 4.9 },
+  { year: 1996, value: 6 },
+  { year: 1997, value: 7 },
+  { year: 1998, value: 9 },
+  { year: 1991, value: 3 },
+];
+
+describe('Slider', () => {
+  const div = createDiv();
+
+  const chart = new Chart({
+    container: div,
+    height: 500,
+    width: 600,
+  });
+
+  chart.data(Data);
+
+  chart.option('slider', {});
+
+  chart.interval().position('year*value');
+  chart.render();
+
+  it('xScale linear', async () => {
+    await delay(1);
+    const [slider] = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.SLIDER);
+    const { component: sliderComponent } = slider;
+    
+    expect(sliderComponent.get('minText')).toBe(1991);
+    expect(sliderComponent.get('maxText')).toBe(1999);
+  });
+
+  afterAll(() => {
+    chart.destroy();
+    removeDom(div);
+  });
+});


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/65594180/147814754-52bd636d-56fb-4909-9751-2c44b333e237.png)
开始值和结束值都是按照 data 原始的顺序来的， 而线性xScale 会排列数据， 导致 滚动条和缩略轴 交互不是线性的，而是 cat的

- [x] 滚动条
![image](https://user-images.githubusercontent.com/65594180/147813249-b4a122c6-c0f8-4d71-b5b7-c223ccba06a9.png)
- [x] 缩略轴
![image](https://user-images.githubusercontent.com/65594180/147813281-543ea8e8-8e75-4b6d-8601-d28934e9cc29.png)

