### PR TITLE
feat(runtime): support simple pack as one of adjust

### DIFF
--- a/.genjirc
+++ b/.genjirc
@@ -14,6 +14,7 @@
       "Text": "text",
       "Grid": "grid"
     },
+    "Adjust": "adjust",
     "Animation": "animation",
     "Interaction": "interaction",
     "Composition": {

--- a/__tests__/unit/adjust/pack.spec.ts
+++ b/__tests__/unit/adjust/pack.spec.ts
@@ -1,0 +1,22 @@
+import { Vector2 } from '@antv/coord';
+import { Pack } from '../../../src/adjust';
+
+describe('pack', () => {
+  it('Pack() returns function pack points uniformly', () => {
+    const adjust = Pack();
+    const layout = { innerWidth: 100, innerHeight: 200 };
+    const points: Vector2[][] = new Array(6).fill(null).map((i) => [
+      [0, 0],
+      [5, 5],
+    ]);
+    const transforms = adjust(points, layout);
+    expect(transforms).toEqual([
+      'translate(22.5, 172.5) scale(10, 10)',
+      'translate(72.5, 172.5) scale(10, 10)',
+      'translate(22.5, 122.5) scale(10, 10)',
+      'translate(72.5, 122.5) scale(10, 10)',
+      'translate(22.5, 72.5) scale(10, 10)',
+      'translate(72.5, 72.5) scale(10, 10)',
+    ]);
+  });
+});

--- a/__tests__/unit/composition/mark.spec.ts
+++ b/__tests__/unit/composition/mark.spec.ts
@@ -22,6 +22,7 @@ describe('composition', () => {
       transform: [{ type: 'sortBy' }],
       statistic: [{ type: 'stackY' }],
       key: '0',
+      adjust: { type: 'pack' },
     };
     expect(composition(options)).toEqual([
       {
@@ -37,6 +38,7 @@ describe('composition', () => {
         paddingTop: 40,
         x: 10,
         y: 20,
+        adjust: { type: 'pack' },
         component: [{ type: 'title' }],
         coordinate: [{ type: 'polar' }],
         marks: [

--- a/__tests__/unit/geometry/point.spec.ts
+++ b/__tests__/unit/geometry/point.spec.ts
@@ -25,6 +25,7 @@ describe('Point', () => {
         { type: 'maybeTitle' },
         { type: 'maybeTooltip' },
         { type: 'maybeZeroY1' },
+        { type: 'maybeZeroX1' },
         { type: 'maybeSize' },
       ],
       shapes: ['point', 'hollowPoint'],

--- a/__tests__/unit/runtime/adjust.spec.ts
+++ b/__tests__/unit/runtime/adjust.spec.ts
@@ -1,0 +1,43 @@
+import { G2Spec, render } from '../../../src';
+import { createDiv, mount } from '../../utils/dom';
+
+describe('adjust', () => {
+  it('Pack() should pack points with specified x and y channel uniformly', () => {
+    const chart = render<G2Spec>({
+      type: 'point',
+      transform: [
+        {
+          type: 'fetch',
+          url: 'https://gw.alipayobjects.com/os/basement_prod/6b4aa721-b039-49b9-99d8-540b3f87d339.json',
+        },
+      ],
+      encode: {
+        x: 'height',
+        y: 'weight',
+        color: 'gender',
+      },
+      adjust: { type: 'pack' },
+    });
+
+    mount(createDiv(), chart);
+  });
+
+  it('Pack() should pack points without specified x and y channel uniformly', () => {
+    const chart = render<G2Spec>({
+      type: 'point',
+      transform: [
+        {
+          type: 'fetch',
+          url: 'https://gw.alipayobjects.com/os/basement_prod/6b4aa721-b039-49b9-99d8-540b3f87d339.json',
+        },
+      ],
+      encode: {
+        color: 'gender',
+        tooltip: ['height', 'weight'],
+      },
+      adjust: { type: 'pack' },
+    });
+
+    mount(createDiv(), chart);
+  });
+});

--- a/__tests__/unit/stdlib/index.spec.ts
+++ b/__tests__/unit/stdlib/index.spec.ts
@@ -89,6 +89,7 @@ import {
 } from '../../../src/action';
 import { MousePosition, TouchPosition } from '../../../src/interactor';
 import { Layer, Flex, Mark, View } from '../../../src/composition';
+import { Pack } from '../../../src/adjust';
 
 describe('stdlib', () => {
   it('createLibrary() should returns expected builtin', () => {
@@ -171,6 +172,7 @@ describe('stdlib', () => {
       'composition.flex': Flex,
       'composition.mark': Mark,
       'composition.view': View,
+      'adjust.pack': Pack,
     });
   });
 });

--- a/docs/adjust.md
+++ b/docs/adjust.md
@@ -1,0 +1,41 @@
+# Adjust
+
+- <a href="#pack-uniform">Pack Uniform</a>
+
+## Pack Uniform
+
+The different of following examples is only the tooltip inference.
+
+```js | dom
+G2.render({
+  type: 'point',
+  transform: [
+    {
+      type: 'fetch',
+      url: 'https://gw.alipayobjects.com/os/basement_prod/6b4aa721-b039-49b9-99d8-540b3f87d339.json',
+    },
+  ],
+  encode: {
+    color: 'gender',
+  },
+  adjust: { type: 'pack' },
+});
+```
+
+```js | dom
+G2.render({
+  type: 'point',
+  transform: [
+    {
+      type: 'fetch',
+      url: 'https://gw.alipayobjects.com/os/basement_prod/6b4aa721-b039-49b9-99d8-540b3f87d339.json',
+    },
+  ],
+  encode: {
+    color: 'gender',
+    x: 'height',
+    y: 'weight',
+  },
+  adjust: { type: 'pack' },
+});
+```

--- a/src/action/transformer/tooltip.ts
+++ b/src/action/transformer/tooltip.ts
@@ -50,6 +50,8 @@ export const Tooltip: AC<TooltipOptions> = () => {
     const { scale, coordinate, theme, selection, shared } = context;
     const { mouseX, mouseY, selectedElements = [] } = shared;
     const data = selectedElements.map((d) => d.__data__);
+    const { tooltip } = scale;
+    if (tooltip === undefined) return;
 
     selection
       .select('.selection')

--- a/src/adjust/index.ts
+++ b/src/adjust/index.ts
@@ -1,0 +1,1 @@
+export { Pack, PackOptions } from './pack';

--- a/src/adjust/pack.ts
+++ b/src/adjust/pack.ts
@@ -1,0 +1,57 @@
+import { AdjustComponent as AC } from '../runtime';
+import { calcBBox } from '../utils/vector';
+
+export type PackOptions = Record<string, unknown>;
+
+/**
+ * Uniform pack to avid overlap.
+ * @todo Improve or change algorithm to increase space usage.
+ * @todo Take some special case into account.
+ */
+export const Pack: AC<PackOptions> = () => {
+  return (P, layout) => {
+    // col * row >= count
+    // row is close to col * aspect, so
+    // col * (col * aspect) >= count
+    const { innerWidth, innerHeight } = layout;
+    const count = P.length;
+    const aspect = innerHeight / innerWidth;
+    let col = Math.ceil(Math.sqrt(count / aspect));
+
+    // Increase col to avoid total height of packed shape
+    // being large than height of bbox.
+    let size = innerWidth / col;
+    let row = Math.ceil(count / col);
+    let h0 = row * size;
+    while (h0 > innerHeight) {
+      col = col + 1;
+      size = innerWidth / col;
+      row = Math.ceil(count / col);
+      h0 = row * size;
+    }
+
+    const space = innerHeight - row * size;
+    return P.map((points, m) => {
+      const [x, y, width, height] = calcBBox(points);
+      const cx = x + width / 2;
+      const cy = y + height / 2;
+
+      const i = m % col;
+      const j = Math.floor(m / col);
+
+      const newCX = i * size + size / 2;
+      const newCY = (row - j - 1) * size + space + size / 2;
+
+      const sx = size / width;
+      const sy = size / height;
+
+      // Translate the shape and mark to make sure the center of
+      // shape is overlap before and after scale transformation.
+      const tx = newCX - cx;
+      const ty = newCY - cy;
+      return `translate(${tx}, ${ty}) scale(${sx}, ${sy})`;
+    });
+  };
+};
+
+Pack.props = {};

--- a/src/component/legendCategory.ts
+++ b/src/component/legendCategory.ts
@@ -64,5 +64,5 @@ export const LegendCategory: GCC<LegendCategoryOptions> = (options) => {
 LegendCategory.props = {
   defaultPosition: 'top',
   defaultOrder: 1,
-  defaultSize: 64,
+  defaultSize: 40,
 };

--- a/src/component/legendContinuous.ts
+++ b/src/component/legendContinuous.ts
@@ -49,5 +49,5 @@ export const LegendContinuous: GCC<LegendContinuousOptions> = (options) => {
 LegendContinuous.props = {
   defaultPosition: 'top',
   defaultOrder: 1,
-  defaultSize: 64,
+  defaultSize: 40,
 };

--- a/src/composition/mark.ts
+++ b/src/composition/mark.ts
@@ -20,6 +20,7 @@ export const Mark: CC<MarkOptions> = () => {
       x,
       y,
       key,
+      adjust,
       ...mark
     } = options;
     return [
@@ -38,6 +39,7 @@ export const Mark: CC<MarkOptions> = () => {
         coordinate,
         component,
         interaction,
+        adjust,
         marks: [{ ...mark, key: `${key}-0`, data }],
       },
     ];

--- a/src/geometry/point.ts
+++ b/src/geometry/point.ts
@@ -36,6 +36,11 @@ Point.props = {
     { name: 'y', required: true },
     { name: 'size', required: true },
   ],
-  infer: [...baseInference(), { type: 'maybeZeroY1' }, { type: 'maybeSize' }],
+  infer: [
+    ...baseInference(),
+    { type: 'maybeZeroY1' },
+    { type: 'maybeZeroX1' },
+    { type: 'maybeSize' },
+  ],
   shapes: ['point', 'hollowPoint'],
 };

--- a/src/runtime/component.ts
+++ b/src/runtime/component.ts
@@ -15,20 +15,31 @@ import {
 import { G2Theme, GuideComponentPosition } from './types/common';
 import { isPolar, isTranspose, isParallel } from './coordinate';
 import { useLibrary } from './library';
+import { isPosition } from './scale';
 
 export function inferComponent(
   scales: G2ScaleOptions[],
   partialOptions: G2View,
   library: G2Library,
 ): G2GuideComponentOptions[] {
-  const { component: partialComponents = [], coordinate = [] } = partialOptions;
+  const {
+    component: partialComponents = [],
+    coordinate = [],
+    adjust,
+  } = partialOptions;
   const [, createGuideComponent] = useLibrary<
     G2GuideComponentOptions,
     GuideComponentComponent,
     GuideComponent
   >('component', library);
 
-  const displayedScales = scales.filter(({ guide }) => guide !== null);
+  // For view with adjust, the position channel is meaningless for visualization,
+  // so there is no need to show axis.
+  const displayedScales = scales.filter(({ guide, name }) => {
+    if (guide === null) return false;
+    if (adjust && isPosition(name)) return false;
+    return true;
+  });
   const components = [...partialComponents];
 
   for (const scale of displayedScales) {

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -13,6 +13,7 @@ import {
   G2ShapeOptions,
   G2AnimationOptions,
   G2CompositionOptions,
+  G2AdjustOptions,
 } from './types/options';
 import {
   ThemeComponent,
@@ -28,6 +29,8 @@ import {
   Animation,
   CompositionComponent,
   Composition,
+  AdjustComponent,
+  Adjust,
 } from './types/component';
 import { Channel, G2ViewDescriptor, G2MarkState } from './types/common';
 import { useLibrary } from './library';
@@ -116,9 +119,13 @@ async function initializeView(
     'scale',
     library,
   );
+  const [useAdjust] = useLibrary<G2AdjustOptions, AdjustComponent, Adjust>(
+    'adjust',
+    library,
+  );
 
   // Initialize theme.
-  const { theme: partialTheme, marks: partialMarks, key } = options;
+  const { theme: partialTheme, marks: partialMarks, key, adjust } = options;
   const theme = useTheme(inferTheme(partialTheme));
 
   // Infer options and calc state for each mark.
@@ -169,13 +176,15 @@ async function initializeView(
 
     const calcPoints = useMark(mark);
     const [I, P] = calcPoints(index, markScale, value, coordinate);
+    const T = adjust ? useAdjust(adjust)(P, layout) : [];
     const data: Record<string, any>[] = I.map((d, i) =>
       Object.entries(value).reduce(
         (datum, [k, V]) => ((datum[k] = V[d]), datum),
-        { points: P[i] },
+        { points: P[i], transform: T[i] },
       ),
     );
     state.data = data;
+    state.index = I;
     Object.assign(scale, markScale);
   }
 

--- a/src/runtime/scale.ts
+++ b/src/runtime/scale.ts
@@ -312,7 +312,7 @@ function isQuantitative(name: string): boolean {
   );
 }
 
-function isPosition(name: string): boolean {
+export function isPosition(name: string): boolean {
   return name === 'x' || name === 'y' || name.startsWith('position');
 }
 

--- a/src/runtime/types/component.ts
+++ b/src/runtime/types/component.ts
@@ -13,6 +13,7 @@ import {
   Vector2,
   GuideComponentPosition,
   G2ViewDescriptor,
+  Layout,
 } from './common';
 import { G2View, G2ViewTree } from './options';
 
@@ -34,7 +35,8 @@ export type G2ComponentNamespaces =
   | 'action'
   | 'interaction'
   | 'interactor'
-  | 'composition';
+  | 'composition'
+  | 'adjust';
 
 export type G2Component =
   | RendererComponent
@@ -52,7 +54,8 @@ export type G2Component =
   | ActionComponent
   | InteractionComponent
   | InteractorComponent
-  | CompositionComponent;
+  | CompositionComponent
+  | AdjustComponent;
 
 export type G2ComponentValue =
   | Renderer
@@ -71,7 +74,8 @@ export type G2ComponentValue =
   | Action
   | Interaction
   | Interactor
-  | Composition;
+  | Composition
+  | Adjust;
 
 export type G2BaseComponent<
   R = any,
@@ -266,5 +270,11 @@ export type InteractorComponent<O = Record<string, unknown>> = G2BaseComponent<
 export type Composition = (children: G2ViewTree) => G2ViewTree[];
 export type CompositionComponent<O = Record<string, unknown>> = G2BaseComponent<
   Composition,
+  O
+>;
+
+export type Adjust = (points: Vector2[][], layout: Layout) => string[];
+export type AdjustComponent<O = Record<string, unknown>> = G2BaseComponent<
+  Adjust,
   O
 >;

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -20,6 +20,7 @@ import {
   InteractorComponent,
   MarkComponent,
   CompositionComponent,
+  AdjustComponent,
 } from './component';
 
 export type G2ViewTree = {
@@ -59,6 +60,7 @@ export type G2View = {
   component?: G2GuideComponentOptions[];
   interaction?: G2InteractionOptions[];
   marks?: G2Mark[];
+  adjust?: { type?: string; [key: string]: any };
 };
 
 export type G2Mark = {
@@ -100,7 +102,8 @@ export type G2ComponentOptions =
   | G2ActionOptions
   | G2InteractionOptions
   | G2InteractorOptions
-  | G2CompositionOptions;
+  | G2CompositionOptions
+  | G2AdjustOptions;
 
 export type G2TransformOptions = G2BaseComponentOptions<TransformComponent>;
 export type G2StatisticOptions = G2BaseComponentOptions<StatisticComponent>;
@@ -139,3 +142,4 @@ export type G2ActionOptions = G2BaseComponentOptions<ActionComponent>;
 export type G2InteractionOptions = G2BaseComponentOptions<InteractionComponent>;
 export type G2InteractorOptions = G2BaseComponentOptions<InteractorComponent>;
 export type G2CompositionOptions = G2BaseComponentOptions<CompositionComponent>;
+export type G2AdjustOptions = G2BaseComponentOptions<AdjustComponent>;

--- a/src/shape/interval/colorRect.ts
+++ b/src/shape/interval/colorRect.ts
@@ -31,7 +31,7 @@ export const ColorRect: SC<ColorRectOptions> = (options) => {
   return (points, value, coordinate, theme) => {
     const { radius = 0 } = style;
     const { defaultColor } = theme;
-    const { color = defaultColor } = value;
+    const { color = defaultColor, transform } = value;
     const [p0, p1, p2, p3] = isTranspose(coordinate) ? reorder(points) : points;
 
     // Render rect in non-polar coordinate.
@@ -73,6 +73,7 @@ export const ColorRect: SC<ColorRectOptions> = (options) => {
       .style('path', path(arcObject))
       .style('transform', `translate(${center[0]}, ${center[1]})`)
       .style('stroke', color)
+      .style('transform', transform)
       .style(colorAttribute, color)
       .call(applyStyle, style)
       .node();

--- a/src/shape/line/curveLine.ts
+++ b/src/shape/line/curveLine.ts
@@ -14,7 +14,7 @@ export const CurveLine: SC<CurveLineOptions> = (options) => {
   const { curve, ...style } = options;
   return (points, value, coordinate, theme) => {
     const { defaultColor, defaultSize } = theme;
-    const { color = defaultColor, size = defaultSize } = value;
+    const { color = defaultColor, size = defaultSize, transform } = value;
     // Append first point to draw close line in polar coordinate.
     const P = isPolar(coordinate) ? [...points, points[0]] : points;
     const path = line()
@@ -26,6 +26,7 @@ export const CurveLine: SC<CurveLineOptions> = (options) => {
       .style('d', path(P))
       .style('stroke', color)
       .style('lineWidth', size)
+      .style('transform', transform)
       .call(applyStyle, style)
       .node();
   };

--- a/src/shape/point/colorPoint.ts
+++ b/src/shape/point/colorPoint.ts
@@ -18,7 +18,7 @@ export const ColorPoint: SC<ColorPointOptions> = (options) => {
 
   return (points, value, coordinate, theme) => {
     const { defaultColor } = theme;
-    const { color = defaultColor } = value;
+    const { color = defaultColor, transform } = value;
     const [[x0, y0], [x2, y2]] = points;
     const [cx, cy] = [(x0 + x2) / 2, (y0 + y2) / 2];
     const a = (x2 - x0) / 2;
@@ -30,6 +30,7 @@ export const ColorPoint: SC<ColorPointOptions> = (options) => {
       .style('y', cy)
       .style('lineWidth', lineWidth)
       .style('stroke', color)
+      .style('transform', transform)
       .style(colorAttribute, color)
       .call(applyStyle, style)
       .node();

--- a/src/shape/text/text.ts
+++ b/src/shape/text/text.ts
@@ -17,6 +17,7 @@ export const Text: SC<TextOptions> = (options) => {
       text = '',
       fontSize = 14,
       rotate = 0,
+      transform = '',
     } = value;
     const [[x0, y0]] = points;
 
@@ -27,7 +28,7 @@ export const Text: SC<TextOptions> = (options) => {
       .style('stroke', color)
       .style('fill', color)
       .style('fontSize', fontSize as any)
-      .style('transform', `rotate(${+rotate})`)
+      .style('transform', `${transform}rotate(${+rotate})`)
       .call(applyStyle, style)
       .node();
   };

--- a/src/spec/composition.ts
+++ b/src/spec/composition.ts
@@ -1,4 +1,4 @@
-import { Geometry } from './geometry';
+import { Geometry, Adjust } from './geometry';
 import { Theme } from './theme';
 import { Coordinate } from './coordinate';
 import { Interaction } from './interaction';
@@ -23,6 +23,7 @@ export type ViewComposition = {
   interaction?: Interaction[];
   theme?: Theme;
   children?: MarkComposition[];
+  adjust?: Adjust;
 };
 
 export type LayerComposition = {

--- a/src/spec/geometry.ts
+++ b/src/spec/geometry.ts
@@ -56,10 +56,13 @@ export type BaseGeometry<
   style?: Record<string, any>;
   interaction?: Interaction[];
   theme?: Theme;
+  adjust?: Adjust;
   animate?: {
     enter?: Animation;
   };
 };
+
+export type Adjust = { type: 'pack' };
 
 export type IntervalGeometry = BaseGeometry<
   'interval',

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -72,6 +72,7 @@ import {
 } from '../action';
 import { MousePosition, TouchPosition } from '../interactor';
 import { Layer, Flex, Mark, View } from '../composition';
+import { Pack } from '../adjust';
 
 export function createLibrary(): G2Library {
   return {
@@ -153,5 +154,6 @@ export function createLibrary(): G2Library {
     'composition.flex': Flex,
     'composition.mark': Mark,
     'composition.view': View,
+    'adjust.pack': Pack,
   };
 }

--- a/src/utils/vector.ts
+++ b/src/utils/vector.ts
@@ -12,3 +12,19 @@ export function angle([x, y]: Vector2): number {
   const theta = Math.atan2(y, x);
   return theta;
 }
+
+export function calcBBox(points: Vector2[]) {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const [x, y] of points) {
+    minX = Math.min(x, minX);
+    maxX = Math.max(x, maxX);
+    minY = Math.min(y, minY);
+    maxY = Math.max(y, maxY);
+  }
+  const width = maxX - minX;
+  const height = maxY - minY;
+  return [minX, minY, width, height];
+}


### PR DESCRIPTION
feat(runtime): support simple pack as one of adjust(Test coverage: 93%)([demo](https://pearmini.github.io/hello-g2v5/#/adjust))

- Apply transform attribute to shape.
- Apply adjust for each view rather than mark, and auto hide axis for view with adjust. This is because the x and y attribute of shape make no sense for visualization after adjust.
- A simple implementation of pack uniform.

![image](https://user-images.githubusercontent.com/49330279/164718768-7a861c5e-0527-475c-89f4-baf2766ec38a.png)

```js
G2.render({
  type: 'point',
  transform: [
    {
      type: 'fetch',
      url: 'https://gw.alipayobjects.com/os/basement_prod/6b4aa721-b039-49b9-99d8-540b3f87d339.json',
    },
  ],
  encode: {
    color: 'gender',
  },
  adjust: { type: 'pack' },
});
```