### PR TITLE
feat(axis): update @antv/gui, limit axis-title in bounds

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 // Installing third-party modules by tnpm or cnpm will name modules with underscore as prefix.
 // In this case _{module} is also necessary.
-const esm = ['internmap', 'd3-*'].map((d) => `_${d}|${d}`).join('|');
+const esm = ['internmap', 'd3-*', 'lodash-es'].map((d) => `_${d}|${d}`).join('|');
 
 module.exports = {
   runner: 'jest-electron/runner',

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@antv/coord": "^0.4.1",
     "@antv/g": "^5.0.20",
     "@antv/g-canvas": "^1.0.13",
-    "@antv/gui": "0.4.0",
+    "@antv/gui": "^0.4.3-alpha.5",
     "@antv/scale": "^0.4.7",
     "@antv/util": "^2.0.17",
     "d3-array": "^3.1.1",

--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -149,7 +149,6 @@ export const Axis: GCC<AxisOptions> = (options) => {
       titlePosition,
       titlePadding,
       titleRotate,
-      labelAlign,
       verticalFactor,
     } = inferPosition(position, bbox);
     const ticks = getTicks(scale, domain, formatter, position, coordinate);
@@ -177,9 +176,9 @@ export const Axis: GCC<AxisOptions> = (options) => {
             title: {
               content: Array.isArray(field) ? field[0] : field,
               titleAnchor: scale.getTicks ? titlePosition : 'center',
-              style: {},
+              style: { fontWeight: 'bold', fillOpacity: 1 },
               titlePadding,
-              rotation: titleRotate,
+              rotate: titleRotate,
             },
           }),
       },

--- a/src/component/legendCategory.ts
+++ b/src/component/legendCategory.ts
@@ -44,12 +44,14 @@ export const LegendCategory: GCC<LegendCategoryOptions> = (options) => {
             spacing: 0,
             style: {
               fontSize: 12,
+              fontWeight: 'bold',
+              fillOpacity: 1,
             },
           },
         }),
         itemMarker: ({ color }) => {
           return {
-            size: 10,
+            size: 8,
             marker: 'circle',
             style: {
               selected: {


### PR DESCRIPTION
update `@antv/gui` to `0.4.3-alpha.5`. Details to see: https://github.com/antvis/GUI/pull/148

- **fix:** position of facet axis-title
- **feat:** axis support `title.bounds` to make title not out-of bounds.


force axis-title to show, `label.maxLength`  may cause axis-label ellipsis.

<img width="81" alt="image" src="https://user-images.githubusercontent.com/15646325/166480727-1d94c062-c8eb-4e92-916c-26353069d96d.png">
