### PR TITLE
chore: add bundle analysis visualizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ esm
 
 # Test
 coverage
+
+# Bundle visualizer
+stats.html

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:cjs": "rimraf ./lib && tsc --module commonjs --outDir lib",
     "build:esm": "rimraf ./esm && tsc --module ESNext --outDir esm",
     "build": "run-p build:*",
+    "bundle-vis": "cross-env BUNDLE_VIS=1 run-p build:umd",
     "ci": "run-s lint test build",
     "prepublishOnly": "npm run ci",
     "prepare": "husky install"
@@ -67,6 +68,7 @@
     "rollup-plugin-polyfill-node": "^0.8.0",
     "rollup-plugin-typescript": "^1.0.1",
     "rollup-plugin-uglify": "^6.0.4",
+    "rollup-plugin-visualizer": "^5.6.0",
     "ts-jest": "^26.5.1",
     "typescript": "^4.1.5"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,9 @@ import resolve from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript';
 import commonjs from '@rollup/plugin-commonjs';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
+import { visualizer } from 'rollup-plugin-visualizer';
+
+const isBundleVis = !!process.env.BUNDLE_VIS;
 
 module.exports = [
   {
@@ -13,6 +16,13 @@ module.exports = [
       format: 'umd',
       sourcemap: false,
     },
-    plugins: [nodePolyfills(), resolve(), commonjs(), typescript(), uglify()],
+    plugins: [
+      nodePolyfills(),
+      resolve(),
+      commonjs(),
+      typescript(),
+      uglify(),
+      ...(isBundleVis ? [visualizer()] : []),
+    ],
   },
 ];


### PR DESCRIPTION
> 控制包大小，从开始做起。

使用方式： 

1. npm run bundle-vis
2. 然后用浏览器打开目录中的 `stats.html`

![image](https://user-images.githubusercontent.com/7856674/168201796-51a66b6a-b3d8-404b-aba3-d0342358d50c.png)
