### PR TITLE
fix: some bugs showing in examples

### DIFF
--- a/__tests__/unit/runtime/unit.spec.ts
+++ b/__tests__/unit/runtime/unit.spec.ts
@@ -123,7 +123,7 @@ describe('adjust', () => {
           order: 'DESC',
         },
       ],
-      paddingRight: 50,
+      paddingRight: 70,
       encode: {
         x: 'Class',
         y: 'Sex',
@@ -156,7 +156,7 @@ describe('adjust', () => {
           order: 'DESC',
         },
       ],
-      paddingRight: 50,
+      paddingRight: 70,
       shareData: true,
       encode: {
         x: 'Class',
@@ -176,7 +176,7 @@ describe('adjust', () => {
     mount(createDiv(), chart);
   });
 
-  it('Pack() should pack points with specified x and y channel uniformly', () => {
+  it.only('Pack() should pack points with specified x and y channel uniformly', () => {
     const chart = render<G2Spec>({
       type: 'rect',
       transform: [
@@ -191,7 +191,7 @@ describe('adjust', () => {
       ],
       paddingRight: 50,
       paddingBottom: 50,
-      paddingLeft: 50,
+      paddingLeft: 80,
       encode: {
         y: 'pclass',
       },
@@ -216,10 +216,7 @@ describe('adjust', () => {
               encode: { y: 'sex' },
               shareSize: true,
               scale: {
-                y: {
-                  guide: ({ columnValue }) =>
-                    columnValue === '0' ? { position: 'left' } : null,
-                },
+                y: { guide: { position: 'left' } },
                 x: { guide: null },
               },
               children: [

--- a/__tests__/unit/runtime/unit.spec.ts
+++ b/__tests__/unit/runtime/unit.spec.ts
@@ -176,7 +176,7 @@ describe('adjust', () => {
     mount(createDiv(), chart);
   });
 
-  it.only('Pack() should pack points with specified x and y channel uniformly', () => {
+  it('Pack() should pack points with specified x and y channel uniformly', () => {
     const chart = render<G2Spec>({
       type: 'rect',
       transform: [

--- a/__tests__/unit/shape/text/text.spec.ts
+++ b/__tests__/unit/shape/text/text.spec.ts
@@ -119,4 +119,23 @@ describe('Text', () => {
     expect(shape.getLineBoundingRects().length).toBeGreaterThan(1);
     mount(createDiv(), container);
   });
+
+  it('Text() returns a function draw rotate text', () => {
+    const container = document.createElement('div');
+    const shape = draw({
+      width: 150,
+      height: 50,
+      shape: Text({}),
+      container,
+      value: {
+        text: 'hello',
+        color: 'steelblue',
+        rotate: '90',
+      },
+      vectors: [[0.5, 0.5]],
+    });
+    mount(createDiv(), container);
+
+    expect(shape.getBoundingClientRect().right).toBe(96);
+  });
 });

--- a/__tests__/unit/shape/text/text.spec.ts
+++ b/__tests__/unit/shape/text/text.spec.ts
@@ -136,6 +136,7 @@ describe('Text', () => {
     });
     mount(createDiv(), container);
 
-    expect(shape.getBoundingClientRect().right).toBe(96);
+    const { right } = shape.getBoundingClientRect();
+    expect(Math.abs(right - 96)).toBeLessThanOrEqual(1);
   });
 });

--- a/docs/unit.md
+++ b/docs/unit.md
@@ -130,7 +130,7 @@ G2.render({
       order: 'DESC',
     },
   ],
-  paddingRight: 50,
+  paddingRight: 70,
   encode: {
     x: 'Class',
     y: 'Sex',
@@ -163,7 +163,7 @@ G2.render({
       order: 'DESC',
     },
   ],
-  paddingRight: 50,
+  paddingRight: 70,
   shareData: true,
   encode: {
     x: 'Class',
@@ -198,7 +198,7 @@ G2.render({
   ],
   paddingRight: 50,
   paddingBottom: 50,
-  paddingLeft: 50,
+  paddingLeft: 80,
   encode: {
     y: 'pclass',
   },
@@ -223,10 +223,7 @@ G2.render({
           encode: { y: 'sex' },
           shareSize: true,
           scale: {
-            y: {
-              guide: ({ columnValue }) =>
-                columnValue === '0' ? { position: 'left' } : null,
-            },
+            y: { guide: { position: 'left' } },
             x: { guide: null },
           },
           children: [

--- a/src/composition/rect.ts
+++ b/src/composition/rect.ts
@@ -250,29 +250,29 @@ const setChildren = useOverrideAdaptor<G2ViewTree>((options) => {
 });
 
 function createGuideX(guideX) {
-  const type = typeof guideX;
-  if (type === 'function') return guideX;
-  if (type === 'object') return () => guideX;
+  if (typeof guideX === 'function') return guideX;
+  if (guideX === null) return () => null;
   return (facet) => {
     const { rowIndex, rowValuesLength, columnIndex, columnValuesLength } =
       facet;
     // Only the bottom-most facet show axisX.
     if (rowIndex !== rowValuesLength - 1) return null;
     // Only the bottom-left facet show title.
-    if (columnIndex !== columnValuesLength - 1) return { title: false };
+    if (columnIndex !== columnValuesLength - 1) {
+      return deepMix({ title: false }, guideX);
+    }
   };
 }
 
 function createGuideY(guideY) {
-  const type = typeof guideY;
-  if (type === 'function') return guideY;
-  if (type === 'object') return () => guideY;
+  if (typeof guideY === 'function') return guideY;
+  if (guideY === null) return () => null;
   return (facet) => {
     const { rowIndex, columnIndex } = facet;
     // Only the left-most facet show axisY.
     if (columnIndex !== 0) return null;
     // Only the left-top facet show title.
-    if (rowIndex !== 0) return { title: false };
+    if (rowIndex !== 0) return deepMix({ title: false }, guideY);
   };
 }
 

--- a/src/shape/text/text.ts
+++ b/src/shape/text/text.ts
@@ -28,7 +28,7 @@ export const Text: SC<TextOptions> = (options) => {
       .style('stroke', color)
       .style('fill', color)
       .style('fontSize', fontSize as any)
-      .style('transform', `${transform}rotate(${+rotate})`)
+      .style('transform', `${transform}rotate(${+rotate}deg)`)
       .call(applyStyle, style)
       .node();
   };


### PR DESCRIPTION
fix: some bugs showing in examples.

- Text shape requires deg as the unit for rotate transformation.

```js
// before
const text = new Text({
  style: {
    transform: 'rotate(90)' // This is invalid.
  }
});

// after
const text = new Text({
  style: {
    transform: 'rotate(90deg)' // This is valid.
  }
});
```
- For guide options of axis, it will only affect displayed axis if it is an object in facet.

```js
// before
const o1 = {
  scale: {
    y: {
      guide: ({ columnValue }) => 
        // Control the the visibility of axis explicitly.
        columnValue === '0' ? { position: 'left' } : null,
    },
  },
};

// after
const o2 = {
  scale: {
    y: {
       // Only the left-most axis will show by default.
       // This is no need to control the visibility of axis explicitly.
       // The option below will only affect the displayed axis.
      guide: { position: 'left' },
  },
};
```