### PR TITLE
feat: add zoom-in zoom-out cursor

### DIFF
--- a/docs/api/advanced/register-interaction.en.md
+++ b/docs/api/advanced/register-interaction.en.md
@@ -402,6 +402,18 @@ class CursorAction extends Action {
   public ewResize() {
     this.setCursor('ew-resize');
   }
+  /**
+   * 光标显示可以被放大
+   */
+  public zoomIn() {
+    this.setCursor('zoom-in');
+  }
+  /**
+   * 光标显示可以缩小尺寸
+   */
+  public zoomOut() {
+    this.setCursor('zoom-out');
+  }
 }
 ```
 

--- a/docs/api/advanced/register-interaction.zh.md
+++ b/docs/api/advanced/register-interaction.zh.md
@@ -402,6 +402,18 @@ class CursorAction extends Action {
   public ewResize() {
     this.setCursor('ew-resize');
   }
+  /**
+   * 光标显示可以被放大
+   */
+  public zoomIn() {
+    this.setCursor('zoom-in');
+  }
+  /**
+   * 光标显示可以缩小尺寸
+   */
+  public zoomOut() {
+    this.setCursor('zoom-out');
+  }
 }
 ```
 

--- a/docs/api/general/interaction.zh.md
+++ b/docs/api/general/interaction.zh.md
@@ -632,6 +632,8 @@ registerInteraction('brush-visible', {
 - swResize() 光标指示可移动的方向左下方（西南）
 - nsResize() 光标指示可以在上下方向移动
 - ewResize() 光标指示可以在左右方向移动
+- zoomIn() 光标显示可以被放大
+- zoomOut() 光标显示可以缩小尺寸
 
 ### Chart/View 的 Action
 

--- a/src/interaction/action/cursor.ts
+++ b/src/interaction/action/cursor.ts
@@ -112,6 +112,18 @@ class CursorAction extends Action {
   public ewResize() {
     this.setCursor('ew-resize');
   }
+  /**
+   * 光标显示可以被放大
+   */
+  public zoomIn() {
+    this.setCursor('zoom-in');
+  }
+  /**
+   * 光标显示可以缩小尺寸
+   */
+  public zoomOut() {
+    this.setCursor('zoom-out');
+  }
 }
 
 export default CursorAction;

--- a/tests/unit/interaction/action/cursor-spec.ts
+++ b/tests/unit/interaction/action/cursor-spec.ts
@@ -28,6 +28,7 @@ describe('active test', () => {
   first.shape.attr('cursor', 'pointer');
   const action = new CursorActive(context);
   const cursors = ['default', 'crosshair', 'pointer', 'move', 'wait', 'help', 'text'];
+  const zoomCursors = ['In', 'Out'];
   const resizeArr = ['n', 's', 'w', 'e', 'ne', 'nw', 'se', 'sw', 'ns', 'ew'];
 
   it('test cursors', () => {
@@ -51,6 +52,15 @@ describe('active test', () => {
   it('text cursor', () => {
     action.text();
     expect(canvas.getCursor()).toBe('text');
+  });
+
+  it('zoom cursor', () => {
+    each(zoomCursors, (name: string) => {
+      const method = 'zoom' + name;
+      const cursor = 'zoom-' + name.toLowerCase();
+      action[method]();
+      expect(canvas.getCursor()).toBe(cursor);
+    });
   });
 
   afterAll(() => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
You can use zoomIn and zoomOut cursor in register-interaction. 


This is useful. For example, you use scale-transform zooming.
```js
registerInteraction('custom-zoom', {
  showEnable: [
    { trigger: 'plot:mouseenter', action: 'cursor:zoomIn' },
    { trigger: 'plot:mouseleave', action: 'cursor:zoomOut' },
  ],
});
```
