### PR TITLE
feat(runtime): support flex options for interval and grid

### DIFF
--- a/__tests__/unit/runtime/grid.spec.ts
+++ b/__tests__/unit/runtime/grid.spec.ts
@@ -123,4 +123,29 @@ describe('grid', () => {
     });
     mount(createDiv(), chart);
   });
+
+  it('render({...}) should render grid with flex band', () => {
+    const chart = render<G2Spec>({
+      type: 'grid',
+      data: [
+        { name: 'A', course: 'a' },
+        { name: 'A', course: 'b' },
+        { name: 'B', course: 'a' },
+        { name: 'B', course: 'b' },
+      ],
+      scale: {
+        x: { flex: [2, 1] },
+        y: { flex: [1, 2] },
+      },
+      encode: {
+        y: 'name',
+        x: 'course',
+      },
+      style: {
+        stroke: 'black',
+        lineWidth: 1,
+      },
+    });
+    mount(createDiv(), chart);
+  });
 });

--- a/__tests__/unit/runtime/interval.spec.ts
+++ b/__tests__/unit/runtime/interval.spec.ts
@@ -418,6 +418,33 @@ describe('render', () => {
     mount(createDiv(), chart);
   });
 
+  it('render({...} renders chart with specified scale options', (done) => {
+    const chart = render<G2Spec>(
+      {
+        type: 'interval',
+        data: [
+          { genre: 'Sports', sold: 275 },
+          { genre: 'Strategy', sold: 115 },
+          { genre: 'Action', sold: 120 },
+          { genre: 'Shooter', sold: 350 },
+          { genre: 'Other', sold: 150 },
+        ],
+        scale: {
+          x: { flex: [2, 3, 1, 4, 2] },
+        },
+        encode: {
+          x: 'genre',
+          y: 'sold',
+          color: 'genre',
+        },
+      },
+      {},
+      done,
+    );
+
+    mount(createDiv(), chart);
+  });
+
   it('render({...} renders chart with specified palette option', (done) => {
     const chart = render<G2Spec>(
       {

--- a/docs/grid.md
+++ b/docs/grid.md
@@ -2,7 +2,7 @@
 
 - <a href="#ordinal-grid">Ordinal Grid</a>
 - <a href="#quantize-grid">Quantize Grid</a>
-
+- <a href="#flex-grid">Flex Grid</a>
 ## Ordinal Grid
 
 ```js | dom
@@ -57,6 +57,32 @@ G2.render({
     x: (_, i) => ((i / 5) | 0) + 1,
     color: 'salary',
     tooltip: 'salary',
+  },
+  style: {
+    stroke: 'black',
+    lineWidth: 1,
+  },
+});
+```
+
+## Flex Grid
+
+```js | dom
+G2.render({
+  type: 'grid',
+  data: [
+    { name: 'A', course: 'a' },
+    { name: 'A', course: 'b' },
+    { name: 'B', course: 'a' },
+    { name: 'B', course: 'b' },
+  ],
+  scale: {
+    x: { flex: [2, 1] },
+    y: { flex: [1, 2] },
+  },
+  encode: {
+    y: 'name',
+    x: 'course',
   },
   style: {
     stroke: 'black',

--- a/docs/interval.md
+++ b/docs/interval.md
@@ -1,6 +1,7 @@
 # Interval
 
 - <a href="#basic-interval">Basic Interval</a>
+- <a href="#flex-interval">Flex Interval</a>
 - <a href="#hollow-interval">Hollow Interval</a>
 - <a href="#transpose-interval">Transpose Interval</a>
 - <a href="#polar-interval">Polar Interval</a>
@@ -22,6 +23,29 @@ G2.render({
     { genre: 'Shooter', sold: 350 },
     { genre: 'Other', sold: 150 },
   ],
+  encode: {
+    x: 'genre',
+    y: 'sold',
+    color: 'genre',
+  },
+});
+```
+
+## Flex Interval
+
+```js | dom
+G2.render({
+  type: 'interval',
+  data: [
+    { genre: 'Sports', sold: 275 },
+    { genre: 'Strategy', sold: 115 },
+    { genre: 'Action', sold: 120 },
+    { genre: 'Shooter', sold: 350 },
+    { genre: 'Other', sold: 150 },
+  ],
+  scale: {
+    x: { flex: [2, 3, 1, 4, 2] },
+  },
   encode: {
     x: 'genre',
     y: 'sold',

--- a/docs/scale.md
+++ b/docs/scale.md
@@ -155,6 +155,29 @@ G2.render({
 });
 ```
 
+Flex option.
+
+```js | dom
+G2.render({
+  type: 'interval',
+  data: [
+    { genre: 'Sports', sold: 275 },
+    { genre: 'Strategy', sold: 115 },
+    { genre: 'Action', sold: 120 },
+    { genre: 'Shooter', sold: 350 },
+    { genre: 'Other', sold: 150 },
+  ],
+  scale: {
+    x: { flex: [2, 3, 1, 4, 2] },
+  },
+  encode: {
+    x: 'genre',
+    y: 'sold',
+    color: 'genre',
+  },
+});
+```
+
 ## Ordinal
 
 The scale for color channel of following point is ordinal scale.

--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -118,7 +118,7 @@ function getTicks(
   const ticks = scale.getTicks?.() || domain;
   const formatter = scale.getFormatter?.() || ((d) => `${d}`);
   return ticks.map((d) => {
-    const offset = scale.getBandWidth?.() / 2 || 0;
+    const offset = scale.getBandWidth?.(d) / 2 || 0;
     const tick = scale.map(d) + offset;
     const point = getTickPoint(tick, position);
     const vector = coordinate.map(point) as Vector2;

--- a/src/geometry/grid.ts
+++ b/src/geometry/grid.ts
@@ -15,9 +15,10 @@ export const Grid: MC<GridOptions> = () => {
     const { x: X, y: Y } = value;
     const x = scale.x as Band;
     const y = scale.y as Band;
-    const width = x.getBandWidth();
-    const height = y.getBandWidth();
+
     const P = Array.from(index, (i) => {
+      const width = x.getBandWidth(x.invert(X[i][0]));
+      const height = y.getBandWidth(y.invert(Y[i][0]));
       const x1 = +X[i][0];
       const y1 = +Y[i][0];
       const p1 = [x1, y1];

--- a/src/geometry/interval.ts
+++ b/src/geometry/interval.ts
@@ -16,14 +16,14 @@ export const Interval: MC<IntervalOptions> = () => {
     // The scales for x and series channels must be band scale.
     const x = scale.x as Band;
     const series = scale.series as Band;
-    const groupWidth = x.getBandWidth();
-    const ratio = series ? series.getBandWidth() : 1;
-    const width = groupWidth * ratio;
 
     // Calc the points of bounding box for the interval.
     // They are start from left-top corner in clock wise order.
     const P = Array.from(index, (i) => {
-      const offset = ((S?.[i] as number) || 0) * groupWidth;
+      const groupWidth = x.getBandWidth(x.invert(X[i][0]));
+      const ratio = series ? series.getBandWidth(series.invert(+S?.[i])) : 1;
+      const width = groupWidth * ratio;
+      const offset = (+S?.[i] || 0) * groupWidth;
       const x1 = X[i][0] + offset;
       const x2 = x1 + width;
       const [y1, y2] = Y[i];

--- a/src/runtime/types/component.ts
+++ b/src/runtime/types/component.ts
@@ -128,7 +128,7 @@ export type Scale = {
   map: (x: any) => any;
   invert: (x: any) => any;
   getTicks?: () => any[];
-  getBandWidth?: () => number;
+  getBandWidth?: (d?: any) => number;
   getFormatter?: () => (x: any) => string;
 };
 export type ScaleComponent<O = Record<string, unknown>> = G2BaseComponent<


### PR DESCRIPTION
feat(runtime): support flex options for interval and grid. ([demo](https://pearmini.github.io/hello-g2v5/#/interval))

Currently the flex options can only specified by non-declarative method, this should be solved in the next stage. And this PR should be merged after https://github.com/antvis/scale/pull/182 being merged and @antv/scale releasing 0.4.7. At the time, the CI will pass.

**Flex Interval.**
![image](https://user-images.githubusercontent.com/49330279/164968094-95808742-5eda-4fda-91e5-c57dc74e1297.png)
```js
G2.render({
  type: 'interval',
  data: [
    { genre: 'Sports', sold: 275 },
    { genre: 'Strategy', sold: 115 },
    { genre: 'Action', sold: 120 },
    { genre: 'Shooter', sold: 350 },
    { genre: 'Other', sold: 150 },
  ],
  scale: {
    x: { flex: [2, 3, 1, 4, 2] },
  },
  encode: {
    x: 'genre',
    y: 'sold',
    color: 'genre',
  },
});
```

**Flex Grid.**

![image](https://user-images.githubusercontent.com/49330279/164968135-fcdf329b-8053-470c-a0ea-4eaaa3fc9ab0.png)

```js
G2.render({
  type: 'grid',
  data: [
    { name: 'A', course: 'a' },
    { name: 'A', course: 'b' },
    { name: 'B', course: 'a' },
    { name: 'B', course: 'b' },
  ],
  scale: {
    x: { flex: [2, 1] },
    y: { flex: [1, 2] },
  },
  encode: {
    y: 'name',
    x: 'course',
  },
  style: {
    stroke: 'black',
    lineWidth: 1,
  },
});
```