### PR TITLE
feat: add jitter and jitterY transform

### DIFF
--- a/.genjirc
+++ b/.genjirc
@@ -5,7 +5,8 @@
     "Dimension": "dimension",
     "Transform": {
       "Stack": "Stack",
-      "Normalize": "Normalize"
+      "Normalize": "Normalize",
+      "Jitter": "Jitter"
     },
     "Encode": "encode",
     "Scale": "scale",

--- a/__tests__/unit/mark/geometry/point.spec.ts
+++ b/__tests__/unit/mark/geometry/point.spec.ts
@@ -17,6 +17,8 @@ describe('Point', () => {
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true },
         { name: 'y', required: true },
+        { name: 'dx', scale: 'identity' },
+        { name: 'dy', scale: 'identity' },
         { name: 'size', required: true },
       ],
       preInference: [

--- a/__tests__/unit/mark/geometry/point.spec.ts
+++ b/__tests__/unit/mark/geometry/point.spec.ts
@@ -17,9 +17,9 @@ describe('Point', () => {
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true },
         { name: 'y', required: true },
+        { name: 'size', required: true },
         { name: 'dx', scale: 'identity' },
         { name: 'dy', scale: 'identity' },
-        { name: 'size', required: true },
       ],
       preInference: [
         { type: 'maybeArrayField' },

--- a/__tests__/unit/runtime/statistic.spec.ts
+++ b/__tests__/unit/runtime/statistic.spec.ts
@@ -313,4 +313,75 @@ describe('statistic', () => {
     });
     mount(createDiv(), chart);
   });
+
+  it('should render jittered points in x and y dimensions', () => {
+    const chart = render<G2Spec>({
+      type: 'point',
+      transform: [
+        {
+          type: 'fetch',
+          url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
+        },
+        { type: 'jitter' },
+      ],
+      scale: { x: { padding: 0.5 }, y: { guide: null } },
+      encode: {
+        x: 'clarity',
+        color: 'clarity',
+      },
+    });
+    mount(createDiv(), chart);
+  });
+
+  it('should render jittered points in polar', () => {
+    const chart = render<G2Spec>({
+      type: 'point',
+      transform: [
+        {
+          type: 'fetch',
+          url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
+        },
+        { type: 'jitter', paddingX: 0.1, paddingY: 0.1 },
+      ],
+      paddingLeft: 90,
+      coordinate: [{ type: 'polar' }],
+      scale: {
+        x: { padding: 0.5 },
+        y: { padding: 0.5 },
+        color: { guide: null },
+      },
+      encode: {
+        x: 'clarity',
+        y: 'cut',
+        color: (d) => `(${d.clarity}, ${d.cut})`,
+      },
+    });
+    mount(createDiv(), chart);
+  });
+
+  it('should render jittered points in y dimension', () => {
+    const chart = render<G2Spec>({
+      type: 'point',
+      transform: [
+        {
+          type: 'fetch',
+          url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
+        },
+        { type: 'jitterY', padding: 0.1 },
+      ],
+      paddingLeft: 90,
+      scale: {
+        x: { padding: 0.5 },
+        y: { padding: 0.5 },
+        color: { guide: null },
+      },
+      encode: {
+        x: 'clarity',
+        y: 'cut',
+        shape: 'hyphen',
+        size: 25,
+      },
+    });
+    mount(createDiv(), chart);
+  });
 });

--- a/__tests__/unit/shape/point/point.spec.ts
+++ b/__tests__/unit/shape/point/point.spec.ts
@@ -27,7 +27,7 @@ describe('Point', () => {
     expect(shape.nodeName).toBe('path');
     expect(style(shape, ['fill', 'lineWidth'])).toEqual({
       fill: 'steelblue',
-      lineWidth: 1,
+      lineWidth: '',
     });
   });
 

--- a/__tests__/unit/shape/text/text.spec.ts
+++ b/__tests__/unit/shape/text/text.spec.ts
@@ -35,7 +35,7 @@ describe('Text', () => {
     expect(style(shape, ['fill', 'stroke', 'lineWidth'])).toEqual({
       fill: 'steelblue',
       stroke: 'steelblue',
-      lineWidth: 0,
+      lineWidth: '',
     });
   });
 

--- a/__tests__/unit/stdlib/index.spec.ts
+++ b/__tests__/unit/stdlib/index.spec.ts
@@ -128,6 +128,8 @@ import {
   Voronoi,
   Sankey,
   NormalizeY,
+  Jitter,
+  JitterY,
 } from '../../../src/transform';
 
 describe('stdlib', () => {
@@ -152,6 +154,8 @@ describe('stdlib', () => {
       'transform.maybeSeries': MaybeSeries,
       'transform.stackY': StackY,
       'transform.dodgeX': DodgeX,
+      'transform.jitter': Jitter,
+      'transform.jitterY': JitterY,
       'transform.stackEnter': StackEnter,
       'transform.normalizeY': NormalizeY,
       'transform.maybeSize': MaybeSize,

--- a/docs/jitter.md
+++ b/docs/jitter.md
@@ -1,0 +1,85 @@
+# Jitter
+
+The **jitter** transform produce dy channels for marks (especially for point) with ordinal x and y dimension, say to make them jitter in their own space. It is useful to see the density of distribution for data.
+
+- _Jitter_ - Produce both dx and y channels.
+- _JitterY_ - Produce only dy channel, which result in produce dy channel in transpose coordinate.
+
+It also support _padding_ option to specify padding of space.
+
+## Jitter Both
+
+```js
+G2.render({
+  type: 'point',
+  transform: [
+    {
+      type: 'fetch',
+      url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
+    },
+    { type: 'jitter' },
+  ],
+  scale: { x: { padding: 0.5 }, y: { guide: null } },
+  encode: {
+    x: 'clarity',
+    color: 'clarity',
+  },
+});
+```
+
+## Jitter In Polar
+
+Specify _paddingX_ and _paddingY_ option for jitter.
+
+```js
+G2.render({
+  type: 'point',
+  transform: [
+    {
+      type: 'fetch',
+      url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
+    },
+    { type: 'jitter', paddingX: 0.05, paddingY: 0.05 },
+  ],
+  paddingLeft: 90,
+  coordinate: [{ type: 'polar' }],
+  scale: {
+    x: { padding: 0.5 },
+    y: { padding: 0.5 },
+  },
+  encode: {
+    x: 'clarity',
+    y: 'cut',
+    color: (d) => `(${d.clarity}, ${d.cut})`,
+  },
+});
+```
+
+## JitterY
+
+Specify _padding_ option for jitterY.
+
+```js
+G2.render({
+  type: 'point',
+  transform: [
+    {
+      type: 'fetch',
+      url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
+    },
+    { type: 'jitterY', padding: 0.1 },
+  ],
+  paddingLeft: 90,
+  scale: {
+    x: { padding: 0.5 },
+    y: { padding: 0.5 },
+    color: { guide: null },
+  },
+  encode: {
+    x: 'clarity',
+    y: 'cut',
+    shape: 'hyphen',
+    size: 25,
+  },
+});
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -97,7 +97,7 @@ genji.preview(
       title: 'Jitter In Polar',
       path: '/jitter#jitter-in-polar',
       thumbnail:
-        'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*y4cqTb9zA6YAAAAAAAAAAAAAARQnAQ',
+        'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*Z0BHQ6NBLT0AAAAAAAAAAAAAARQnAQ',
     },
     {
       title: 'JitterY',

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -82,6 +82,34 @@ genji.preview(
 );
 ```
 
+### Jitter
+
+```js | dom "pin: false"
+genji.preview(
+  [
+    {
+      title: 'Jitter Both',
+      path: '/jitter#jitter-both',
+      thumbnail:
+        'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*-MaBTb6i7RQAAAAAAAAAAAAAARQnAQ',
+    },
+    {
+      title: 'Jitter In Polar',
+      path: '/jitter#jitter-in-polar',
+      thumbnail:
+        'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*y4cqTb9zA6YAAAAAAAAAAAAAARQnAQ',
+    },
+    {
+      title: 'JitterY',
+      path: '/jitter#jittery',
+      thumbnail:
+        'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*qSd7S56SzGMAAAAAAAAAAAAAARQnAQ',
+    },
+  ],
+  { height: 175 },
+);
+```
+
 ## Scale
 
 > TODO
@@ -201,26 +229,29 @@ genji.preview(
 ## Annotation
 
 ```js | dom "pin: false"
-genji.preview([
-  {
-    title: 'Text Annotation',
-    path: '/annotation#text-annotation',
-    thumbnail:
-      'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*rbg3QYa_Vx4AAAAAAAAAAAAAARQnAQ',
-  },
-  {
-    title: 'Badge Annotation',
-    path: '/annotation#badge-annotation',
-    thumbnail:
-      'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*VZLqQYo5pokAAAAAAAAAAAAAARQnAQ',
-  },
-  {
-    title: 'Connector Annotation',
-    path: '/annotation#connector-annotation',
-    thumbnail:
-      'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*pkbESpuunUwAAAAAAAAAAAAAARQnAQ',
-  }
-]);
+genji.preview(
+  [
+    {
+      title: 'Text Annotation',
+      path: '/annotation#text-annotation',
+      thumbnail:
+        'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*rbg3QYa_Vx4AAAAAAAAAAAAAARQnAQ',
+    },
+    {
+      title: 'Badge Annotation',
+      path: '/annotation#badge-annotation',
+      thumbnail:
+        'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*VZLqQYo5pokAAAAAAAAAAAAAARQnAQ',
+    },
+    {
+      title: 'Connector Annotation',
+      path: '/annotation#connector-annotation',
+      thumbnail:
+        'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*pkbESpuunUwAAAAAAAAAAAAAARQnAQ',
+    },
+  ],
+  { height: 175 },
+);
 ```
 
 ## Animation

--- a/src/mark/geometry/point.ts
+++ b/src/mark/geometry/point.ts
@@ -16,11 +16,13 @@ export type PointOptions = Omit<PointGeometry, 'type'>;
  */
 export const Point: MC<PointOptions> = () => {
   return (index, scale, value, coordinate) => {
-    const { x: X, y: Y, size: S } = value;
+    const { x: X, y: Y, size: S, dx: DX, dy: DY } = value;
     const [width, height] = coordinate.getSize();
     const P = Array.from(index, (i) => {
-      const cx = +X[i];
-      const cy = +Y[i];
+      const dx = +(DX?.[i] || 0);
+      const dy = +(DY?.[i] || 0);
+      const cx = +X[i] + dx;
+      const cy = +Y[i] + dy;
       const r = +S[i];
       const a = r / width;
       const b = r / height;
@@ -39,6 +41,8 @@ Point.props = {
     { name: 'x', required: true },
     { name: 'y', required: true },
     { name: 'size', required: true },
+    { name: 'dx', scale: 'identity' },
+    { name: 'dy', scale: 'identity' },
   ],
   preInference: [
     ...basePreInference(),

--- a/src/runtime/mark.ts
+++ b/src/runtime/mark.ts
@@ -114,7 +114,7 @@ function createTransformContext(
     'encode',
     library,
   );
-  const { data, encode = {}, transform = [] } = mark;
+  const { data, encode = {}, transform = [], scale = {} } = mark;
   const columnOf: ColumnOf = (data, encode) => {
     if (encode === undefined) return null;
     if (data === undefined) return null;
@@ -130,6 +130,7 @@ function createTransformContext(
     encode: flatEncode(encode),
     columnOf,
     transform,
+    scale,
   };
 }
 

--- a/src/runtime/types/transform.ts
+++ b/src/runtime/types/transform.ts
@@ -6,6 +6,8 @@ export type TransformContext = {
   encode?: Record<string, EncodeSpec>;
   columnOf?: ColumnOf;
   transform?: TransformSpec[];
+  // @todo Replace with ScaleSpec
+  scale?: Record<string, any>;
 };
 
 export type TransformOptions = Record<string, any>;

--- a/src/shape/point/colorPoint.ts
+++ b/src/shape/point/colorPoint.ts
@@ -25,8 +25,8 @@ export const ColorPoint: SC<ColorPointOptions> = (options) => {
     const { color = defaultColor, transform } = value;
     const [[x0, y0], [x2, y2]] = points;
     const [cx, cy] = [(x0 + x2) / 2, (y0 + y2) / 2];
-    const a = (x2 - x0) / 2;
-    const b = (y2 - y0) / 2;
+    const a = Math.abs((x2 - x0) / 2);
+    const b = Math.abs((y2 - y0) / 2);
     const r = Math.max(0, (a + b) / 2);
     return select(new Path({}))
       .style('d', path(cx, cy, r))

--- a/src/shape/point/colorPoint.ts
+++ b/src/shape/point/colorPoint.ts
@@ -1,4 +1,6 @@
 import { Path } from '@antv/g';
+import { Coordinate, Vector2 } from '@antv/coord';
+import { isFisheye } from '../../utils/coordinate';
 import { ShapeComponent as SC } from '../../runtime';
 import { select } from '../../utils/selection';
 import { applyStyle } from '../utils';
@@ -7,27 +9,46 @@ import * as Symbols from './symbol';
 export type ColorPointOptions = {
   colorAttribute: 'fill' | 'stroke';
   symbol: string;
+  mode?: 'fixed' | 'auto' | 'normal';
   [key: string]: any;
 };
+
+function getRadius(
+  mode: ColorPointOptions['mode'],
+  points: Vector2[],
+  value: Record<string, any>,
+  coordinate: Coordinate,
+) {
+  const { size } = value;
+  if (mode === 'fixed') return size;
+  if (mode === 'normal' || isFisheye(coordinate)) {
+    const [[x0, y0], [x2, y2]] = points;
+    const a = Math.abs((x2 - x0) / 2);
+    const b = Math.abs((y2 - y0) / 2);
+    return Math.max(0, (a + b) / 2);
+  }
+  return size;
+}
+
+function getOrigin(points: Vector2[]) {
+  const [[x0, y0], [x2, y2]] = points;
+  return [(x0 + x2) / 2, (y0 + y2) / 2];
+}
 
 /**
  * Render point in different coordinate.
  */
 export const ColorPoint: SC<ColorPointOptions> = (options) => {
   // Render border only when colorAttribute is stroke.
-  const { colorAttribute, symbol, ...style } = options;
+  const { colorAttribute, symbol, mode = 'auto', ...style } = options;
   const lineWidth = colorAttribute === 'stroke' ? 1 : undefined;
-
   const path = Symbols[symbol] || Symbols.point;
 
   return (points, value, coordinate, theme) => {
     const { defaultColor } = theme;
     const { color = defaultColor, transform } = value;
-    const [[x0, y0], [x2, y2]] = points;
-    const [cx, cy] = [(x0 + x2) / 2, (y0 + y2) / 2];
-    const a = Math.abs((x2 - x0) / 2);
-    const b = Math.abs((y2 - y0) / 2);
-    const r = Math.max(0, (a + b) / 2);
+    const [cx, cy] = getOrigin(points);
+    const r = getRadius(mode, points, value, coordinate);
     return select(new Path({}))
       .style('d', path(cx, cy, r))
       .style('lineWidth', lineWidth)

--- a/src/spec/statistic.ts
+++ b/src/spec/statistic.ts
@@ -4,13 +4,17 @@ export type StatisticTransform =
   | StackYTransform
   | DodgeXTransform
   | NormalizeYTransform
-  | StackEnterTransform;
+  | StackEnterTransform
+  | JitterTransform
+  | JitterYTransform;
 
 export type StatisticTransformTypes =
   | 'dodgeX'
   | 'stackY'
   | 'normalizeY'
   | 'stackEnter'
+  | 'jitter'
+  | 'jitterY'
   | TransformComponent;
 
 export type DodgeXTransform = {
@@ -45,6 +49,17 @@ export type NormalizeYTransform = {
     | 'min'
     | 'sum'
     | 'extent';
+};
+
+export type JitterTransform = {
+  type?: 'jitter';
+  paddingX?: number;
+  paddingY?: number;
+};
+
+export type JitterYTransform = {
+  type?: 'jitterY';
+  padding?: number;
 };
 
 export type StackEnterTransform = {

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -117,6 +117,8 @@ import {
   Voronoi,
   Sankey,
   NormalizeY,
+  Jitter,
+  JitterY,
 } from '../transform';
 
 export function createLibrary(): G2Library {
@@ -140,6 +142,8 @@ export function createLibrary(): G2Library {
     'transform.maybeSeries': MaybeSeries,
     'transform.stackY': StackY,
     'transform.dodgeX': DodgeX,
+    'transform.jitter': Jitter,
+    'transform.jitterY': JitterY,
     'transform.stackEnter': StackEnter,
     'transform.normalizeY': NormalizeY,
     'transform.maybeSize': MaybeSize,

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -22,6 +22,8 @@ export { StackY, StackYOptions } from './statistic/stackY';
 export { DodgeX, DodgeXOptions } from './statistic/dodgeX';
 export { StackEnter, StackEnterOptions } from './statistic/stackEnter';
 export { NormalizeY, NormalizeYOptions } from './statistic/normalizeY';
+export { Jitter, JitterOptions } from './statistic/Jitter';
+export { JitterY, JitterYOptions } from './statistic/JitterY';
 
 // Connector
 export { Fetch, FetchOptions } from './connector/fetch';

--- a/src/transform/statistic/Jitter.ts
+++ b/src/transform/statistic/Jitter.ts
@@ -1,0 +1,52 @@
+import { Band } from '@antv/scale';
+import { ColumnValue, TransformComponent as TC } from '../../runtime';
+import { JitterTransform } from '../../spec';
+import { merge, column } from '../utils/helper';
+import { random } from '../../utils/helper';
+
+export type JitterOptions = Omit<JitterTransform, 'type'>;
+
+function domainOf(value: ColumnValue) {
+  return Array.from(new Set(value));
+}
+
+export function rangeOf(
+  value: ColumnValue,
+  scaleOptions: Record<string, any>,
+  padding: number,
+): [number, number] {
+  if (value === null) return [-0.5, 0.5];
+  const domain = scaleOptions?.domain || domainOf(value);
+  const scale = new Band({ domain, range: [0, 1], padding });
+  const step = scale.getBandWidth();
+  return [-step / 2, step / 2];
+}
+
+/**
+ * The jitter transform produce dx and dy channels for marks (especially for point)
+ * with ordinal x and y dimension, say to make them jitter in their own space.
+ */
+export const Jitter: TC<JitterOptions> = (options = {}) => {
+  const { paddingX = 0, paddingY = 0 } = options;
+  return merge((context) => {
+    const { data, I, columnOf, encode, scale } = context;
+    const { x, y } = encode;
+    const { x: scaleX, y: scaleY } = scale;
+    const X = columnOf(data, x);
+    const Y = columnOf(data, y);
+    const rangeX = rangeOf(X, scaleX, paddingX);
+    const rangeY = rangeOf(Y, scaleY, paddingY);
+    const DY = I.map(() => random(...rangeY));
+    const DX = I.map(() => random(...rangeX));
+    return {
+      encode: {
+        dy: column(DY),
+        dx: column(DX),
+      },
+    };
+  });
+};
+
+Jitter.props = {
+  category: 'statistic',
+};

--- a/src/transform/statistic/JitterY.ts
+++ b/src/transform/statistic/JitterY.ts
@@ -1,0 +1,32 @@
+import { TransformComponent as TC } from '../../runtime';
+import { JitterYTransform } from '../../spec';
+import { merge, column } from '../utils/helper';
+import { random } from '../../utils/helper';
+import { rangeOf } from './Jitter';
+
+export type JitterYOptions = Omit<JitterYTransform, 'type'>;
+
+/**
+ * The jitterY transform produce dy channels for marks (especially for point)
+ * with ordinal x and y dimension, say to make them jitter in their own space.
+ */
+export const JitterY: TC<JitterYOptions> = (options = {}) => {
+  const { padding = 0 } = options;
+  return merge((context) => {
+    const { data, I, columnOf, encode, scale } = context;
+    const { y } = encode;
+    const { y: scaleY } = scale;
+    const Y = columnOf(data, y);
+    const rangeY = rangeOf(Y, scaleY, padding);
+    const DY = I.map(() => random(...rangeY));
+    return {
+      encode: {
+        dy: column(DY),
+      },
+    };
+  });
+};
+
+JitterY.props = {
+  category: 'statistic',
+};

--- a/src/transform/statistic/stackY.ts
+++ b/src/transform/statistic/stackY.ts
@@ -6,7 +6,7 @@ import { normalizeComparator, createGroups, applyOrder } from './utils';
 export type StackYOptions = Omit<StackYTransform, 'type'>;
 
 /**
- * The **stack** transform group marks into series by color or series channel,
+ * The stack transform group marks into series by color or series channel,
  * and then produce new y channel for each series by specified order,
  * say to form vertical "stacks" by specified channels.
  */

--- a/src/utils/coordinate.ts
+++ b/src/utils/coordinate.ts
@@ -17,3 +17,8 @@ export function isParallel(coordinate: Coordinate): boolean {
   const { transformations } = coordinate.getOptions();
   return transformations.some(([type]) => type === 'parallel');
 }
+
+export function isFisheye(coordinate: Coordinate): boolean {
+  const { transformations } = coordinate.getOptions();
+  return transformations.some(([type]) => type === 'fisheye');
+}

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -45,3 +45,7 @@ export function copyAttributes(target: DisplayObject, source: DisplayObject) {
 export function defined(x: any) {
   return x !== undefined && x !== null && !Number.isNaN(x);
 }
+
+export function random(a: number, b: number): number {
+  return a + (b - a) * Math.random();
+}


### PR DESCRIPTION
feat: add jitter and jitterY transform

The **jitter** transform produce dy channels for marks (especially for point) with ordinal x and y dimension, say to make them jitter in their own space. It is useful to see the density of distribution for data.

- _Jitter_ - Produce both dx and y channels.
- _JitterY_ - Produce only dy channel, which result in produce dy channel in transpose coordinate.

It also supports _padding_ option to specify padding of space.

**Jitter Both**

![image](https://user-images.githubusercontent.com/49330279/170933352-30228e18-c596-4f87-8e91-f667392a74af.png)

```js
G2.render({
  type: 'point',
  transform: [
    {
      type: 'fetch',
      url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
    },
    { type: 'jitter' },
  ],
  scale: { x: { padding: 0.5 }, y: { guide: null } },
  encode: {
    x: 'clarity',
    color: 'clarity',
  },
});
```

**Jitter In Polar**

![image](https://user-images.githubusercontent.com/49330279/170933373-76381813-1fb8-49a2-b309-64b9fd04589e.png)

Specify _paddingX_ and _paddingY_ option for jitter.

```js
G2.render({
  type: 'point',
  transform: [
    {
      type: 'fetch',
      url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
    },
    { type: 'jitter', paddingX: 0.05, paddingY: 0.05 },
  ],
  paddingLeft: 90,
  coordinate: [{ type: 'polar' }],
  scale: {
    x: { padding: 0.5 },
    y: { padding: 0.5 },
  },
  encode: {
    x: 'clarity',
    y: 'cut',
    color: (d) => `(${d.clarity}, ${d.cut})`,
  },
});
```

**JitterY**

![image](https://user-images.githubusercontent.com/49330279/170933408-9ffbd842-9f5b-4900-9235-3dd0c1487478.png)


Specify _padding_ option for jitterY.

```js
G2.render({
  type: 'point',
  transform: [
    {
      type: 'fetch',
      url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
    },
    { type: 'jitterY', padding: 0.1 },
  ],
  paddingLeft: 90,
  scale: {
    x: { padding: 0.5 },
    y: { padding: 0.5 },
    color: { guide: null },
  },
  encode: {
    x: 'clarity',
    y: 'cut',
    shape: 'hyphen',
    size: 25,
  },
});
```
