### PR TITLE
fix(axis-label): 修复 axis-label tooltip 移开没有 hide 的问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -343,6 +343,7 @@ registerInteraction('ellipsis-text', {
     { trigger: 'legend-item-name:mouseleave', action: 'ellipsis-text:hide' },
     { trigger: 'legend-item-name:touchend', action: 'ellipsis-text:hide' },
     { trigger: 'axis-label:mouseleave', action: 'ellipsis-text:hide' },
+    { trigger: 'axis-label:mouseout', action: 'ellipsis-text:hide' },
     { trigger: 'axis-label:touchend', action: 'ellipsis-text:hide' },
   ],
 });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65594180/175489293-a35cb504-e762-4ae1-847e-44bf6dfd9d64.png)
`renderer:'svg' mouseleave 事件不能触发`
![image](https://user-images.githubusercontent.com/65594180/175489628-062fbf26-0aef-4fa1-aad0-358248e3f904.png)

fiexd #3849 