### PR TITLE
fix(animate): optimize scale-in by break the animation into two phases

### DIFF
--- a/__tests__/unit/animation/scaleInY.spec.ts
+++ b/__tests__/unit/animation/scaleInY.spec.ts
@@ -18,9 +18,14 @@ describe('ScaleInY', () => {
     });
     expect(style(shape, 'origin')).toEqual(new Float32Array([0, 200, 0]));
     expect(keyframes(animation, 'transform')).toEqual([
-      'scale(1, 0.0001)',
+      'scale(1, 0.001)',
+      'scale(1, 0.001)',
       'scale(1, 1)',
     ]);
+    expect(keyframes(animation, 'fillOpacity')).toEqual([0, 1, undefined]);
+    expect(keyframes(animation, 'strokeOpacity')).toEqual([0, 1, undefined]);
+    expect(keyframes(animation, 'opacity')).toEqual([0, 1, undefined]);
+    expect(keyframes(animation, 'offset')).toEqual([null, 0.01, null]);
 
     const { onfinish } = animation;
     return new Promise<void>((resolve) => {
@@ -47,7 +52,8 @@ describe('ScaleInY', () => {
 
     expect(style(shape, 'origin')).toEqual(new Float32Array([0, 0, 0]));
     expect(keyframes(animation, 'transform')).toEqual([
-      'scale(0.0001, 1)',
+      'scale(0.001, 1)',
+      'scale(0.001, 1)',
       'scale(1, 1)',
     ]);
   });

--- a/__tests__/unit/animation/scaleInY.spec.ts
+++ b/__tests__/unit/animation/scaleInY.spec.ts
@@ -16,10 +16,10 @@ describe('ScaleInY', () => {
       animate: ScaleInY({ fill: 'both', duration: 300 }),
       container,
     });
-    expect(style(shape, 'origin')).toEqual(new Float32Array([0, 200, 0]));
+    expect(shape.getOrigin()).toEqual(new Float32Array([0, 200, 0]));
     expect(keyframes(animation, 'transform')).toEqual([
-      'scale(1, 0.001)',
-      'scale(1, 0.001)',
+      'scale(1, 0.0001)',
+      'scale(1, 0.0001)',
       'scale(1, 1)',
     ]);
     expect(keyframes(animation, 'fillOpacity')).toEqual([0, 1, undefined]);
@@ -31,7 +31,7 @@ describe('ScaleInY', () => {
     return new Promise<void>((resolve) => {
       animation.onfinish = (e) => {
         onfinish.call(animation, e);
-        expect(style(shape, 'origin')).toEqual(new Float32Array([0, 0, 0]));
+        expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
         resolve();
       };
     });
@@ -50,10 +50,10 @@ describe('ScaleInY', () => {
       container,
     });
 
-    expect(style(shape, 'origin')).toEqual(new Float32Array([0, 0, 0]));
+    expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
     expect(keyframes(animation, 'transform')).toEqual([
-      'scale(0.001, 1)',
-      'scale(0.001, 1)',
+      'scale(0.0001, 1)',
+      'scale(0.0001, 1)',
       'scale(1, 1)',
     ]);
   });

--- a/__tests__/unit/shape/interval/hollowRect.spec.ts
+++ b/__tests__/unit/shape/interval/hollowRect.spec.ts
@@ -22,7 +22,7 @@ describe('HollowRect', () => {
 
     expect(style(shape, ['stroke', 'lineWidth', 'fill'])).toEqual({
       stroke: 'steelblue',
-      fill: 'transparent',
+      fill: '',
       lineWidth: 2,
     });
   });
@@ -46,7 +46,7 @@ describe('HollowRect', () => {
 
     expect(style(shape, ['stroke', 'lineWidth', 'fill'])).toEqual({
       stroke: 'steelblue',
-      fill: 'transparent',
+      fill: '',
       lineWidth: 10,
     });
   });

--- a/__tests__/unit/shape/point/point.spec.ts
+++ b/__tests__/unit/shape/point/point.spec.ts
@@ -28,7 +28,7 @@ describe('Point', () => {
     expect(style(shape, ['fill', 'r', 'lineWidth'])).toEqual({
       fill: 'steelblue',
       r: 75,
-      lineWidth: 0,
+      lineWidth: '0',
     });
   });
 

--- a/src/animation/scaleInY.ts
+++ b/src/animation/scaleInY.ts
@@ -11,7 +11,7 @@ export type ScaleInYOptions = Animation;
 export const ScaleInY: AC<ScaleInYOptions> = (options) => {
   // Small enough to hide or show very small part of mark,
   // but bigger enough to not cause bug.
-  const ZERO = 0.001;
+  const ZERO = 0.0001;
 
   return (shape, style, coordinate, theme) => {
     const { height } = shape.getBoundingClientRect();

--- a/src/animation/scaleInY.ts
+++ b/src/animation/scaleInY.ts
@@ -9,9 +9,9 @@ export type ScaleInYOptions = Animation;
  * Scale mark from nothing to desired shape in y direction.
  */
 export const ScaleInY: AC<ScaleInYOptions> = (options) => {
-  // Small enough to hide mark,
-  // But bigger enough to not cause bug.
-  const ZERO = 0.0001;
+  // Small enough to hide or show very small part of mark,
+  // but bigger enough to not cause bug.
+  const ZERO = 0.001;
 
   return (shape, style, coordinate, theme) => {
     const { height } = shape.getBoundingClientRect();
@@ -19,7 +19,14 @@ export const ScaleInY: AC<ScaleInYOptions> = (options) => {
       isTranspose(coordinate)
         ? [[0, 0], `scale(${ZERO}, 1)`] // left-top corner
         : [[0, height], `scale(1, ${ZERO})`]; // left-bottom corner
-    const keyframes = [{ transform }, { transform: 'scale(1, 1)' }];
+
+    // Using a short fadeIn transition to hide element with scale(0.001)
+    // which is still visible.
+    const keyframes = [
+      { transform, fillOpacity: 0, strokeOpacity: 0, opacity: 0 },
+      { transform, fillOpacity: 1, strokeOpacity: 1, opacity: 1, offset: 0.01 },
+      { transform: 'scale(1, 1)' },
+    ];
 
     // Change transform origin for correct transform.
     shape.setOrigin(transformOrigin);


### PR DESCRIPTION
Using a short fadeIn transition to hide element with scale(0.001, 1) which is still visible.

![image](https://user-images.githubusercontent.com/49330279/165668420-6c399be0-10a2-4661-9ffc-07f5eba1e9a6.png)
