### PR TITLE
feat(axis): support arc axis in polar coordinate

### DIFF
--- a/__tests__/data/sales.ts
+++ b/__tests__/data/sales.ts
@@ -1,13 +1,12 @@
 export const SALE_OF_YEAR = [
-  { year: '1991', sale: 15468 },
-  { year: '1992', sale: 16100 },
-  { year: '1993', sale: 15900 },
-  { year: '1994', sale: 17409 },
-  { year: '1995', sale: 17000 },
-  { year: '1996', sale: 31056 },
-  { year: '1997', sale: 31982 },
-  { year: '1998', sale: 32040 },
-  { year: '1999', sale: 33233 },
+  { year: '1951 年', sale: 38 },
+  { year: '1952 年', sale: 52 },
+  { year: '1956 年', sale: 61 },
+  { year: '1957 年', sale: 145 },
+  { year: '1958 年', sale: 48 },
+  { year: '1959 年', sale: 38 },
+  { year: '1960 年', sale: 38 },
+  { year: '1962 年', sale: 38 },
 ];
 
 export const SALE_OF_YEAR_WITH_TYPE = [
@@ -29,4 +28,27 @@ export const SALE_OF_YEAR_WITH_TYPE = [
   { year: '1997', sale: 28982, type: '食品' },
   { year: '1998', sale: 32040, type: '食品' },
   { year: '1999', sale: 40233, type: '食品' },
+];
+
+export const SCORE_OF_ITEM_WITH_TYPE = [
+  { item: 'Design', type: 'a', score: 70 },
+  { item: 'Design', type: 'b', score: 30 },
+  { item: 'Development', type: 'a', score: 60 },
+  { item: 'Development', type: 'b', score: 70 },
+  { item: 'Marketing', type: 'a', score: 50 },
+  { item: 'Marketing', type: 'b', score: 60 },
+  { item: 'Users', type: 'a', score: 40 },
+  { item: 'Users', type: 'b', score: 50 },
+  { item: 'Test', type: 'a', score: 60 },
+  { item: 'Test', type: 'b', score: 70 },
+  { item: 'Language', type: 'a', score: 70 },
+  { item: 'Language', type: 'b', score: 50 },
+  { item: 'Technology', type: 'a', score: 50 },
+  { item: 'Technology', type: 'b', score: 40 },
+  { item: 'Support', type: 'a', score: 30 },
+  { item: 'Support', type: 'b', score: 40 },
+  { item: 'Sales', type: 'a', score: 60 },
+  { item: 'Sales', type: 'b', score: 40 },
+  { item: 'UX', type: 'a', score: 50 },
+  { item: 'UX', type: 'b', score: 60 },
 ];

--- a/__tests__/unit/runtime/area.spec.ts
+++ b/__tests__/unit/runtime/area.spec.ts
@@ -1,6 +1,10 @@
 import { G2Spec, render } from '../../../src';
 import { createDiv, mount } from '../../utils/dom';
-import { SALE_OF_YEAR, SALE_OF_YEAR_WITH_TYPE } from '../../data/sales';
+import {
+  SALE_OF_YEAR,
+  SALE_OF_YEAR_WITH_TYPE,
+  SCORE_OF_ITEM_WITH_TYPE,
+} from '../../data/sales';
 
 describe('area', () => {
   it('render({...}) should render basic area chart', () => {
@@ -49,19 +53,19 @@ describe('area', () => {
   it('render({...}) should render area chart in polar', () => {
     const chart = render<G2Spec>({
       type: 'area',
-      data: SALE_OF_YEAR_WITH_TYPE,
+      data: SCORE_OF_ITEM_WITH_TYPE,
       encode: {
-        x: 'year',
-        y: 'sale',
+        x: 'item',
+        y: 'score',
         color: 'type',
       },
       scale: {
-        x: { padding: 0.5, align: 0 },
+        x: { guide: { type: 'axisX' }, padding: 0.5, align: 0 },
+        y: { guide: { type: 'axisY', zIndex: 1 }, tickCount: 5 },
       },
-      statistic: [{ type: 'stackY' }],
       coordinate: [{ type: 'polar' }],
       style: {
-        fillOpacity: 0.7,
+        fillOpacity: 0.25,
       },
     });
 

--- a/__tests__/unit/runtime/interval.spec.ts
+++ b/__tests__/unit/runtime/interval.spec.ts
@@ -1005,7 +1005,7 @@ describe('render', () => {
     mount(createDiv(), chart);
   });
 
-  it('render({...} renders interval chart in transposed polar coordinate', () => {
+  it.only('render({...} renders interval chart in transposed polar coordinate', () => {
     const chart = render<G2Spec>({
       type: 'interval',
       data: SALE_OF_YEAR,
@@ -1016,7 +1016,7 @@ describe('render', () => {
       ],
       scale: {
         x: { guide: { type: 'axisX', title: null } },
-        y: { nice: true },
+        y: { guide: { type: 'axisY', title: null }, nice: true },
       },
       encode: {
         x: 'year',

--- a/__tests__/unit/runtime/interval.spec.ts
+++ b/__tests__/unit/runtime/interval.spec.ts
@@ -1,6 +1,7 @@
 import { Polygon } from '@antv/g';
 import { G2Spec, Vector2, render, ShapeComponent } from '../../../src';
 import { createLibrary } from '../../../src/stdlib';
+import { SALE_OF_YEAR } from '../../data/sales';
 import { createDiv, mount, unmountAll } from '../../utils/dom';
 
 describe('render', () => {
@@ -1000,6 +1001,29 @@ describe('render', () => {
       {},
       done,
     );
+
+    mount(createDiv(), chart);
+  });
+
+  it('render({...} renders interval chart in transposed polar coordinate', () => {
+    const chart = render<G2Spec>({
+      type: 'interval',
+      data: SALE_OF_YEAR,
+      coordinate: [
+        { type: 'transpose' },
+        { type: 'polar' },
+        { type: 'cartesian' },
+      ],
+      scale: {
+        x: { guide: { type: 'axisX', title: null } },
+        y: { nice: true },
+      },
+      encode: {
+        x: 'year',
+        y: 'sale',
+        color: 'year',
+      },
+    });
 
     mount(createDiv(), chart);
   });

--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -1,7 +1,8 @@
 import { Coordinate, Vector2 } from '@antv/coord';
-import { Linear } from '@antv/gui';
+import { Arc, Linear } from '@antv/gui';
 import { Linear as LinearScale } from '@antv/scale';
-import { isParallel } from '../utils/coordinate';
+import { deepMix } from '@antv/util';
+import { getPolarOptions, isParallel, isPolar } from '../utils/coordinate';
 import {
   BBox,
   GuideComponentComponent as GCC,
@@ -19,6 +20,7 @@ export type AxisOptions = {
 function inferPosition(
   position: GuideComponentPosition,
   bbox: BBox,
+  coordinate: Coordinate,
 ): {
   startPos: [number, number];
   endPos: [number, number];
@@ -27,6 +29,7 @@ function inferPosition(
   titlePadding: number;
   titleRotate: number;
   verticalFactor: 1 | -1;
+  titleOffsetY?: number;
   labelAlign?: 'start' | 'end' | 'center' | 'left' | 'right';
 } {
   const { x, y, width, height } = bbox;
@@ -61,6 +64,19 @@ function inferPosition(
       labelAlign: 'start',
       labelOffset: 4,
       verticalFactor: 1,
+    };
+  } else if (position === 'arcY') {
+    const [cx, cy] = coordinate.getCenter() as Vector2;
+    const radius = Math.min(bbox.width, bbox.height) / 2;
+    return {
+      startPos: [cx + bbox.x, cy + bbox.y - radius],
+      endPos: [cx + bbox.x, cy + bbox.y],
+      titlePosition: 'start',
+      titlePadding: -16,
+      titleOffsetY: -8,
+      titleRotate: 0,
+      labelOffset: 4,
+      verticalFactor: -1,
     };
   }
   return {
@@ -120,6 +136,18 @@ function getTicks(
 ) {
   const ticks = scale.getTicks?.() || domain;
   const formatter = scale.getFormatter?.() || defaultFormatter;
+
+  if (isPolar(coordinate)) {
+    return ticks.map((d) => {
+      const offset = scale.getBandWidth?.(d) / 2 || 0;
+      const tick = scale.map(d) + offset;
+      return {
+        value: tick,
+        text: formatter(d),
+      };
+    });
+  }
+
   return ticks.map((d) => {
     const offset = scale.getBandWidth?.(d) / 2 || 0;
     const tick = scale.map(d) + offset;
@@ -133,6 +161,44 @@ function getTicks(
   });
 }
 
+const ArcAxis = (options) => {
+  const { position, formatter = (d) => `${d}` } = options;
+  return (scale, value, coordinate, theme) => {
+    const [cx, cy] = coordinate.getCenter() as Vector2;
+    const { domain, bbox } = value;
+    const ticks = getTicks(scale, domain, formatter, position, coordinate);
+    const radius = Math.min(bbox.width, bbox.height) / 2;
+    const [startAngle, endAngle] = getPolarOptions(coordinate);
+    return new Arc({
+      style: deepMix(
+        {},
+        {
+          center: [cx + bbox.x, cy + bbox.y],
+          radius,
+          startAngle,
+          endAngle,
+          ticks,
+          axisLine: {
+            style: {
+              lineWidth: 0,
+              strokeOpacity: 0,
+            },
+          },
+          tickLine: {
+            len: 4,
+            style: { lineWidth: 1 },
+          },
+          label: {
+            align: 'tangential',
+            style: { dy: -2 },
+          },
+        },
+        scale.getOptions().guide,
+      ),
+    });
+  };
+};
+
 /**
  * Guide Component for position channel(e.g. x, y).
  * @todo Render Circular in polar coordinate.
@@ -141,6 +207,10 @@ function getTicks(
 export const Axis: GCC<AxisOptions> = (options) => {
   const { position, title = true, formatter = (d) => `${d}` } = options;
   return (scale, value, coordinate, theme) => {
+    if (position === 'arc') {
+      return ArcAxis(options)(scale, value, coordinate, theme);
+    }
+
     const { domain, field, bbox } = value;
     const {
       startPos,
@@ -150,42 +220,45 @@ export const Axis: GCC<AxisOptions> = (options) => {
       titlePadding,
       titleRotate,
       verticalFactor,
-    } = inferPosition(position, bbox);
+      titleOffsetY,
+    } = inferPosition(position, bbox, coordinate);
     const ticks = getTicks(scale, domain, formatter, position, coordinate);
-    const axis = new Linear({
-      style: {
-        startPos,
-        endPos,
-        verticalFactor,
-        ticks,
-        label: {
-          tickPadding: labelOffset,
-          autoHide: true,
-          style: {},
-        },
-        axisLine: {
-          style: {
-            lineWidth: 0,
-            strokeOpacity: 0,
+    return new Linear({
+      style: deepMix(
+        {
+          startPos,
+          endPos,
+          verticalFactor,
+          ticks,
+          label: {
+            tickPadding: labelOffset,
+            autoHide: true,
+            style: {},
           },
-        },
-        tickLine: {
-          len: 5,
-          style: { lineWidth: 1 },
-        },
-        ...(field &&
-          title && {
-            title: {
-              content: Array.isArray(field) ? field[0] : field,
-              titleAnchor: scale.getTicks ? titlePosition : 'center',
-              style: { fontWeight: 'bold', fillOpacity: 1 },
-              titlePadding,
-              rotate: titleRotate,
+          axisLine: {
+            style: {
+              lineWidth: 0,
+              strokeOpacity: 0,
             },
-          }),
-      },
+          },
+          tickLine: {
+            len: 4,
+            style: { lineWidth: 1 },
+          },
+          ...(field &&
+            title && {
+              title: {
+                content: Array.isArray(field) ? field[0] : field,
+                titleAnchor: scale.getTicks ? titlePosition : 'center',
+                style: { fontWeight: 'bold', fillOpacity: 1, dy: titleOffsetY },
+                titlePadding,
+                rotate: titleRotate,
+              },
+            }),
+        },
+        scale.getOptions().guide || {},
+      ),
     });
-    return axis;
   };
 };
 

--- a/src/component/legendCategory.ts
+++ b/src/component/legendCategory.ts
@@ -41,7 +41,6 @@ export const LegendCategory: GCC<LegendCategoryOptions> = (options) => {
         ...(field && {
           title: {
             content: Array.isArray(field) ? field[0] : field,
-            spacing: 0,
             style: {
               fontSize: 12,
               fontWeight: 'bold',

--- a/src/component/legendContinuous.ts
+++ b/src/component/legendContinuous.ts
@@ -23,18 +23,17 @@ export const LegendContinuous: GCC<LegendContinuousOptions> = (options) => {
         x,
         y,
         rail: {
-          width: 120,
-          height: 12,
+          // length: 120,
+          // size: 12,
           ticks,
         },
         min,
         max,
         indicator: null,
-        handle: false,
+        handle: null,
         ...(field && {
           title: {
             content: Array.isArray(field) ? field[0] : field,
-            spacing: 0,
             style: {
               fontSize: 12,
             },

--- a/src/runtime/component.ts
+++ b/src/runtime/component.ts
@@ -95,12 +95,11 @@ function inferComponentType(
   scale: G2ScaleOptions,
   coordinates: G2CoordinateOptions[],
 ) {
-  if (isPolar(coordinates)) return null;
-  if (isTranspose(coordinates)) return null;
-
   const { name, guide, type: scaleType } = scale;
   const { type } = guide;
   if (type !== undefined) return type;
+  if (isTranspose(coordinates)) return null;
+  if (isPolar(coordinates)) return null;
   if (name === 'x') return 'axisX';
   if (name === 'y') return 'axisY';
   if (name.startsWith('position')) return 'axisY';
@@ -143,6 +142,14 @@ function inferComponentPosition(
     if (match === null) return ordinalPosition;
     const index = +match[1];
     return index === 0 ? ordinalPosition : 'centerHorizontal';
+  } else if (
+    type === 'axisX' &&
+    isPolar(coordinate) &&
+    !isTranspose(coordinate)
+  ) {
+    return 'arc';
+  } else if (isPolar(coordinate) && (type === 'axisX' || type === 'axisY')) {
+    return 'arcY';
   }
   return ordinalPosition;
 }

--- a/src/runtime/component.ts
+++ b/src/runtime/component.ts
@@ -143,9 +143,8 @@ function inferComponentPosition(
     const index = +match[1];
     return index === 0 ? ordinalPosition : 'centerHorizontal';
   } else if (
-    type === 'axisX' &&
-    isPolar(coordinate) &&
-    !isTranspose(coordinate)
+    (type === 'axisX' && isPolar(coordinate) && !isTranspose(coordinate)) ||
+    (type === 'axisY' && isPolar(coordinate) && isTranspose(coordinate))
   ) {
     return 'arc';
   } else if (isPolar(coordinate) && (type === 'axisX' || type === 'axisY')) {

--- a/src/runtime/layout.ts
+++ b/src/runtime/layout.ts
@@ -86,12 +86,16 @@ export function placeComponents(
     bottom: [pl, height - pb, innerWidth, pb, 0, false, descending],
     left: [0, pt, pl, innerHeight, 1, true, ascending],
     centerHorizontal: [pl, pt, innerWidth, innerHeight, -1, null, null],
+    arc: [pl, pt, width - pl - pr, height - pt - pb, -1, null, null],
+    arcY: [pl, pt, width - pl - pr, height - pt - pb, -1, null, null],
   };
 
   for (const [key, components] of positionComponents.entries()) {
     const area = section[key];
     if (key === 'centerHorizontal') {
       placeCenterHorizontal(components, layout, coordinate, area);
+    } else if (key === 'arc' || key === 'arcY') {
+      placeArc(components, coordinate, area);
     } else {
       placePaddingArea(components, coordinate, area);
     }
@@ -160,5 +164,17 @@ function placePaddingArea(
       [crossSizeKey]: crossSizeValue,
     };
     start += size * (reverse ? -1 : 1);
+  }
+}
+
+function placeArc(
+  components: G2GuideComponentOptions[],
+  coordinate: Coordinate,
+  area: SectionArea,
+) {
+  const [x, y, width, height] = area;
+  for (let i = 0; i < components.length; i++) {
+    const component = components[i];
+    component.bbox = { x, y, width, height };
   }
 }

--- a/src/runtime/types/common.ts
+++ b/src/runtime/types/common.ts
@@ -84,7 +84,9 @@ export type GuideComponentPosition =
   | 'left'
   | 'bottom'
   | 'right'
-  | 'centerHorizontal';
+  | 'centerHorizontal'
+  | 'arc'
+  | 'arcY';
 
 export type Layout = {
   paddingLeft?: number;

--- a/src/utils/coordinate.ts
+++ b/src/utils/coordinate.ts
@@ -17,3 +17,9 @@ export function isParallel(coordinate: Coordinate): boolean {
   const { transformations } = coordinate.getOptions();
   return transformations.some(([type]) => type === 'parallel');
 }
+
+export function getPolarOptions(coordinate: Coordinate): [number, number] {
+  const { transformations } = coordinate.getOptions();
+  const [, sr, er] = transformations.find(([type]) => type === 'polar');
+  return [(+sr / Math.PI) * 180, (+er / Math.PI) * 180];
+}

--- a/src/utils/coordinate.ts
+++ b/src/utils/coordinate.ts
@@ -17,9 +17,3 @@ export function isParallel(coordinate: Coordinate): boolean {
   const { transformations } = coordinate.getOptions();
   return transformations.some(([type]) => type === 'parallel');
 }
-
-export function getPolarOptions(coordinate: Coordinate): [number, number] {
-  const { transformations } = coordinate.getOptions();
-  const [, sr, er] = transformations.find(([type]) => type === 'polar');
-  return [(+sr / Math.PI) * 180, (+er / Math.PI) * 180];
-}


### PR DESCRIPTION
**feat:** support axis in polar coordinate

**Features:** components
    - add `axisArc` (default in `circle` position)
    - `axis` support `circle` position
    - support custom axisStyleProps by config `scale.guide`


### Radar chart in polar coordinate

<img width="533" alt="image" src="https://user-images.githubusercontent.com/15646325/168715875-9777bbf6-1c04-41be-a32b-bfcfed7eac83.png">


```ts
const chart = render({
  type: 'area',
  data: SCORE_OF_ITEM_WITH_TYPE,
  encode: {
    x: 'item',
    y: 'score',
    color: 'type',
  },
  scale: {
    x: { guide: { type: 'axisX' }, padding: 0.5, align: 0 },
    y: { guide: { type: 'axisY', zIndex: 1 }, tickCount: 5 },
  },
  coordinate: [{ type: 'polar' }],
  style: {
    fillOpacity: 0.25,
  },
});
```

### Transposed polar coordinate

<img width="542" alt="image" src="https://user-images.githubusercontent.com/15646325/168719262-7c55a1a3-ef2e-4f04-a8e3-5a6436c64e94.png">


```ts
const chart = render({
   type: 'interval',
    data: SALE_OF_YEAR,
    coordinate: [
      { type: 'transpose' },
      { type: 'polar' },
      { type: 'cartesian' },
    ],
    scale: {
      x: { guide: { type: 'axisX', title: null } },
      y: { guide: { type: 'axisY', }, nice: true },
    },
    encode: {
      x: 'year',
      y: 'sale',
      color: 'year',
    },
  });
```
