### PR TITLE
fix(issue-3723): 修复annotation 在筛选条件下，范围外的标注不需要展示

### DIFF
--- a/tests/bugs/3723-spec.ts
+++ b/tests/bugs/3723-spec.ts
@@ -1,0 +1,117 @@
+import 'jest-extended';
+import { Chart } from '../../src/chart';
+import { COMPONENT_TYPE } from '../../src/constant';
+import { delay } from '../util/delay';
+import { createDiv } from '../util/dom';
+
+const DATA = [
+  {
+    Time: '0:00',
+    Count: 489,
+  },
+  {
+    Time: '1:00',
+    Count: 389,
+  },
+  {
+    Time: '2:00',
+    Count: 0,
+  },
+  {
+    Time: '3:00',
+    Count: 0,
+  },
+  {
+    Time: '4:00',
+    Count: 0,
+  },
+  {
+    Time: '5:00',
+    Count: 0,
+  },
+  {
+    Time: '6:00',
+    Count: 0,
+  },
+  {
+    Time: '7:00',
+    Count: 0,
+  },
+  {
+    Time: '8:00',
+    Count: 632,
+  },
+  {
+    Time: '9:00',
+    Count: 2250,
+  },
+  {
+    Time: '10:00',
+    Count: 2858,
+  },
+  {
+    Time: '11:00',
+    Count: 3287,
+  },
+  {
+    Time: '12:00',
+    Count: 2899,
+  },
+];
+
+describe('dataMarker', () => {
+  const container = createDiv();
+
+  const chart = new Chart({
+    container,
+    autoFit: true,
+    height: 500,
+  });
+
+  chart.data(DATA);
+  chart.line().position('Time*Count');
+
+  chart.render();
+
+  it('dataMarker annotation over view', async () => {
+    chart.annotation().dataMarker({
+      position: ['9:00', 2250],
+      text: {
+        content: 'value：2250',
+        style: {
+          textAlign: 'left',
+        },
+      },
+      point: {
+        style: {
+          fill: 'red',
+          stroke: 'red',
+        },
+      },
+      line: {
+        length: 20,
+      },
+    });
+
+    chart.option('slider', {
+      start: 0,
+      end: 1,
+    });
+
+    chart.render();
+    let dataMarker = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.ANNOTATION)[0].component;
+    await delay(60);
+    expect(dataMarker.get('visible')).not.toEqual(false);
+
+    chart.option('slider', {
+      start: 0,
+      end: 0.5,
+    });
+
+    chart.render();
+
+    dataMarker = chart.getComponents().filter((co) => co.type === COMPONENT_TYPE.ANNOTATION)[0].component;
+    await delay(60);
+    expect(dataMarker.get('visible')).toEqual(false);
+  });
+});


### PR DESCRIPTION
1、parsePosition 后的位置如果存在 NaN 时，直接返回 null；从 annotationCfg 为 null 的情况下，来决定 visible 是否展示
2、主要场景是：filterData 的场景下

close: https://github.com/antvis/G2/issues/3723
close: https://github.com/antvis/G2/pull/3730