### PR TITLE
fix(transform): merge ignore undefined new encode

### DIFF
--- a/src/transform/preprocessor/wordCloud.ts
+++ b/src/transform/preprocessor/wordCloud.ts
@@ -1,5 +1,4 @@
 import { min, max } from 'd3-array';
-import { indexOf } from '../../utils/array';
 import { TransformComponent as TC } from '../../runtime';
 import { WordCloudTransform } from '../../spec';
 import { tagCloud } from '../utils/d3-cloud';
@@ -107,7 +106,7 @@ export const WordCloud: TC<WordCloudOptions> = (options) => {
       },
     );
 
-    return { data: tags, I: indexOf(tags) };
+    return { data: tags };
   });
 };
 

--- a/src/transform/utils/helper.ts
+++ b/src/transform/utils/helper.ts
@@ -23,15 +23,13 @@ export function merge(
 ): Transform {
   return async (options) => {
     const newOptions = await transform(options);
-    const { encode: newEncode = {} } = newOptions;
-    const { encode: oldEncode = {} } = options;
+    const { encode: newEncode } = newOptions;
+    const { encode: oldEncode } = options;
     return {
       ...options,
       ...newOptions,
-      encode: {
-        ...oldEncode,
-        ...newEncode,
-      },
+      // Update encode options only when newEncode is defined.
+      ...(newEncode && { encode: { ...oldEncode, ...newEncode } }),
     };
   };
 }


### PR DESCRIPTION
The helper function `merge` update encode options only when newEncode is defined.