### PR TITLE
feat(shape): add index and point2d params

### DIFF
--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -358,6 +358,7 @@ async function plotView(
 
   // Render marks with corresponding data.
   for (const [{ key }, { data }] of markState.entries()) {
+    const point2d = data.map((d) => d.points);
     selection
       .select(`#${key}`)
       .selectAll('.element')
@@ -365,9 +366,10 @@ async function plotView(
       .join(
         (enter) =>
           enter
-            .append(({ shape, points, ...v }) =>
-              shape(points, v, coordinate, theme),
-            )
+            .append(({ shape, points, ...v }, i) => {
+              const value = { ...v, index: i };
+              return shape(points, value, coordinate, theme, point2d);
+            })
             .attr('className', 'element')
             .each(function ({ enterType: animate, ...v }) {
               const {
@@ -379,8 +381,9 @@ async function plotView(
               animate(this, style, coordinate, theme);
             }),
         (update) =>
-          update.each(function ({ shape, points, ...v }) {
-            const node = shape(points, v, coordinate, theme);
+          update.each(function ({ shape, points, ...v }, i) {
+            const value = { ...v, index: i };
+            const node = shape(points, value, coordinate, theme, point2d);
             copyAttributes(this, node);
           }),
       );

--- a/src/runtime/types/component.ts
+++ b/src/runtime/types/component.ts
@@ -179,10 +179,12 @@ export type Shape = (
   points: Vector2[],
   value: {
     color?: string;
+    index?: number;
     [key: string]: Primitive;
   },
   coordinate: Coordinate,
   theme: G2Theme,
+  point2d?: Vector2[][],
 ) => DisplayObject;
 export type ShapeProps = {
   defaultEnterAnimation: string;


### PR DESCRIPTION
feat(shape): add index and point2d params

This is for get drawing context for some shapes, such as funnel. Point2d means two dimension point array.

```js
function Funnel() {
  return (points, value, coordinate, theme, point2d) => {
    const {index} = value; // The index of current shape.
    const prePoints = point2d[index - 1]; // The points of next shape.
    // ...
  }
}
```