### PR TITLE
feat: add groupX

### DIFF
--- a/.genjirc
+++ b/.genjirc
@@ -4,12 +4,13 @@
     "Overview": "overview",
     "Dimension": "dimension",
     "Transform": {
-      "Stack": "Stack",
-      "Dodge": "Dodge",
-      "Normalize": "Normalize",
-      "Symmetry": "Symmetry",
-      "Jitter": "Jitter",
-      "Select": "Select"
+      "Stack": "stack",
+      "Dodge": "dodge",
+      "Normalize": "normalize",
+      "Symmetry": "symmetry",
+      "Jitter": "jitter",
+      "Select": "select",
+      "Group": "group"
     },
     "Encode": "encode",
     "Scale": "scale",

--- a/__tests__/unit/runtime/statistic.spec.ts
+++ b/__tests__/unit/runtime/statistic.spec.ts
@@ -686,4 +686,27 @@ describe('statistic', () => {
 
     mount(createDiv(), chart);
   });
+
+  it('should render interval aggregated by groupX', () => {
+    const chart = render<G2Spec>({
+      type: 'interval',
+      transform: [
+        {
+          type: 'fetch',
+          url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
+        },
+        {
+          type: 'groupX',
+          y: 'mean',
+        },
+      ],
+      paddingLeft: 60,
+      encode: {
+        x: 'clarity',
+        y: 'price',
+        color: 'clarity',
+      },
+    });
+    mount(createDiv(), chart);
+  });
 });

--- a/__tests__/unit/stdlib/index.spec.ts
+++ b/__tests__/unit/stdlib/index.spec.ts
@@ -159,6 +159,7 @@ import {
   SelectX,
   SelectY,
   Connector,
+  GroupX,
 } from '../../../src/transform';
 
 describe('stdlib', () => {
@@ -196,6 +197,7 @@ describe('stdlib', () => {
       'transform.select': Select,
       'transform.selectX': SelectX,
       'transform.selectY': SelectY,
+      'transform.groupX': GroupX,
       'transform.maybeSize': MaybeSize,
       'transform.maybeZeroY': MaybeZeroY,
       'transform.maybeKey': MaybeKey,

--- a/docs/group.md
+++ b/docs/group.md
@@ -1,0 +1,25 @@
+# Group
+
+## GroupX
+
+```js
+G2.render({
+  type: 'interval',
+  transform: [
+    {
+      type: 'fetch',
+      url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
+    },
+    {
+      type: 'groupX',
+      y: 'mean',
+    },
+  ],
+  paddingLeft: 60,
+  encode: {
+    x: 'clarity',
+    y: 'price',
+    color: 'clarity',
+  },
+});
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -194,6 +194,22 @@ genji.preview(
 );
 ```
 
+### Group
+
+```js | dom "pin: false"
+genji.preview(
+  [
+    {
+      title: 'GroupX',
+      path: '/group#groupX',
+      thumbnail:
+        'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*R3_FSY2cH1oAAAAAAAAAAAAAARQnAQ',
+    },
+  ],
+  { height: 175 },
+);
+```
+
 ## Scale
 
 > TODO
@@ -336,13 +352,15 @@ genji.preview(
     {
       title: 'RangeX Annotation',
       path: '/annotation#rangex-annotation',
-      thumbnail: 'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*Pp1EQZdAIQMAAAAAAAAAAAAAARQnAQ'
+      thumbnail:
+        'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*Pp1EQZdAIQMAAAAAAAAAAAAAARQnAQ',
     },
     {
       title: 'RangeY Annotation',
       path: '/annotation#rangey-annotation',
-      thumbnail: 'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*nOmVR4gsaugAAAAAAAAAAAAAARQnAQ'
-    }
+      thumbnail:
+        'https://gw.alipayobjects.com/mdn/rms_dfc253/afts/img/A*nOmVR4gsaugAAAAAAAAAAAAAARQnAQ',
+    },
   ],
   { height: 175 },
 );

--- a/src/spec/statistic.ts
+++ b/src/spec/statistic.ts
@@ -34,7 +34,6 @@ export type StatisticTransformTypes =
   | 'selectY'
   | 'selectX'
   | 'groupX'
-  | 'group'
   | TransformComponent;
 
 export type DodgeXTransform = {

--- a/src/spec/statistic.ts
+++ b/src/spec/statistic.ts
@@ -11,7 +11,8 @@ export type StatisticTransform =
   | SymmetryYTransform
   | SelectTransform
   | SelectXTransform
-  | SelectYTransform;
+  | SelectYTransform
+  | GroupXTransform;
 
 export type StatisticOrder =
   | 'value'
@@ -32,6 +33,8 @@ export type StatisticTransformTypes =
   | 'select'
   | 'selectY'
   | 'selectX'
+  | 'groupX'
+  | 'group'
   | TransformComponent;
 
 export type DodgeXTransform = {
@@ -114,3 +117,20 @@ export type SelectYTransform = {
   groupBy?: string | string[];
   selector?: Selector;
 };
+
+export type Reducer =
+  | 'mean'
+  | 'max'
+  | 'count'
+  | 'min'
+  | 'median'
+  | 'sum'
+  | 'first'
+  | 'last'
+  | ((I: number[], V: Primitive[]) => Primitive);
+
+export type GroupXTransform = {
+  type?: 'groupX';
+  orderBy?: ChannelTypes;
+  reverse?: boolean;
+} & { [key in ChannelTypes]?: Reducer };

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -153,6 +153,7 @@ import {
   SelectX,
   SelectY,
   Connector,
+  GroupX,
 } from '../transform';
 
 export function createLibrary(): G2Library {
@@ -189,6 +190,7 @@ export function createLibrary(): G2Library {
     'transform.select': Select,
     'transform.selectX': SelectX,
     'transform.selectY': SelectY,
+    'transform.groupX': GroupX,
     'transform.maybeSize': MaybeSize,
     'transform.maybeZeroY': MaybeZeroY,
     'transform.maybeKey': MaybeKey,

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -28,6 +28,7 @@ export { SymmetryY, SymmetryYOptions } from './statistic/symmetryY';
 export { Select, SelectOptions } from './statistic/Select';
 export { SelectX, SelectXOptions } from './statistic/SelectX';
 export { SelectY, SelectYOptions } from './statistic/SelectY';
+export { GroupX, GroupXOptions } from './statistic/groupX';
 
 // Preprocessor
 export { Fetch, FetchOptions } from './preprocessor/fetch';

--- a/src/transform/inference/maybeStackY.ts
+++ b/src/transform/inference/maybeStackY.ts
@@ -1,10 +1,19 @@
 import { StackY } from '../statistic/stackY';
-import { TransformComponent as TC } from '../../runtime';
+import { TransformComponent as TC, TransformSpec } from '../../runtime';
 import { merge } from '../utils/helper';
 
 export type MaybeStackYOptions = {
   series?: boolean;
 };
+
+// Avoid duplicate stackY.
+// In most of case only one of stackY and dodgeX is needed.
+// So pass statistic with stackY and dodgeX.
+function exclude(transform: TransformSpec): boolean {
+  const { type } = transform;
+  const excludes = ['stackY', 'dodgeX', 'groupX'];
+  return typeof type === 'string' && excludes.includes(type);
+}
 
 /**
  * Add zero constant encode for x channel.
@@ -14,12 +23,8 @@ export const MaybeStackY: TC<MaybeStackYOptions> = (options) => {
   return merge((context) => {
     const { encode, transform } = context;
     const { x, y } = encode;
-    // Avoid duplicate stackY.
-    // In most of case only one of stackY and dodgeX is needed.
-    // So pass statistic with stackY and dodgeX.
-    if (transform.find(({ type }) => type === 'stackY' || type === 'dodgeX')) {
-      return {};
-    }
+    if (transform.some(exclude)) return {};
+
     // StackY need both x and y channel values, so pass value with empty x or y channel.
     if (x === undefined || y === undefined) return {};
     const { series } = options;

--- a/src/transform/statistic/groupX.ts
+++ b/src/transform/statistic/groupX.ts
@@ -1,0 +1,91 @@
+import { group, max as d3Max, mean as d3Mean, sum as d3Sum } from 'd3-array';
+import { TransformComponent as TC, Primitive } from '../../runtime';
+import { GroupXTransform, Reducer } from '../../spec';
+import { merge, column, field } from '../utils/helper';
+import { indexOf } from '../../utils/array';
+
+export type GroupXOptions = Omit<GroupXTransform, 'type'>;
+
+type ReducerFunction = (I: number[], V: Primitive[]) => Primitive;
+
+type Formatter = (d: Primitive) => string;
+
+function normalizeReducer(reducer: Reducer): [ReducerFunction, Formatter] {
+  if (typeof reducer === 'function') return [reducer, null];
+  const registry = { mean, max, count, first, last, sum };
+  const reducerFunction = registry[reducer];
+  if (!reducerFunction) throw new Error(`Unknown reducer: ${reducer}.`);
+  return reducerFunction();
+}
+
+function mean(): [ReducerFunction, Formatter] {
+  const reducer: ReducerFunction = (I, V) => d3Mean(I, (i) => +V[i]);
+  const formatter: Formatter = (d) => `mean of ${d}`;
+  return [reducer, formatter];
+}
+
+function max(): [ReducerFunction, Formatter] {
+  const reducer: ReducerFunction = (I, V) => d3Max(I, (i) => +V[i]);
+  const formatter: Formatter = (d) => `max of ${d}`;
+  return [reducer, formatter];
+}
+
+function count(): [ReducerFunction, Formatter] {
+  const reducer: ReducerFunction = (I, V) => I.length;
+  const formatter: Formatter = (d) => `count of ${d}`;
+  return [reducer, formatter];
+}
+
+function sum(): [ReducerFunction, Formatter] {
+  const reducer: ReducerFunction = (I, V) => d3Sum(I, (i) => +V[i]);
+  const formatter: Formatter = (d) => `sum of ${d}`;
+  return [reducer, formatter];
+}
+
+function first(): [ReducerFunction, Formatter] {
+  const reducer: ReducerFunction = (I, V) => V[0];
+  const formatter: Formatter = (d) => `first of ${d}`;
+  return [reducer, formatter];
+}
+
+function last(): [ReducerFunction, Formatter] {
+  const reducer: ReducerFunction = (I, V) => V[I[I.length - 1]];
+  const formatter: Formatter = (d) => `last of ${d}`;
+  return [reducer, formatter];
+}
+
+/**
+ * The GroupX transform group data by x channel, and aggregate.
+ * @todo Sort among groups and apply reverse options.
+ */
+export const GroupX: TC<GroupXOptions> = (options = {}) => {
+  const { orderBy, reverse = false, ...rest } = options;
+  return merge((context) => {
+    const { data, encode, columnOf, I } = context;
+    const { x } = encode;
+    const X = columnOf(data, x);
+    const groups = X ? Array.from(group(I, (i) => X[i]).values()) : [I];
+    const outputs = Object.entries(rest).map(([channel, reducer]) => {
+      const { [channel]: e } = encode;
+      const V = columnOf(data, e);
+      const [reducerFunction, formatter] = normalizeReducer(reducer);
+      const RV = groups.map((I) => reducerFunction(I, V ?? data));
+      return [channel, column(field(RV, V, formatter))];
+    });
+    const GD = groups.map((I) => data[I[0]]);
+    const GX = groups.map((I) => X[I[0]]);
+    const GI = indexOf(groups);
+    return {
+      I: GI,
+      data: GD,
+      encode: {
+        x: column(field(GX, X)),
+        ...Object.fromEntries(outputs),
+      },
+    };
+  });
+};
+
+GroupX.props = {
+  category: 'statistic',
+};

--- a/src/transform/utils/helper.ts
+++ b/src/transform/utils/helper.ts
@@ -43,8 +43,12 @@ export function constant(value: Primitive) {
   return { type: 'constant', value };
 }
 
-export function field(target: ColumnValue, source: ColumnValue) {
+export function field(
+  target: ColumnValue,
+  source: ColumnValue,
+  formatter?: (d: any) => string,
+) {
   if (!source) return target;
-  target.field = source.field;
+  target.field = formatter ? formatter(source.field) : source.field;
   return target;
 }


### PR DESCRIPTION
 The GroupX transform group data by x channel, and aggregate. ([preview](http://g2-next.antv.vision/group#groupX))

![image](https://user-images.githubusercontent.com/49330279/176135866-52ed3212-22dc-405f-965d-6a838f808262.png)

```js
G2.render({
  type: 'interval',
  transform: [
    {
      type: 'fetch',
      url: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
    },
    {
      type: 'groupX',
      y: 'mean',
    },
  ],
  paddingLeft: 60,
  encode: {
    x: 'clarity',
    y: 'price',
    color: 'clarity',
  },
});
```