### PR TITLE
feat(legend): support config category legend

### DIFF
--- a/__tests__/unit/runtime/statistic.spec.ts
+++ b/__tests__/unit/runtime/statistic.spec.ts
@@ -106,9 +106,11 @@ describe('statistic', () => {
         },
         { type: 'stackY', orderBy: 'series' },
       ],
+      paddingTop: 68,
       scale: {
         x: { field: 'Date', utc: true },
         y: { guide: { label: { formatter: (d) => `${+d.text / 1000}k` } } },
+        color: { guide: { autoWrap: true, size: 68, maxRows: 3, cols: 4 } },
       },
       encode: {
         shape: 'smoothArea',

--- a/src/component/legendCategory.ts
+++ b/src/component/legendCategory.ts
@@ -1,4 +1,5 @@
 import { Category } from '@antv/gui';
+import { deepMix } from '@antv/util';
 import {
   GuideComponentComponent as GCC,
   GuideComponentPosition,
@@ -23,19 +24,23 @@ export const LegendCategory: GCC<LegendCategoryOptions> = (options) => {
       name: formatter(d),
       color: scale.map(d),
     }));
-    return new Category({
-      style: {
+    const { cols, autoWrap, ...guideCfg } = scale.getOptions().guide || {};
+    const maxItemWidth = autoWrap && cols ? width / cols : undefined;
+    const legendStyle = deepMix(
+      {},
+      {
         items,
         x,
         y,
         maxWidth: width,
         maxHeight: height,
+        autoWrap,
+        maxItemWidth,
+        itemWidth: maxItemWidth,
         spacing: [8, 0],
         itemName: {
           style: {
-            default: {
-              fontSize: 12,
-            },
+            fontSize: 12,
           },
         },
         ...(field && {
@@ -53,7 +58,9 @@ export const LegendCategory: GCC<LegendCategoryOptions> = (options) => {
           symbol: 'circle',
         },
       },
-    });
+      guideCfg,
+    );
+    return new Category({ style: legendStyle });
   };
 };
 


### PR DESCRIPTION
**feat:** support config category legend

#### Usage
```ts
{
  scale: {
    x: { field: 'Date', utc: true },
    y: { guide: { label: { formatter: (d) => `${+d.text / 1000}k` } } },
    // config legend.
    color: { guide: { autoWrap: true, size: 68, maxRows: 3, cols: 5 } },
  },
}
```

config `autoWrap` and `cols`
- [ ] use `cols` to calculate `itemWidth` should be done by `GUI`
<img width="631" alt="image" src="https://user-images.githubusercontent.com/15646325/171221374-280c2d41-4072-4a98-adea-710fb56dad18.png">
