### PR TITLE
refactor(runtime): separate compute and render logic for plotting a view

### DIFF
--- a/__tests__/unit/composition/mark.spec.ts
+++ b/__tests__/unit/composition/mark.spec.ts
@@ -1,0 +1,55 @@
+import { Mark } from '../../../src/composition';
+
+describe('composition', () => {
+  it('Mark({...}) should propagate data and transform to standard Mark', () => {
+    const composition = Mark();
+    const options = {
+      type: 'interval',
+      width: 200,
+      height: 100,
+      paddingLeft: 10,
+      paddingBottom: 20,
+      paddingRight: 30,
+      paddingTop: 40,
+      theme: { defaultColor: 'red' },
+      x: 10,
+      y: 20,
+      component: [{ type: 'title' }],
+      data: [1, 2, 3],
+      scale: { x: { type: 'log' } },
+      interaction: [{ type: 'elementActive' }],
+      coordinate: [{ type: 'polar' }],
+      transform: [{ type: 'sortBy' }],
+      statistic: [{ type: 'stackY' }],
+      key: '0',
+    };
+    expect(composition(options)).toEqual([
+      {
+        type: 'standardView',
+        theme: { defaultColor: 'red' },
+        interaction: [{ type: 'elementActive' }],
+        key: '0',
+        width: 200,
+        height: 100,
+        paddingLeft: 10,
+        paddingBottom: 20,
+        paddingRight: 30,
+        paddingTop: 40,
+        x: 10,
+        y: 20,
+        component: [{ type: 'title' }],
+        coordinate: [{ type: 'polar' }],
+        marks: [
+          {
+            key: '0-0',
+            data: [1, 2, 3],
+            scale: { x: { type: 'log' } },
+            type: 'interval',
+            transform: [{ type: 'sortBy' }],
+            statistic: [{ type: 'stackY' }],
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/__tests__/unit/composition/view.spec.ts
+++ b/__tests__/unit/composition/view.spec.ts
@@ -1,0 +1,18 @@
+import { View } from '../../../src/composition';
+
+describe('composition', () => {
+  it('View({...}) should propagate data and transform to standard view', () => {
+    const composition = View();
+    const options = {
+      type: 'view',
+      data: [1, 2, 3],
+      children: [{ data: [2, 3, 4] }, {}],
+    };
+    expect(composition(options)).toEqual([
+      {
+        type: 'standardView',
+        marks: [{ data: [2, 3, 4] }, { data: [1, 2, 3] }],
+      },
+    ]);
+  });
+});

--- a/__tests__/unit/stdlib/index.spec.ts
+++ b/__tests__/unit/stdlib/index.spec.ts
@@ -88,7 +88,7 @@ import {
   Plot,
 } from '../../../src/action';
 import { MousePosition, TouchPosition } from '../../../src/interactor';
-import { Layer, Flex } from '../../../src/composition';
+import { Layer, Flex, Mark, View } from '../../../src/composition';
 
 describe('stdlib', () => {
   it('createLibrary() should returns expected builtin', () => {
@@ -169,6 +169,8 @@ describe('stdlib', () => {
       'interactor.touchPosition': TouchPosition,
       'composition.layer': Layer,
       'composition.flex': Flex,
+      'composition.mark': Mark,
+      'composition.view': View,
     });
   });
 });

--- a/src/animation/utils.ts
+++ b/src/animation/utils.ts
@@ -8,9 +8,9 @@ export function effectTiming(
 ): Record<string, any> {
   const { enter = {} } = theme;
   return Container.of({})
-    .map(assignDefined, enter)
-    .map(assignDefined, style)
-    .map(assignDefined, options)
+    .call(assignDefined, enter)
+    .call(assignDefined, style)
+    .call(assignDefined, options)
     .value();
 }
 

--- a/src/composition/flex.ts
+++ b/src/composition/flex.ts
@@ -1,7 +1,7 @@
 import { CompositionComponent as CC } from '../runtime';
-import { Flex as FlexSpec } from '../spec';
+import { FlexComposition } from '../spec';
 
-export type FlexOptions = Omit<FlexSpec, 'type'>;
+export type FlexOptions = Omit<FlexComposition, 'type'>;
 
 export const Flex: CC<FlexOptions> = () => {
   return (options) => {

--- a/src/composition/index.ts
+++ b/src/composition/index.ts
@@ -1,2 +1,4 @@
 export { Layer, LayerOptions } from './layer';
 export { Flex, FlexOptions } from './flex';
+export { View, ViewOptions } from './view';
+export { Mark, MarkOptions } from './mark';

--- a/src/composition/layer.ts
+++ b/src/composition/layer.ts
@@ -1,7 +1,7 @@
 import { CompositionComponent as CC } from '../runtime';
-import { Layer as LayerSpec } from '../spec';
+import { LayerComposition } from '../spec';
 
-export type LayerOptions = Omit<LayerSpec, 'type'>;
+export type LayerOptions = Omit<LayerComposition, 'type'>;
 
 export const Layer: CC<LayerOptions> = () => {
   return (options) => {

--- a/src/composition/mark.ts
+++ b/src/composition/mark.ts
@@ -1,0 +1,47 @@
+import { CompositionComponent as CC } from '../runtime';
+import { MarkComposition } from '../spec';
+
+export type MarkOptions = Omit<MarkComposition, 'type'>;
+
+export const Mark: CC<MarkOptions> = () => {
+  return (options) => {
+    const {
+      width,
+      height,
+      paddingLeft,
+      paddingRight,
+      paddingTop,
+      paddingBottom,
+      data,
+      coordinate,
+      theme,
+      component,
+      interaction,
+      x,
+      y,
+      key,
+      ...mark
+    } = options;
+    return [
+      {
+        type: 'standardView',
+        x,
+        y,
+        key,
+        width,
+        height,
+        paddingLeft,
+        paddingRight,
+        paddingTop,
+        paddingBottom,
+        theme,
+        coordinate,
+        component,
+        interaction,
+        marks: [{ ...mark, key: `${key}-0`, data }],
+      },
+    ];
+  };
+};
+
+Mark.props = {};

--- a/src/composition/view.ts
+++ b/src/composition/view.ts
@@ -1,0 +1,17 @@
+import { CompositionComponent as CC } from '../runtime';
+import { ViewComposition } from '../spec';
+
+export type ViewOptions = Omit<ViewComposition, 'type'>;
+
+export const View: CC<ViewOptions> = () => {
+  return (options) => {
+    const { children = [], data: viewData, ...rest } = options;
+    const marks = children.map(({ data = viewData, ...rest }) => ({
+      data,
+      ...rest,
+    }));
+    return [{ ...rest, marks, type: 'standardView' }];
+  };
+};
+
+View.props = {};

--- a/src/runtime/interaction.ts
+++ b/src/runtime/interaction.ts
@@ -1,6 +1,7 @@
 import { throttle } from '@antv/util';
 import { group } from 'd3-array';
 import { composeAsync } from '../utils/helper';
+import { Selection } from '../utils/selection';
 import {
   G2View,
   G2Library,
@@ -21,6 +22,7 @@ import { useLibrary } from './library';
 
 export function applyInteraction(
   options: G2View,
+  selection: Selection,
   view: G2ViewDescriptor,
   update: any,
   library: G2Library,
@@ -42,7 +44,7 @@ export function applyInteraction(
 
   const { interaction: partialInteraction = [] } = options;
   const interactions = inferInteraction(partialInteraction);
-  const { scale, selection, coordinate, theme } = view;
+  const { scale, coordinate, theme } = view;
 
   for (const options of interactions) {
     const {

--- a/src/runtime/mark.ts
+++ b/src/runtime/mark.ts
@@ -1,7 +1,7 @@
 import { compose, composeAsync } from '../utils/helper';
 import { indexOf, mapObject, transpose, isFlatArray } from '../utils/array';
 import { useLibrary } from './library';
-import { G2Theme } from './types/common';
+import { G2MarkState, G2Theme } from './types/common';
 import {
   MarkProps,
   Transform,
@@ -34,7 +34,7 @@ export async function initializeMark(
   theme: G2Theme,
   options: G2View,
   library: G2Library,
-): Promise<[G2Mark, MarkProps]> {
+): Promise<[G2Mark, G2MarkState]> {
   const [useTransform] = useLibrary<
     G2TransformOptions,
     TransformComponent,
@@ -153,9 +153,10 @@ export async function initializeMark(
   for (const channel of channels) {
     const { name } = channel;
     const { shapes } = partialProps;
+    const { [name]: options = {} } = partialScale;
     scale[name] = inferScale(
       channel,
-      partialScale[name] || {},
+      options,
       coordinate,
       shapes,
       theme,
@@ -171,8 +172,8 @@ export async function initializeMark(
     scale,
     data: transformedData,
   };
-  const props = { ...partialProps, channels, index: transformedIndex };
-  return [mark, props];
+  const state = { ...partialProps, channels, index: transformedIndex };
+  return [mark, state];
 }
 
 // This is for scale type inference.

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -154,6 +154,8 @@ async function initializeView(
   placeComponents(components, coordinate, layout);
 
   // Calc data to be rendered for each mark.
+  // @todo More readable APIs for Container which stays
+  // the same style with JS standard and lodash APIs.
   const scale = {};
   for (const [mark, state] of markState.entries()) {
     const { scale: scaleDescriptor, style = {}, animate = {} } = mark;
@@ -253,9 +255,7 @@ async function plotView(
           .call(updateMainLayers, Array.from(markState.keys())),
     );
 
-  // Render marks with corresponding props.
-  // @todo More readable APIs for Container which stays
-  // the same style with JS standard and lodash APIs.
+  // Render marks with corresponding data.
   for (const [{ key }, { data }] of markState.entries()) {
     selection
       .select(`#${key}`)

--- a/src/runtime/render.ts
+++ b/src/runtime/render.ts
@@ -17,7 +17,7 @@ function inferKeys<T extends G2ViewTree = G2ViewTree>(options: T): T {
   const nodeIndex = new Map<T, number>([[null, -1]]);
   const discovered = [root];
   while (discovered.length) {
-    const node = discovered.pop();
+    const node = discovered.shift();
     // If key of node is not specified, using parentKey and the index for it
     // in parent.children as its key.
     // e.g. The key of node named 'a' will be 'a', and the key of node named

--- a/src/runtime/types/common.ts
+++ b/src/runtime/types/common.ts
@@ -1,6 +1,6 @@
 import { Coordinate } from '@antv/coord';
-import { Selection } from '../../utils/selection';
-import { Scale } from './component';
+import { G2GuideComponentOptions, G2Mark } from './options';
+import { Scale, MarkProps } from './component';
 
 export type G2Theme = {
   defaultColor?: string;
@@ -16,11 +16,19 @@ export type G2Theme = {
 };
 
 export type G2ViewDescriptor = {
-  selection: Selection;
   scale: Record<string, Scale>;
   coordinate: Coordinate;
   theme: G2Theme;
+  markState: Map<G2Mark, G2MarkState>;
+  components: G2GuideComponentOptions[];
+  layout: Layout;
+  key: string;
 };
+
+export type G2MarkState = {
+  index?: number[];
+  data?: Record<string, any>[];
+} & MarkProps;
 
 export type MaybeArray<T> = T | T[];
 

--- a/src/runtime/types/component.ts
+++ b/src/runtime/types/component.ts
@@ -1,5 +1,6 @@
 import { Canvas, DisplayObject, Animation as GAnimation } from '@antv/g';
 import { Transformation, Coordinate } from '@antv/coord';
+import { Selection } from '../../utils/selection';
 import {
   IndexedValue,
   EncodeFunction,
@@ -162,7 +163,6 @@ export type MarkProps = {
   channels: Channel[];
   infer: { type: string; [key: string]: any }[];
   shapes: string[];
-  index?: number[];
 };
 export type MarkComponent<O = Record<string, unknown>> = G2BaseComponent<
   Mark,
@@ -246,6 +246,7 @@ export type ActionContext = {
   event: G2Event;
   update: (updater: (options: G2View) => G2View) => void;
   shared: Record<string, any>;
+  selection: Selection;
 } & G2ViewDescriptor;
 export type Action = (options: ActionContext) => ActionContext;
 export type ActionComponent<O = Record<string, unknown>> = G2BaseComponent<

--- a/src/spec/composition.ts
+++ b/src/spec/composition.ts
@@ -3,9 +3,15 @@ import { Theme } from './theme';
 import { Coordinate } from './coordinate';
 import { Interaction } from './interaction';
 
-export type Node = Geometry | View | Layer | Flex;
+export type Node =
+  | MarkComposition
+  | ViewComposition
+  | LayerComposition
+  | FlexComposition;
 
-export type View = {
+export type MarkComposition = Geometry;
+
+export type ViewComposition = {
   type?: 'view';
   data?: any;
   key?: string;
@@ -16,17 +22,17 @@ export type View = {
   coordinate?: Coordinate[];
   interaction?: Interaction[];
   theme?: Theme;
-  children?: Geometry[];
+  children?: MarkComposition[];
 };
 
-export type Layer = {
+export type LayerComposition = {
   type?: 'layer';
   key?: string;
   data?: any;
   children?: Node[];
 };
 
-export type Flex = {
+export type FlexComposition = {
   type?: 'flex';
   key?: string;
   data?: any;

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -71,7 +71,7 @@ import {
   Plot,
 } from '../action';
 import { MousePosition, TouchPosition } from '../interactor';
-import { Layer, Flex } from '../composition';
+import { Layer, Flex, Mark, View } from '../composition';
 
 export function createLibrary(): G2Library {
   return {
@@ -151,5 +151,7 @@ export function createLibrary(): G2Library {
     'interactor.touchPosition': TouchPosition,
     'composition.layer': Layer,
     'composition.flex': Flex,
+    'composition.mark': Mark,
+    'composition.view': View,
   };
 }

--- a/src/utils/container.ts
+++ b/src/utils/container.ts
@@ -9,7 +9,7 @@ class Container<O> {
     return new Container<O>(x);
   }
 
-  map<T, U>(f: (x: T, ...rest: any[]) => U, ...rest: any[]) {
+  call<T, U>(f: (x: T, ...rest: any[]) => U, ...rest: any[]) {
     return (this.$value = f(this.$value, ...rest)), this;
   }
 


### PR DESCRIPTION
refactor(runtime): separate compute and render logic for plotting a view

- Separate compute and render logic for plotting a view
```js
// Before
plotView(options, selection);
```
```js
// After
const view = initializeView(options);
plotView(view, selection);
```
- Using BFS instead of recursion to plot view tree.
```js
// Before
function plot(root) {
  plotView(root);
  root.children.forEach(plotView);
}
```
```js
// After
function plot(root) {
  const views = BFS(root);
  views.forEach(plotView);
}
```
- Add view and mark specification as composition, both of them will be transformed into standard view specification.

```js
// Transform view to standard view 
const view = {
  type: 'view',
  children: [{}, {}],
};

const standardView = {
  type: 'standardView',
  marks: [{}, {}]
}
```

```js
// Transform mark to standard view 
const mark = {
  type: 'interval',
  coordinate: [{type: 'polar'}],
  encode: {x: 'name', y: 'value'}
}

const standardView = {
  type: 'standardView',
  coordinate: [{type: 'polar'}],
  marks: [{
    type: 'interval',
    encode: {x: 'name', y: 'value'}
  }]
}
```