### PR TITLE
feat(component): components support combine multiple scales

### DIFF
--- a/__tests__/unit/runtime/component.spec.ts
+++ b/__tests__/unit/runtime/component.spec.ts
@@ -1,0 +1,81 @@
+import { G2Spec, render } from '../../../src';
+import { createDiv, mount } from '../../utils/dom';
+
+describe('render', () => {
+  it('render({}) returns chart with color and shape combined legend.', () => {
+    const context: any = {};
+    const chart = render<G2Spec>(
+      {
+        type: 'interval',
+        data: [
+          { genre: 'Sports', sold: 275 },
+          { genre: 'Strategy', sold: 115 },
+          { genre: 'Action', sold: 120 },
+          { genre: 'Shooter', sold: 350 },
+          { genre: 'Other', sold: 150 },
+        ],
+        encode: {
+          x: 'genre',
+          y: 'sold',
+          color: 'genre',
+          shape: 'genre',
+        },
+        scale: {
+          color: {
+            range: ['#5B8FF9', '#5AD8A6', '#5D7092', '#F6BD16', '#6F5EF9'],
+          },
+        },
+      },
+      context,
+      () => {
+        const legend =
+          context.canvas.document.querySelector('.category-legend');
+        const items = legend.style.items;
+        expect(items[0].symbol).toBe('square');
+        expect(items[1].symbol).toBe('hollowsquare');
+        expect(items[0].color).toBe('#5B8FF9');
+        expect(items[1].color).toBe('#5AD8A6');
+      },
+    );
+    mount(createDiv(), chart);
+  });
+
+  it('render({}) returns chart has combined legend with different scales.', () => {
+    const context: any = {};
+    const chart = render<G2Spec>(
+      {
+        type: 'interval',
+        data: [
+          { genre: 'Sports', sold: 275, type: 'A' },
+          { genre: 'Strategy', sold: 115, type: 'A' },
+          { genre: 'Action', sold: 120, type: 'A' },
+          { genre: 'Shooter', sold: 350, type: 'B' },
+          { genre: 'Other', sold: 150, type: 'B' },
+        ],
+        encode: {
+          x: 'genre',
+          y: 'sold',
+          color: 'genre',
+          shape: 'type',
+        },
+        scale: {
+          color: {
+            range: ['#5B8FF9', '#5AD8A6', '#5D7092', '#F6BD16', '#6F5EF9'],
+          },
+        },
+      },
+      context,
+      () => {
+        const legend =
+          context.canvas.document.querySelector('.category-legend');
+        const items = legend.style.items;
+        expect(items.length).toBe(7);
+        expect(items[5].symbol).toBe('square');
+        expect(items[6].symbol).toBe('hollowsquare');
+        expect(items[0].color).toBe('#5B8FF9');
+        expect(items[1].color).toBe('#5AD8A6');
+      },
+    );
+    mount(createDiv(), chart);
+  });
+});

--- a/docs/normalize.md
+++ b/docs/normalize.md
@@ -81,7 +81,10 @@ G2.render({
     { type: 'stackY' },
     { type: 'normalizeY' },
   ],
-  scale: { x: { field: 'Date' } },
+  scale: {
+    x: { field: 'Date' },
+    color: { guide: { autoWrap:true, size: 84, cols: 4 } }
+  },
   encode: {
     shape: 'smoothArea',
     x: (d) => new Date(d.date),

--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -207,12 +207,12 @@ const ArcAxis = (options) => {
  */
 export const Axis: GCC<AxisOptions> = (options) => {
   const { position, title = true, formatter = (d) => `${d}` } = options;
-  return (scale, value, coordinate, theme) => {
+  return (scales, value, coordinate, theme) => {
+    const scale = scales[0];
     if (position === 'arc') {
       return ArcAxis(options)(scale, value, coordinate, theme);
     }
-
-    const { domain, field, bbox } = value;
+    const { domain, field } = scale.getOptions();
     const {
       startPos,
       endPos,
@@ -222,7 +222,7 @@ export const Axis: GCC<AxisOptions> = (options) => {
       titleRotate,
       verticalFactor,
       titleOffsetY,
-    } = inferPosition(position, bbox, coordinate);
+    } = inferPosition(position, value.bbox, coordinate);
     const ticks = getTicks(scale, domain, formatter, position, coordinate);
     return new Linear({
       style: deepMix(

--- a/src/component/legendCategory.ts
+++ b/src/component/legendCategory.ts
@@ -39,8 +39,7 @@ export const LegendCategory: GCC<LegendCategoryOptions> = (options) => {
         items.set(item.id, item);
       });
     });
-    const { cols, autoWrap, ...guideCfg } = scales[0].getOptions().guide || {};
-    const maxItemWidth = autoWrap && cols ? width / cols : undefined;
+    const { autoWrap, ...guideCfg } = scales[0].getOptions().guide || {};
     const legendStyle = deepMix(
       {},
       {
@@ -50,8 +49,6 @@ export const LegendCategory: GCC<LegendCategoryOptions> = (options) => {
         maxWidth: width,
         maxHeight: height,
         autoWrap,
-        maxItemWidth,
-        itemWidth: maxItemWidth,
         spacing: [8, 0],
         itemName: {
           style: {

--- a/src/component/legendContinuous.ts
+++ b/src/component/legendContinuous.ts
@@ -13,9 +13,10 @@ export type LegendContinuousOptions = {
  * @todo Custom style.
  */
 export const LegendContinuous: GCC<LegendContinuousOptions> = (options) => {
-  return (scale, value, coordinate, theme) => {
-    const { field, domain, bbox } = value;
-    const { x, y } = bbox;
+  return (scales, value, coordinate, theme) => {
+    const scale = scales[0];
+    const { field, domain } = scale.getOptions();
+    const { x, y } = value.bbox;
     const ticks = scale.getTicks?.() || [];
     const [min, max] = domain;
     return new Continuous({

--- a/src/runtime/types/component.ts
+++ b/src/runtime/types/component.ts
@@ -200,7 +200,7 @@ export type ThemeComponent<O = Record<string, unknown>> = G2BaseComponent<
 >;
 
 export type GuideComponent = (
-  scale: Scale,
+  scales: Scale[],
   style: Record<string, any>,
   coordinate: Coordinate,
   theme: G2Theme,

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -148,7 +148,7 @@ export type G2PaletteOptions = G2BaseComponentOptions<PaletteComponent>;
 export type G2GuideComponentOptions = G2BaseComponentOptions<
   GuideComponentComponent,
   {
-    scale?: G2ScaleOptions;
+    scales?: G2ScaleOptions[];
     position?: GuideComponentPosition;
     size?: number;
     order?: number;


### PR DESCRIPTION
### Overview

#### Combined legend with `color` and `shape` scale is shared.

<img width="612" alt="image" src="https://user-images.githubusercontent.com/15646325/171662027-ca4f5933-2883-45d7-8558-d2ec5d96ed81.png">

```ts
render<G2Spec>(
  {
    type: 'interval',
    data: [
      { genre: 'Sports', sold: 275 },
      { genre: 'Strategy', sold: 115 },
      { genre: 'Action', sold: 120 },
      { genre: 'Shooter', sold: 350 },
      { genre: 'Other', sold: 150 },
    ],
    encode: {
      x: 'genre',
      y: 'sold',
      color: 'genre',
      shape: 'genre',
    },
  },
)
```

#### Combined legend with different scales.

<img width="612" alt="image" src="https://user-images.githubusercontent.com/15646325/171662072-06bf195f-1c8e-44af-8444-c1498c400de8.png">

```ts
render<G2Spec>(
  {
    type: 'interval',
    data: [
      { genre: 'Sports', sold: 275, type: 'A' },
      { genre: 'Strategy', sold: 115, type: 'A' },
      { genre: 'Action', sold: 120, type: 'A' },
      { genre: 'Shooter', sold: 350, type: 'B' },
      { genre: 'Other', sold: 150, type: 'B' },
    ],
    encode: {
      x: 'genre',
      y: 'sold',
      color: 'genre',
      shape: 'type',
    },
    scale: {
      color: {
        range: ['#5B8FF9', '#5AD8A6', '#5D7092', '#F6BD16', '#6F5EF9'],
      },
    },
  }
)
```
