### PR TITLE
fix(interval): 修复转置后的圆角条形图渲染多出一部分

### DIFF
--- a/src/geometry/shape/interval/util.ts
+++ b/src/geometry/shape/interval/util.ts
@@ -269,7 +269,6 @@ export function getRectWithCornerRadius(points: Point[], coordinate: Coordinate,
 
   if (coordinate.isTransposed) {
     [p1, p3] = swap(p1, p3);
-    [r1, r2, r3, r4] = [r4, r1, r2, r3]
   }
 
   /**
@@ -300,6 +299,10 @@ export function getRectWithCornerRadius(points: Point[], coordinate: Coordinate,
    */
   const abs = v => Math.abs(v);
   [r1, r2, r3, r4] = parseRadius([r1, r2, r3, r4], Math.min(abs(p3.x - p0.x), abs(p1.y - p0.y))).map(d => abs(d));
+
+  if (coordinate.isTransposed) {
+    [r1, r2, r3, r4] = [r4, r1, r2, r3]
+  }
 
   if (p0.y < p1.y /** 负数情况 */) {
     path.push(['M', p3.x, p3.y + r3]);

--- a/tests/unit/geometry/shape/interval-util-spec.ts
+++ b/tests/unit/geometry/shape/interval-util-spec.ts
@@ -218,6 +218,42 @@ describe('绘制 interval shape 的一些 utils', () => {
     ]);
   });
 
+  it('直角坐标系：corner-radius大于rect最小边长的一半', () => {
+    const rectCoord = new CartesianCoordinate(region);
+
+    const path = getRectWithCornerRadius(
+      [
+        { x: 60, y: 150 },
+        { x: 60, y: 0 },
+        { x: 120, y: 0 },
+        { x: 120, y: 150 },
+      ],
+      rectCoord,
+      45
+    );
+    /**
+     * 从 p1 开始绘制，对应的 radius: [r1, r2, r3, r0]
+     * p1 ----> p2
+     * ↑        |
+     * |        |
+     * |        |
+     * |        ↓
+     * P0 <---- P3
+     */
+    expect(path).toEqual([
+      ['M', 60, 30],
+      ['A', 30, 30, 0, 0, 1, 90, 0],
+      ['L', 90, 0],
+      ['A', 30, 30, 0, 0, 1, 120, 30],
+      ['L', 120, 120],
+      ['A', 30, 30, 0, 0, 1, 90, 150],
+      ['L', 90, 150],
+      ['A', 30, 30, 0, 0, 1, 60, 120],
+      ['L', 60, 30],
+      ['z'],
+    ]);
+  });
+
   it('直角坐标系, 转置: 带 corner-radius 的 rect', () => {
     const rectCoord = new CartesianCoordinate(region);
     rectCoord.transpose();
@@ -309,4 +345,36 @@ describe('绘制 interval shape 的一些 utils', () => {
       ['z'],
     ]);
   });
+
+  it('直角坐标系， 转置，corner-radius大于rect最小边长的一半', () => {
+    const rectCoord = new CartesianCoordinate(region);
+    rectCoord.transpose();
+
+    const points = [
+      { x: 210, y: 150 },
+      { x: 60, y: 150 },
+      { x: 60, y: 90 },
+      { x: 210, y: 90 },
+    ];
+    const path = getRectWithCornerRadius(
+      points,
+      rectCoord,
+      45
+    );
+
+    expect(path).toEqual([
+      ['M', 90, 90],
+      ['A', 30, 30, 0, 0, 0, 60, 120],
+      ['L', 60, 120],
+      ['A', 30, 30, 0, 0, 0, 90, 150],
+      ['L', 180, 150],
+      ['A', 30, 30, 0, 0, 0, 210, 120],
+      ['L', 210, 120],
+      ['A', 30, 30, 0, 0, 0, 180, 90],
+      ['L', 90, 90],
+      ['z'],
+    ]);
+
+  });
+
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [✅] `npm test` passes
- [✅ ] tests and/or benchmarks are included
- [✅ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

复现条件：
转置后的圆角条形图，当radius大于最小边的长度时，渲染会多出一部分，复现链接：https://codesandbox.io/s/purple-violet-v7vfly

修改方法：
parseRadius处理边界值的时候只处理了非转置情况，所以先调用parseRadius，再转置

