### PR TITLE
refactor(annotation): lineX and lineY swap rename

### DIFF
--- a/__tests__/unit/mark/annotation/lineX.ts
+++ b/__tests__/unit/mark/annotation/lineX.ts
@@ -2,7 +2,7 @@ import { LineX } from '../../../../src/mark/annotation/lineX';
 import { plot } from '../helper';
 
 describe('Line annotation', () => {
-  it('LineX and LineY has expected props', () => {
+  it('LineX has expected props', () => {
     expect(LineX.props).toEqual({
       defaultShape: 'annotation.line',
       channels: [
@@ -13,7 +13,7 @@ describe('Line annotation', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
-        { name: 'y', required: true },
+        { name: 'x', required: true },
       ],
       preInference: [{ type: 'maybeArrayField' }],
       postInference: [{ type: 'maybeKey' }],
@@ -21,19 +21,19 @@ describe('Line annotation', () => {
     });
   });
 
-  it('LineX should draw line annotation in x direction', () => {
+  it('LineX should draw line annotation in y direction', () => {
     const [I, P] = plot({
       mark: LineX({}),
       index: [0],
       channel: {
-        y: [0.5, 0.5, 0.5],
+        x: [0.5],
       },
     });
     expect(I).toEqual([0]);
     expect(P).toEqual([
       [
-        [0, 200],
-        [600, 200],
+        [300, 400],
+        [300, 0],
       ],
     ]);
   });
@@ -43,34 +43,34 @@ describe('Line annotation', () => {
       mark: LineX({}),
       index: [0, 1, 2],
       channel: {
-        y: [0.5, 0.2, 0.4],
+        x: [0.5, 0.2, 0.4],
       },
     });
 
     expect(I).toEqual([0, 1, 2]);
     expect(P).toEqual([
       [
-        [0, 200],
-        [600, 200],
+        [300, 400],
+        [300, 0],
       ],
       [
-        [0, 80],
-        [600, 80],
+        [120, 400],
+        [120, 0],
       ],
       [
-        [0, 160],
-        [600, 160],
+        [240, 400],
+        [240, 0],
       ],
     ]);
   });
 
-  it('LineX should throw error without y', () => {
+  it('LineX should throw error without x', () => {
     expect(() =>
       plot({
         mark: LineX({}),
         index: [0, 1, 2],
         channel: {
-          x: [[0.5], [0.2], [0.4]],
+          y: [[0.5], [0.2], [0.4]],
         },
       }),
     ).toThrowError();

--- a/__tests__/unit/mark/annotation/lineY.spec.ts
+++ b/__tests__/unit/mark/annotation/lineY.spec.ts
@@ -13,7 +13,7 @@ describe('Line annotation', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
-        { name: 'x', required: true },
+        { name: 'y', required: true },
       ],
       preInference: [{ type: 'maybeArrayField' }],
       postInference: [{ type: 'maybeKey' }],
@@ -21,19 +21,19 @@ describe('Line annotation', () => {
     });
   });
 
-  it('LineY should draw line annotation in y direction', () => {
+  it('LineY should draw line annotation in x direction', () => {
     const [I, P] = plot({
       mark: LineY({}),
       index: [0],
       channel: {
-        x: [0.5],
+        y: [0.5, 0.5, 0.5],
       },
     });
     expect(I).toEqual([0]);
     expect(P).toEqual([
       [
-        [300, 400],
-        [300, 0],
+        [0, 200],
+        [600, 200],
       ],
     ]);
   });
@@ -43,34 +43,34 @@ describe('Line annotation', () => {
       mark: LineY({}),
       index: [0, 1, 2],
       channel: {
-        x: [0.5, 0.2, 0.4],
+        y: [0.5, 0.2, 0.4],
       },
     });
 
     expect(I).toEqual([0, 1, 2]);
     expect(P).toEqual([
       [
-        [300, 400],
-        [300, 0],
+        [0, 200],
+        [600, 200],
       ],
       [
-        [120, 400],
-        [120, 0],
+        [0, 80],
+        [600, 80],
       ],
       [
-        [240, 400],
-        [240, 0],
+        [0, 160],
+        [600, 160],
       ],
     ]);
   });
 
-  it('LineY should throw error without x', () => {
+  it('LineY should throw error without y', () => {
     expect(() =>
       plot({
         mark: LineY({}),
         index: [0, 1, 2],
         channel: {
-          y: [[0.5], [0.2], [0.4]],
+          x: [[0.5], [0.2], [0.4]],
         },
       }),
     ).toThrowError();

--- a/__tests__/unit/runtime/annotationLine.spec.ts
+++ b/__tests__/unit/runtime/annotationLine.spec.ts
@@ -25,7 +25,7 @@ describe('line annotation', () => {
           },
         },
         {
-          type: 'annotation.lineX',
+          type: 'annotation.lineY',
           encode: {
             y: 30000,
           },
@@ -34,7 +34,7 @@ describe('line annotation', () => {
           },
         },
         {
-          type: 'annotation.lineY',
+          type: 'annotation.lineX',
           transform: [
             {
               type: 'filterBy',
@@ -94,7 +94,7 @@ describe('line annotation', () => {
           },
         },
         {
-          type: 'annotation.lineX',
+          type: 'annotation.lineY',
           transform: [
             {
               type: 'filterBy',
@@ -108,7 +108,7 @@ describe('line annotation', () => {
           },
         },
         {
-          type: 'annotation.lineY',
+          type: 'annotation.lineX',
           transform: [
             {
               type: 'filterBy',
@@ -166,7 +166,7 @@ describe('line annotation', () => {
           },
         },
         {
-          type: 'annotation.lineX',
+          type: 'annotation.lineY',
           encode: {
             x: 'item',
             y: 40,

--- a/__tests__/unit/runtime/statistic.spec.ts
+++ b/__tests__/unit/runtime/statistic.spec.ts
@@ -299,7 +299,7 @@ describe('statistic', () => {
           },
         },
         {
-          type: 'annotation.lineX',
+          type: 'annotation.lineY',
           // @todo Do not need encode.
           data: [0],
           encode: {

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -203,7 +203,7 @@ G2.render({
       },
     },
     {
-      type: 'annotation.lineX',
+      type: 'annotation.lineY',
       data: [0],
       encode: {
         y: 0,

--- a/src/mark/annotation/index.ts
+++ b/src/mark/annotation/index.ts
@@ -1,12 +1,12 @@
 export { AnnotationText, AnnotationTextOptions } from './text';
 export {
-  LineX as AnnotationLineX,
-  LineXOptions as AnnotationLineXOptions,
-} from './lineX';
-export {
   LineY as AnnotationLineY,
   LineYOptions as AnnotationLineYOptions,
 } from './lineY';
+export {
+  LineX as AnnotationLineX,
+  LineXOptions as AnnotationLineXOptions,
+} from './lineX';
 export {
   Connector as AnnotationConnector,
   ConnectorOptions as AnnotationConnectorOptions,

--- a/src/mark/annotation/lineX.ts
+++ b/src/mark/annotation/lineX.ts
@@ -2,19 +2,19 @@ import { Vector } from '@antv/coord';
 import { MarkComponent as MC, Vector2 } from '../../runtime';
 import { AnnotationLineX } from '../../spec';
 import {
+  basePostInference,
   baseAnnotationChannels,
   basePreInference,
-  basePostInference,
 } from '../utils';
 
 export type LineXOptions = Omit<AnnotationLineX, 'type'>;
 
 export const LineX: MC<LineXOptions> = () => {
   return (index, scale, value, coordinate) => {
-    const { y: Y } = value;
+    const { x: X } = value;
     const P = Array.from(index, (i) => {
-      const p1 = [0, Y[i]] as Vector;
-      const p2 = [1, Y[i]] as Vector;
+      const p1 = [X[i], 1] as Vector;
+      const p2 = [X[i], 0] as Vector;
       return [p1, p2].map((d) => coordinate.map(d)) as Vector2[];
     });
     return [index, P];
@@ -23,7 +23,7 @@ export const LineX: MC<LineXOptions> = () => {
 
 LineX.props = {
   defaultShape: 'annotation.line',
-  channels: [...baseAnnotationChannels(), { name: 'y', required: true }],
+  channels: [...baseAnnotationChannels(), { name: 'x', required: true }],
   preInference: [...basePreInference()],
   postInference: [...basePostInference()],
   shapes: ['annotation.line'],

--- a/src/mark/annotation/lineY.ts
+++ b/src/mark/annotation/lineY.ts
@@ -2,19 +2,19 @@ import { Vector } from '@antv/coord';
 import { MarkComponent as MC, Vector2 } from '../../runtime';
 import { AnnotationLineY } from '../../spec';
 import {
-  basePostInference,
   baseAnnotationChannels,
   basePreInference,
+  basePostInference,
 } from '../utils';
 
 export type LineYOptions = Omit<AnnotationLineY, 'type'>;
 
 export const LineY: MC<LineYOptions> = () => {
   return (index, scale, value, coordinate) => {
-    const { x: X } = value;
+    const { y: Y } = value;
     const P = Array.from(index, (i) => {
-      const p1 = [X[i], 1] as Vector;
-      const p2 = [X[i], 0] as Vector;
+      const p1 = [0, Y[i]] as Vector;
+      const p2 = [1, Y[i]] as Vector;
       return [p1, p2].map((d) => coordinate.map(d)) as Vector2[];
     });
     return [index, P];
@@ -23,7 +23,7 @@ export const LineY: MC<LineYOptions> = () => {
 
 LineY.props = {
   defaultShape: 'annotation.line',
-  channels: [...baseAnnotationChannels(), { name: 'x', required: true }],
+  channels: [...baseAnnotationChannels(), { name: 'y', required: true }],
   preInference: [...basePreInference()],
   postInference: [...basePostInference()],
   shapes: ['annotation.line'],


### PR DESCRIPTION
#### refactor

- `lineX` rename to `lineY`, require `y` channel encode.
- `lineY` rename to `lineX`, require `x` channel encode.