### PR TITLE
fix: ts errors in ci

### DIFF
--- a/__tests__/unit/runtime/annotationConnector.spec.ts
+++ b/__tests__/unit/runtime/annotationConnector.spec.ts
@@ -46,7 +46,7 @@ describe('connector Annotation', () => {
     mount(createDiv(), chart);
   });
 
-  it.only('render({...} renders chart with connector annotation in transpose coordinate.', () => {
+  it('render({...} renders chart with connector annotation in transpose coordinate.', () => {
     const chart = render<G2Spec>(
       {
         type: 'view',

--- a/__tests__/unit/runtime/annotationConnector.spec.ts
+++ b/__tests__/unit/runtime/annotationConnector.spec.ts
@@ -46,7 +46,7 @@ describe('connector Annotation', () => {
     mount(createDiv(), chart);
   });
 
-  it('render({...} renders chart with connector annotation in transpose coordinate.', () => {
+  it.only('render({...} renders chart with connector annotation in transpose coordinate.', () => {
     const chart = render<G2Spec>(
       {
         type: 'view',

--- a/__tests__/unit/runtime/interval.spec.ts
+++ b/__tests__/unit/runtime/interval.spec.ts
@@ -1005,7 +1005,7 @@ describe('render', () => {
     mount(createDiv(), chart);
   });
 
-  it.only('render({...} renders interval chart in transposed polar coordinate', () => {
+  it('render({...} renders interval chart in transposed polar coordinate', () => {
     const chart = render<G2Spec>({
       type: 'interval',
       data: SALE_OF_YEAR,

--- a/__tests__/unit/shape/annotation/connector.spec.ts
+++ b/__tests__/unit/shape/annotation/connector.spec.ts
@@ -25,8 +25,8 @@ describe('AnnotationConnector shape', () => {
     mount(createDiv(), container);
 
     expect(shape.nodeName).toBe('g');
-    expect(style(shape, ['path'])).toEqual({
-      path: 'M60,200L60,188L240,188L240,200',
+    expect(style(shape, ['connectorPath'])).toEqual({
+      connectorPath: 'M60,200L60,188L240,188L240,200',
     });
     // @ts-ignore
     expect(shape.endMarker.style.symbol(0, 0, 8)).toEqual([

--- a/__tests__/unit/shape/interval/rect.spec.ts
+++ b/__tests__/unit/shape/interval/rect.spec.ts
@@ -25,8 +25,9 @@ describe('Rect', () => {
       fill: 'steelblue',
       height: 400,
       width: 120,
-      x: 0,
-      y: 0,
+      // G will convert "" to 0
+      x: '',
+      y: '',
     });
   });
 
@@ -51,8 +52,8 @@ describe('Rect', () => {
       fill: 'steelblue',
       height: 400,
       width: 120,
-      x: 0,
-      y: 0,
+      x: '',
+      y: '',
     });
   });
 
@@ -78,8 +79,8 @@ describe('Rect', () => {
       fill: 'steelblue',
       height: 80,
       width: 600,
-      x: 0,
-      y: 0,
+      x: '',
+      y: '',
     });
   });
 

--- a/src/component/legendCategory.ts
+++ b/src/component/legendCategory.ts
@@ -26,7 +26,9 @@ export const LegendCategory: GCC<LegendCategoryOptions> = (options) => {
     return new Category({
       style: {
         items,
+        // @ts-ignore
         x,
+        // @ts-ignore
         y,
         maxWidth: width,
         maxHeight: height,

--- a/src/component/legendContinuous.ts
+++ b/src/component/legendContinuous.ts
@@ -20,7 +20,9 @@ export const LegendContinuous: GCC<LegendContinuousOptions> = (options) => {
     const [min, max] = domain;
     return new Continuous({
       style: {
+        // @ts-ignore
         x,
+        // @ts-ignore
         y,
         rail: {
           // length: 120,

--- a/src/shape/annotation/connector.ts
+++ b/src/shape/annotation/connector.ts
@@ -4,6 +4,7 @@ import {
   DisplayObjectConfig,
   Path,
   PathStyleProps,
+  PathCommand,
 } from '@antv/g';
 import { Marker } from '@antv/gui';
 import { line as d3line } from 'd3-shape';
@@ -19,7 +20,8 @@ type MarkerStyleProps = {
   symbol?: string | ((x: number, y: number, r: number) => string);
 };
 
-type ConnectorPathStyleProps = PathStyleProps & {
+type ConnectorPathStyleProps = Omit<PathStyleProps, 'path'> & {
+  connectorPath?: PathCommand[];
   direction?: 'upward' | 'downward';
   endMarker?: MarkerStyleProps;
 };
@@ -47,18 +49,16 @@ class ConnectorPath extends CustomElement<ConnectorPathStyleProps> {
   }
 
   private drawPath() {
-    const { x: x0, y: y0, path, ...style } = this.attributes;
+    const { connectorPath, ...style } = this.attributes;
     this.connector = select(this.connector || this.appendChild(new Path({})))
-      .style('path', path)
+      .style('path', connectorPath)
       .call(applyStyle, style)
       .node() as Path;
   }
 
   private drawEndMarker() {
     const { stroke, endMarker } = this.style;
-    this.endMarker = select(
-      this.endMarker || this.appendChild(new Marker({})),
-    ).node() as Marker;
+    this.endMarker = this.endMarker || this.appendChild(new Marker({}));
     this.endMarker.update({ size: 8, fill: stroke, ...endMarker });
   }
 }
@@ -119,7 +119,7 @@ export const Connector: SC<ConnectorOptions> = (options) => {
     const [, , , p3] = P;
 
     return select(new ConnectorPath({}))
-      .style('path', path)
+      .style('connectorPath', path)
       .style('stroke', color)
       .style('transform', transform)
       .style('endMarker', {

--- a/src/shape/annotation/text.ts
+++ b/src/shape/annotation/text.ts
@@ -21,7 +21,7 @@ type MarkerStyleProps = {
 };
 
 type TextShapeStyleProps = Omit<TextStyleProps, 'text'> & {
-  connector?: Omit<PathStyleProps, 'x' | 'y'>;
+  connector?: PathStyleProps;
   startMarker?: MarkerStyleProps;
   endMarker?: MarkerStyleProps;
   background?: Omit<RectStyleProps, 'width' | 'height' | 'x' | 'y'> & {
@@ -77,7 +77,7 @@ class TextShape extends CustomElement<TextShapeStyleProps> {
 
   private get endPoint() {
     const { connector } = this.style;
-    if (connector?.path?.length > 0) {
+    if (Array.isArray(connector?.path) && connector.path.length) {
       const [[, x, y]] = connector.path.slice(-1);
       return { x, y };
     }


### PR DESCRIPTION
- fix: G will convert `x: ""` to `x: 0"` and `y: ""` to `y: 0"` internal.
- [todo] fix: GUI legend types definition later

<img width="790" alt="image" src="https://user-images.githubusercontent.com/15646325/168954109-1a9ede5f-9135-4e28-9d60-28b0e39cb06e.png">
