### PR TITLE
fix(fetch): add useMemoConnector to memorize fetch

### DIFF
--- a/__tests__/unit/transform/fetch.spec.ts
+++ b/__tests__/unit/transform/fetch.spec.ts
@@ -15,7 +15,7 @@ describe('Fetch', () => {
     ]);
   });
 
-  it('Fetch({...} returns a function calling  callback on each datum', async () => {
+  it('Fetch({...} returns a function calling callback on each datum', async () => {
     const transform = Fetch({
       url: 'https://gw.alipayobjects.com/os/bmw-prod/ce45e3d7-ba78-4a08-b411-28df40ef9b7f.json',
       callback: ({ sold, ...rest }) => ({ sold: `${sold}`, ...rest }),

--- a/__tests__/unit/transform/utils.spec.ts
+++ b/__tests__/unit/transform/utils.spec.ts
@@ -1,6 +1,7 @@
 import {
   useAsyncMemoTransform,
   useMemoTransform,
+  useMemoConnector,
 } from '../../../src/transform/utils/memo';
 
 describe('useMemo', () => {
@@ -77,5 +78,31 @@ describe('useMemo', () => {
     const r7 = await t3(1);
     expect(r7).toBe(3);
     expect(fn).toBeCalledTimes(4);
+  });
+
+  it('useMemoConnector returns a async function ignoring change of data reference', async () => {
+    const fn = jest.fn();
+
+    const Connector = useMemoConnector(({ a, b }: { a: number; b: number }) => {
+      return async () => {
+        fn();
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        return a + b;
+      };
+    });
+
+    const c1 = Connector({ a: 1, b: 1 });
+    const r1 = await c1({});
+    expect(r1).toBe(2);
+
+    const c2 = Connector({ a: 1, b: 1 });
+    const r2 = await c2({});
+    expect(r2).toBe(2);
+    expect(fn).toBeCalledTimes(1);
+
+    const c3 = Connector({ a: 1, b: 2 });
+    const r3 = await c3({});
+    expect(r3).toBe(3);
+    expect(fn).toBeCalledTimes(2);
   });
 });

--- a/src/transform/fetch.ts
+++ b/src/transform/fetch.ts
@@ -1,7 +1,7 @@
 import { identity } from '../utils/helper';
 import { TransformComponent as TC } from '../runtime';
 import { FetchTransform } from '../spec';
-import { useAsyncMemoTransform } from './utils/memo';
+import { useMemoConnector } from './utils/memo';
 
 export type FetchOptions = Omit<FetchTransform, 'type'>;
 
@@ -18,6 +18,6 @@ const Transform: TC<FetchOptions> = (options) => {
  * Fetch resource in different format asynchronously across the network.
  * @todo Support more formats (e.g., csv, dsv).
  */
-export const Fetch = useAsyncMemoTransform(Transform);
+export const Fetch = useMemoConnector(Transform);
 
 Fetch.props = {};

--- a/src/transform/utils/memo.ts
+++ b/src/transform/utils/memo.ts
@@ -52,3 +52,22 @@ export function useAsyncMemoTransform<T>(
     };
   };
 }
+
+/**
+ * Returns a async function returning memoized connector transform.
+ * The memoized value will recompute only when options has changed
+ * and ignore data.
+ */
+export function useMemoConnector<T>(
+  callbackFn: TransformComponent<T>,
+): TransformComponent<T> {
+  const cache = {};
+  return (options) => {
+    const connector = callbackFn(options);
+    const key = JSON.stringify(options, withFunction);
+    return async () => {
+      cache[key] = cache[key] || (await connector());
+      return cache[key];
+    };
+  };
+}


### PR DESCRIPTION
Connector transform should ignore the change of data reference when memorize it.

```js
// Before
const fetch = Fetch({url:'xxx'});

// This will fetch twice because the two calls of fetch have different {}
fetch({});
fetch({});
```

```js
// After
const fetch = Fetch({url:'xxx'});

// This will fetch only once because  fetch ignore the change of {}
fetch({});
fetch({});
```