### PR TITLE
feat: support merge and split animation

### DIFF
--- a/__tests__/unit/animation/helper.ts
+++ b/__tests__/unit/animation/helper.ts
@@ -31,7 +31,7 @@ export function applyAnimation({
   transform = [],
   value = {},
   defaults = {},
-}: Options): Promise<[DisplayObject, GAnimation]> {
+}: Options): Promise<[DisplayObject, GAnimation | GAnimation[]]> {
   return new Promise((resolve) => {
     requestAnimationFrame(async () => {
       const coordinate = new Coordinate({
@@ -45,7 +45,7 @@ export function applyAnimation({
       await canvas.ready;
 
       canvas.appendChild(shape);
-      resolve([shape, animate(shape, value, coordinate, defaults)]);
+      resolve([shape, animate([shape], [], value, coordinate, defaults)]);
     });
   });
 }
@@ -54,10 +54,15 @@ export function style(shape: DisplayObject, key: string): any {
   return shape.style[key];
 }
 
-export function timing(animation: GAnimation, key: string): any {
-  return animation.effect.timing[key];
+export function timing(animation: GAnimation | GAnimation[], key: string): any {
+  const a = Array.isArray(animation) ? animation[0] : animation;
+  return a.effect.timing[key];
 }
 
-export function keyframes(animate: GAnimation, key: string): any {
-  return animate.effect.normalizedKeyframes.map((d) => d[key]);
+export function keyframes(
+  animation: GAnimation | GAnimation[],
+  key: string,
+): any {
+  const a = Array.isArray(animation) ? animation[0] : animation;
+  return a.effect.normalizedKeyframes.map((d) => d[key]);
 }

--- a/__tests__/unit/animation/scaleInX.spec.ts
+++ b/__tests__/unit/animation/scaleInX.spec.ts
@@ -1,4 +1,4 @@
-import { Rect } from '@antv/g';
+import { Rect, Animation } from '@antv/g';
 import { ScaleInX } from '../../../src/animation';
 import { Transpose } from '../../../src/coordinate';
 import { mount, createDiv } from '../../utils/dom';
@@ -27,14 +27,8 @@ describe('ScaleInX', () => {
     expect(keyframes(animation, 'opacity')).toEqual([0, 1, undefined]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.01, null]);
 
-    const { onfinish } = animation;
-    return new Promise<void>((resolve) => {
-      animation.onfinish = (e) => {
-        onfinish.call(animation, e);
-        expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
-        resolve();
-      };
-    });
+    await (animation as Animation).finished;
+    expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
   });
 
   it('ScaleInX({...}) should scale in different origin in transpose coordinate', async () => {

--- a/__tests__/unit/animation/scaleInY.spec.ts
+++ b/__tests__/unit/animation/scaleInY.spec.ts
@@ -1,4 +1,4 @@
-import { Rect } from '@antv/g';
+import { Rect, Animation } from '@antv/g';
 import { ScaleInY } from '../../../src/animation';
 import { Transpose } from '../../../src/coordinate';
 import { mount, createDiv } from '../../utils/dom';
@@ -27,14 +27,8 @@ describe('ScaleInY', () => {
     expect(keyframes(animation, 'opacity')).toEqual([0, 1, undefined]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.01, null]);
 
-    const { onfinish } = animation;
-    return new Promise<void>((resolve) => {
-      animation.onfinish = (e) => {
-        onfinish.call(animation, e);
-        expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
-        resolve();
-      };
-    });
+    await (animation as Animation).finished;
+    expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
   });
 
   it('ScaleInY({...}) should scale in different origin in transpose coordinate', async () => {

--- a/__tests__/unit/animation/scaleOutX.spec.ts
+++ b/__tests__/unit/animation/scaleOutX.spec.ts
@@ -1,4 +1,4 @@
-import { Rect } from '@antv/g';
+import { Rect, Animation } from '@antv/g';
 import { ScaleOutX } from '../../../src/animation';
 import { Transpose } from '../../../src/coordinate';
 import { mount, createDiv } from '../../utils/dom';
@@ -27,14 +27,8 @@ describe('ScaleOutX', () => {
     expect(keyframes(animation, 'opacity')).toEqual([undefined, 1, 0]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.99, null]);
 
-    const { onfinish } = animation;
-    return new Promise<void>((resolve) => {
-      animation.onfinish = (e) => {
-        onfinish.call(animation, e);
-        expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
-        resolve();
-      };
-    });
+    await (animation as Animation).finished;
+    expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
   });
 
   it('ScaleOutX({...}) should scale in different origin in transpose coordinate', async () => {

--- a/__tests__/unit/animation/scaleOutY.spec.ts
+++ b/__tests__/unit/animation/scaleOutY.spec.ts
@@ -1,4 +1,4 @@
-import { Rect } from '@antv/g';
+import { Rect, Animation } from '@antv/g';
 import { ScaleOutY } from '../../../src/animation';
 import { Transpose } from '../../../src/coordinate';
 import { mount, createDiv } from '../../utils/dom';
@@ -27,14 +27,8 @@ describe('ScaleOutY', () => {
     expect(keyframes(animation, 'opacity')).toEqual([undefined, 1, 0]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.99, null]);
 
-    const { onfinish } = animation;
-    return new Promise<void>((resolve) => {
-      animation.onfinish = (e) => {
-        onfinish.call(animation, e);
-        expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
-        resolve();
-      };
-    });
+    await (animation as Animation).finished;
+    expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
   });
 
   it('ScaleOutY({...}) should scale in different origin in transpose coordinate', async () => {

--- a/__tests__/unit/mark/annotation/connector.spec.ts
+++ b/__tests__/unit/mark/annotation/connector.spec.ts
@@ -14,6 +14,7 @@ describe('Connector', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'x', required: true },
         { name: 'y', required: true },
       ],

--- a/__tests__/unit/mark/annotation/lineX.spec.ts
+++ b/__tests__/unit/mark/annotation/lineX.spec.ts
@@ -13,6 +13,7 @@ describe('Line annotation', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'x', required: true },
       ],
       preInference: [{ type: 'maybeArrayField' }],

--- a/__tests__/unit/mark/annotation/lineY.spec.ts
+++ b/__tests__/unit/mark/annotation/lineY.spec.ts
@@ -13,6 +13,7 @@ describe('Line annotation', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'y', required: true },
       ],
       preInference: [{ type: 'maybeArrayField' }],

--- a/__tests__/unit/mark/annotation/range.spec.ts
+++ b/__tests__/unit/mark/annotation/range.spec.ts
@@ -14,6 +14,7 @@ describe('Range annotation', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'x', required: true },
         { name: 'y', required: true },
       ],

--- a/__tests__/unit/mark/annotation/rangeX.spec.ts
+++ b/__tests__/unit/mark/annotation/rangeX.spec.ts
@@ -14,6 +14,7 @@ describe('RangeX annotation', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'x', required: true },
       ],
       preInference: [{ type: 'maybeArrayField' }],

--- a/__tests__/unit/mark/annotation/rangeY.spec.ts
+++ b/__tests__/unit/mark/annotation/rangeY.spec.ts
@@ -14,6 +14,7 @@ describe('RangeY annotation', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'y', required: true },
       ],
       preInference: [{ type: 'maybeArrayField' }],

--- a/__tests__/unit/mark/annotation/text.spec.ts
+++ b/__tests__/unit/mark/annotation/text.spec.ts
@@ -14,6 +14,7 @@ describe('Annotation Text', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'x', required: true },
         { name: 'y', required: true },
         { name: 'text', required: true, scale: 'identity' },

--- a/__tests__/unit/mark/geometry/area.spec.ts
+++ b/__tests__/unit/mark/geometry/area.spec.ts
@@ -13,6 +13,7 @@ describe('Area', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true },

--- a/__tests__/unit/mark/geometry/edge.spec.ts
+++ b/__tests__/unit/mark/geometry/edge.spec.ts
@@ -13,6 +13,7 @@ describe('Edge', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true },

--- a/__tests__/unit/mark/geometry/grid.spec.ts
+++ b/__tests__/unit/mark/geometry/grid.spec.ts
@@ -14,6 +14,7 @@ describe('Grid', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true, scale: 'band' },

--- a/__tests__/unit/mark/geometry/image.spec.ts
+++ b/__tests__/unit/mark/geometry/image.spec.ts
@@ -13,6 +13,7 @@ describe('Image', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true },

--- a/__tests__/unit/mark/geometry/interval.spec.ts
+++ b/__tests__/unit/mark/geometry/interval.spec.ts
@@ -14,6 +14,7 @@ describe('Interval', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', scale: 'band', required: true },

--- a/__tests__/unit/mark/geometry/line.spec.ts
+++ b/__tests__/unit/mark/geometry/line.spec.ts
@@ -14,6 +14,7 @@ describe('Line', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x' },

--- a/__tests__/unit/mark/geometry/link.spec.ts
+++ b/__tests__/unit/mark/geometry/link.spec.ts
@@ -13,6 +13,7 @@ describe('Link', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true },

--- a/__tests__/unit/mark/geometry/node.spec.ts
+++ b/__tests__/unit/mark/geometry/node.spec.ts
@@ -13,6 +13,7 @@ describe('Node', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true },

--- a/__tests__/unit/mark/geometry/point.spec.ts
+++ b/__tests__/unit/mark/geometry/point.spec.ts
@@ -13,6 +13,7 @@ describe('Point', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true },

--- a/__tests__/unit/mark/geometry/polygon.spec.ts
+++ b/__tests__/unit/mark/geometry/polygon.spec.ts
@@ -13,6 +13,7 @@ describe('Polygon', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true },

--- a/__tests__/unit/mark/geometry/schema.spec.ts
+++ b/__tests__/unit/mark/geometry/schema.spec.ts
@@ -14,6 +14,7 @@ describe('Schema', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', scale: 'band', required: true },

--- a/__tests__/unit/mark/geometry/text.spec.ts
+++ b/__tests__/unit/mark/geometry/text.spec.ts
@@ -14,6 +14,7 @@ describe('Text', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true },

--- a/__tests__/unit/mark/geometry/vector.spec.ts
+++ b/__tests__/unit/mark/geometry/vector.spec.ts
@@ -13,6 +13,7 @@ describe('Vector', () => {
         { name: 'enterDuration', scaleName: 'enter' },
         { name: 'enterEasing' },
         { name: 'key', scale: 'identity' },
+        { name: 'groupKey', scale: 'identity' },
         { name: 'title', scale: 'identity' },
         { name: 'tooltip', scale: 'identity', independent: true },
         { name: 'x', required: true },

--- a/__tests__/unit/runtime/keyframe.spec.ts
+++ b/__tests__/unit/runtime/keyframe.spec.ts
@@ -1,3 +1,4 @@
+import { shuffle } from 'd3-array';
 import { G2Spec, render } from '../../../src';
 import { createDiv, mount } from '../../utils/dom';
 
@@ -154,7 +155,7 @@ describe('keyframe', () => {
     mount(createDiv(), chart);
   });
 
-  it.only('keyframe should play in reverse-alternate direction', () => {
+  it('keyframe should play in reverse-alternate direction', () => {
     const data = [
       { genre: 'Sports', sold: 275 },
       { genre: 'Strategy', sold: 115 },
@@ -190,6 +191,44 @@ describe('keyframe', () => {
         },
       ],
     });
+    mount(createDiv(), chart);
+  });
+
+  it('keyframe should apply transition from one to multiple and reverse', async () => {
+    const response = await fetch(
+      'https://gw.alipayobjects.com/os/bmw-prod/fbe4a8c1-ce04-4ba3-912a-0b26d6965333.json',
+    );
+    const data = await response.json();
+    const chart = render<G2Spec>({
+      type: 'keyframe',
+      direction: 'alternate',
+      duration: 1000,
+      iterationCount: 3,
+      children: [
+        {
+          type: 'interval',
+          data,
+          transform: [{ type: 'groupX', y: 'mean' }],
+          encode: {
+            x: 'gender',
+            y: 'weight',
+            color: 'gender',
+            key: 'gender',
+          },
+        },
+        {
+          type: 'point',
+          data,
+          encode: {
+            x: 'height',
+            y: 'weight',
+            color: 'gender',
+            groupKey: 'gender',
+          },
+        },
+      ],
+    });
+
     mount(createDiv(), chart);
   });
 });

--- a/__tests__/unit/utils/selection.spec.ts
+++ b/__tests__/unit/utils/selection.spec.ts
@@ -137,7 +137,7 @@ describe('select', () => {
   it('Selection.append(node) should append nodes with data to parent for empty selection and return the new selection', () => {
     const group = new Group();
     const data = [1, 2, 3];
-    const selection = new Selection(null, data, group, group.ownerDocument);
+    const selection = new Selection([], data, group, group.ownerDocument);
 
     const s1 = selection.append('rect');
     const nodes = s1.nodes();
@@ -325,14 +325,6 @@ describe('select', () => {
         expect(selection.nodes().map((d) => d.__data__)).toEqual([2, 3, 4, 1]),
       );
     expect(selection.selectAll('.cls').nodes()[1].style.fill).toBe('red');
-  });
-
-  it('Selection.remove() should not remove selected elements without parentNode', () => {
-    const group = new Group();
-    const selection = select(group);
-    const s1 = selection.remove();
-    expect(s1).not.toBe(selection);
-    expect(s1.nodes().length).toBe(1);
   });
 
   it('Selection.remove() should remove selected elements', () => {

--- a/docs/keyframe.md
+++ b/docs/keyframe.md
@@ -127,6 +127,46 @@ Keyframe composition provide a convent mechanism to author storytelling. It can 
 })();
 ```
 
+## Split and Merge
+
+```js
+(async () => {
+  const response = await fetch(
+    'https://gw.alipayobjects.com/os/bmw-prod/fbe4a8c1-ce04-4ba3-912a-0b26d6965333.json',
+  );
+  const data = await response.json();
+  return G2.render({
+    type: 'keyframe',
+    direction: 'alternate',
+    duration: 1000,
+    iterationCount: 4,
+    children: [
+      {
+        type: 'interval',
+        data,
+        transform: [{ type: 'groupX', y: 'mean' }],
+        encode: {
+          x: 'gender',
+          y: 'weight',
+          color: 'gender',
+          key: 'gender',
+        },
+      },
+      {
+        type: 'point',
+        data,
+        encode: {
+          x: 'height',
+          y: 'weight',
+          color: 'gender',
+          groupKey: 'gender',
+        },
+      },
+    ],
+  });
+})();
+```
+
 ## Duration
 
 ```js

--- a/src/animation/fadeIn.ts
+++ b/src/animation/fadeIn.ts
@@ -8,7 +8,8 @@ export type FadeInOptions = Animation;
  * Transform mark from transparent to solid.
  */
 export const FadeIn: AC<FadeInOptions> = (options) => {
-  return (shape, value, coordinate, defaults) => {
+  return (from, to, value, coordinate, defaults) => {
+    const [shape] = from;
     // shape.animate() can not process `opacity = ""`;
     // todo: When G's bug fixed, modify to `shape.style`.
     const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;

--- a/src/animation/fadeOut.ts
+++ b/src/animation/fadeOut.ts
@@ -8,7 +8,8 @@ export type FadeOutOptions = Animation;
  * Transform mark from solid to transparent.
  */
 export const FadeOut: AC<FadeOutOptions> = (options) => {
-  return (shape, value, coordinate, defaults) => {
+  return (from, to, value, coordinate, defaults) => {
+    const [shape] = from;
     const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
     const keyframes = [
       {

--- a/src/animation/morphing.ts
+++ b/src/animation/morphing.ts
@@ -1,9 +1,17 @@
-import { convertToPath, DisplayObject, Animation as GAnimation } from '@antv/g';
+import {
+  convertToPath,
+  DisplayObject,
+  Animation as GAnimation,
+  Rect,
+  Path,
+} from '@antv/g';
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from '../spec';
 import { effectTiming } from './utils';
 
 export type MorphingOptions = Animation;
+
+type BBox = [number, number, number, number];
 
 function attributeOf(shape: DisplayObject, keys: string[]) {
   const attribute = {};
@@ -16,11 +24,18 @@ function attributeOf(shape: DisplayObject, keys: string[]) {
   return attribute;
 }
 
-function pathToPath(
+function oneToOne(
+  shape: DisplayObject,
   from: DisplayObject,
   to: DisplayObject,
   timeEffect: Record<string, any>,
-): GAnimation {
+) {
+  const fromPath = convertToPath(from);
+  const toPath = convertToPath(to);
+  if (fromPath === undefined || toPath === undefined) {
+    return shapeToShape(from, to, timeEffect);
+  }
+
   // @todo Add more attributes need to be transform.
   const keys = [
     'fill',
@@ -30,24 +45,23 @@ function pathToPath(
     'opacity',
     'lineWidth',
   ];
-
   // Convert Path will take transform, anchor, etc into account,
   // so there is no need to specify these attributes in keyframes.
   const keyframes = [
     {
-      path: convertToPath(from),
+      path: fromPath,
       ...attributeOf(from, keys),
     },
     {
-      path: convertToPath(to),
+      path: toPath,
       ...attributeOf(to, keys),
     },
   ];
-  const animation = from.animate(keyframes, timeEffect);
+  const animation = shape.animate(keyframes, timeEffect);
 
   // Remove transform because it already applied in path
   // converted by convertToPath.
-  animation.onfinish = () => (from.style.transform = 'none');
+  animation.finished.then(() => (shape.style.transform = 'none'));
   return animation;
 }
 
@@ -62,18 +76,130 @@ function shapeToShape(
   return null;
 }
 
+function localBBoxOf(shape: DisplayObject): BBox {
+  const { min, max } = shape.getLocalBounds();
+  const [x0, y0] = min;
+  const [x1, y1] = max;
+  const height = y1 - y0;
+  const width = x1 - x0;
+  return [x0, y0, width, height];
+}
+
+function d(bbox: BBox): string {
+  const [x, y, width, height] = bbox;
+  return `
+    M ${x} ${y}
+    L ${x + width} ${y}
+    L ${x + width} ${y + height}
+    L ${x} ${y + height}
+    Z
+  `;
+}
+
+function pack(
+  x0: number,
+  y0: number,
+  width: number,
+  height: number,
+  count: number,
+): BBox[] {
+  const aspect = height / width;
+  const col = Math.ceil(Math.sqrt(count / aspect));
+  const row = Math.ceil(count / col);
+  const B = [];
+  const h = height / row;
+  let j = 0;
+  let n = count;
+  while (n > 0) {
+    const c = Math.min(n, col);
+    const w = width / c;
+    for (let i = 0; i < c; i++) {
+      const x = x0 + i * w;
+      const y = y0 + j * h;
+      B.push([x, y, w, h]);
+    }
+    n -= c;
+    j += 1;
+  }
+  return B;
+}
+
+function split(shape: DisplayObject, count: number): string[] {
+  const [x, y, width, height] = localBBoxOf(shape);
+  return pack(x, y, width, height, count).map(d);
+}
+
+function oneToMultiple(
+  from: DisplayObject,
+  to: DisplayObject[],
+  timeEffect: Record<string, any>,
+) {
+  // Hide the shape to be split before being removing.
+  from.style.visibility = 'hidden';
+  const D = split(from, to.length);
+  return to.map((shape, i) => {
+    const path = new Path({
+      style: {
+        path: D[i],
+        fill: from.style.fill,
+      },
+    });
+    return oneToOne(shape, path, shape, timeEffect);
+  });
+}
+
+function multipleToOne(
+  from: DisplayObject[],
+  to: DisplayObject,
+  timeEffect: Record<string, any>,
+) {
+  const D = split(to, from.length);
+  // @todo Replace with to.style.
+  const { fillOpacity, strokeOpacity, opacity } = to.parsedStyle;
+  const keyframes = [
+    { fillOpacity: 0, strokeOpacity: 0, opacity: 0 },
+    { fillOpacity: 0, strokeOpacity: 0, opacity: 0, offset: 0.99 },
+    {
+      fillOpacity: fillOpacity.value,
+      strokeOpacity: strokeOpacity.value,
+      opacity: opacity.value,
+    },
+  ];
+  const animation = to.animate(keyframes, timeEffect);
+  const animations = from.map((shape, i) => {
+    const path = new Path({
+      style: {
+        path: D[i],
+        fill: to.style.fill,
+      },
+    });
+    return oneToOne(shape, shape, path, timeEffect);
+  });
+  return [...animations, animation];
+}
+
 /**
- * Transform mark from transparent to solid.
+ * Morphing animations.
  */
 export const Morphing: AC<MorphingOptions> = (options) => {
-  return (shape, style, coordinate, defaults) => {
-    const { to, ...rest } = style;
-    const timeEffect = effectTiming(defaults, rest, options);
-    try {
-      return pathToPath(shape, to, timeEffect);
-    } catch {
-      return shapeToShape(shape, to, timeEffect);
+  return (from, to, value, coordinate, defaults) => {
+    const timeEffect = effectTiming(defaults, value, options);
+    const { length: fl } = from;
+    const { length: tl } = to;
+    if ((fl === 1 && tl === 1) || (fl > 1 && tl > 1)) {
+      const [f] = from;
+      const [t] = to;
+      return oneToOne(f, f, t, timeEffect);
     }
+    if (fl === 1 && tl > 1) {
+      const [f] = from;
+      return oneToMultiple(f, to, timeEffect);
+    }
+    if (fl > 1 && tl === 1) {
+      const [t] = to;
+      return multipleToOne(from, t, timeEffect);
+    }
+    return null;
   };
 };
 

--- a/src/animation/scaleInX.ts
+++ b/src/animation/scaleInX.ts
@@ -13,13 +13,14 @@ export const ScaleInX: AC<ScaleInXOptions> = (options) => {
   // but bigger enough to not cause bug.
   const ZERO = 0.0001;
 
-  return (shape, value, coordinate, defaults) => {
+  return (from, to, value, coordinate, defaults) => {
+    const [shape] = from;
     const { height } = shape.getBoundingClientRect();
     const { transform: prefix } = shape.style;
     const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
     const [transformOrigin, transform]: [[number, number], string] =
       isTranspose(coordinate)
-        ? [[0, height], `scale(1, ${ZERO})`] // left-buttom corner
+        ? [[0, height], `scale(1, ${ZERO})`] // left-bottom corner
         : [[0, 0], `scale(${ZERO}, 1)`]; // left-top corner
 
     // Using a short fadeIn transition to hide element with scale(0.001)

--- a/src/animation/scaleInX.ts
+++ b/src/animation/scaleInX.ts
@@ -53,7 +53,7 @@ export const ScaleInX: AC<ScaleInXOptions> = (options) => {
     );
 
     // Reset transform origin to eliminate side effect for following animations.
-    animation.onfinish = () => shape.setOrigin(0, 0);
+    animation.finished.then(() => shape.setOrigin(0, 0));
 
     return animation;
   };

--- a/src/animation/scaleInY.ts
+++ b/src/animation/scaleInY.ts
@@ -13,7 +13,8 @@ export const ScaleInY: AC<ScaleInYOptions> = (options) => {
   // but bigger enough to not cause bug.
   const ZERO = 0.0001;
 
-  return (shape, value, coordinate, defaults) => {
+  return (from, to, value, coordinate, defaults) => {
+    const [shape] = from;
     const { height } = shape.getBoundingClientRect();
     const { transform: prefix } = shape.style;
     const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
@@ -52,7 +53,7 @@ export const ScaleInY: AC<ScaleInYOptions> = (options) => {
     );
 
     // Reset transform origin to eliminate side effect for following animations.
-    animation.onfinish = () => shape.setOrigin(0, 0);
+    animation.finished.then(() => shape.setOrigin(0, 0));
 
     return animation;
   };

--- a/src/animation/scaleOutX.ts
+++ b/src/animation/scaleOutX.ts
@@ -13,13 +13,14 @@ export const ScaleOutX: AC<ScaleOutXOptions> = (options) => {
   // but bigger enough to not cause bug.
   const ZERO = 0.0001;
 
-  return (shape, value, coordinate, defaults) => {
+  return (from, to, value, coordinate, defaults) => {
+    const [shape] = from;
     const { height } = shape.getBoundingClientRect();
     const { transform: prefix } = shape.style;
     const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
     const [transformOrigin, transform]: [[number, number], string] =
       isTranspose(coordinate)
-        ? [[0, height], `scale(1, ${ZERO})`] // left-buttom corner
+        ? [[0, height], `scale(1, ${ZERO})`] // left-bottom corner
         : [[0, 0], `scale(${ZERO}, 1)`]; // left-top corner
 
     // Using a short fadeIn transition to hide element with scale(0.001)

--- a/src/animation/scaleOutX.ts
+++ b/src/animation/scaleOutX.ts
@@ -53,7 +53,7 @@ export const ScaleOutX: AC<ScaleOutXOptions> = (options) => {
     );
 
     // Reset transform origin to eliminate side effect for following animations.
-    animation.onfinish = () => shape.setOrigin(0, 0);
+    animation.finished.then(() => shape.setOrigin(0, 0));
 
     return animation;
   };

--- a/src/animation/scaleOutY.ts
+++ b/src/animation/scaleOutY.ts
@@ -13,7 +13,8 @@ export const ScaleOutY: AC<ScaleOutYOptions> = (options) => {
   // but bigger enough to not cause bug.
   const ZERO = 0.0001;
 
-  return (shape, value, coordinate, defaults) => {
+  return (from, to, value, coordinate, defaults) => {
+    const [shape] = from;
     const { height } = shape.getBoundingClientRect();
     const { transform: prefix } = shape.style;
     const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;

--- a/src/animation/scaleOutY.ts
+++ b/src/animation/scaleOutY.ts
@@ -53,7 +53,7 @@ export const ScaleOutY: AC<ScaleOutYOptions> = (options) => {
     );
 
     // Reset transform origin to eliminate side effect for following animations.
-    animation.onfinish = () => shape.setOrigin(0, 0);
+    animation.finished.then(() => shape.setOrigin(0, 0));
 
     return animation;
   };

--- a/src/mark/utils.ts
+++ b/src/mark/utils.ts
@@ -9,6 +9,7 @@ export function baseChannels(): Channel[] {
     { name: 'enterDuration', scaleName: 'enter' },
     { name: 'enterEasing' },
     { name: 'key', scale: 'identity' },
+    { name: 'groupKey', scale: 'identity' },
   ];
 }
 

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -467,7 +467,7 @@ async function plotView(
           update.transition(function (data, index) {
             const node = shapeFunction(data, index);
             const animation = updateFunction(data, [this], [node]);
-            // @todo Handle shape with different type.
+            // @todo Handle element with different type.
             if (animation === null) copyAttributes(this, node);
             return animation;
           }),
@@ -479,13 +479,14 @@ async function plotView(
             .remove(),
         (merge) =>
           merge
-            // Append shapes to be merged.
+            // Append elements to be merged.
             .append(shapeFunction)
             .attr('className', 'element')
             .transition(function (data) {
-              // Remove merged shapes after animation finishing.
-              const transition = updateFunction(data, this.__from__, [this]);
-              const exit = new Selection(this.__from__, null, this.parentNode);
+              // Remove merged elements after animation finishing.
+              const { __fromElements__: fromElements } = this;
+              const transition = updateFunction(data, fromElements, [this]);
+              const exit = new Selection(fromElements, null, this.parentNode);
               exit.transition(transition).remove();
               return transition;
             }),
@@ -493,14 +494,14 @@ async function plotView(
           split
             .transition(function (data) {
               // Append splitted shapes.
-              const enter = new Selection([], this.__to__, this.parentNode);
-              const to = enter
+              const enter = new Selection([], this.__toData__, this.parentNode);
+              const toElements = enter
                 .append(shapeFunction)
                 .attr('className', 'element')
                 .nodes();
-              return updateFunction(data, [this], to);
+              return updateFunction(data, [this], toElements);
             })
-            // Remove shapes to be splitted after animation finishing.
+            // Remove elements to be splitted after animation finishing.
             .remove(),
       )
       .transitions();
@@ -599,8 +600,7 @@ function createEnterFunction(
  * manually. This is very important for performance.
  */
 function cancel(animation: GAnimation): Promise<any> {
-  animation.finished.then(() => animation.cancel());
-  return animation.finished;
+  return animation.finished.then(() => animation.cancel());
 }
 
 function createUpdateFunction(

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -598,9 +598,12 @@ function createEnterFunction(
 /**
  * Animation will not cancel automatically, it should be canceled
  * manually. This is very important for performance.
+ * @todo Enable cancel after transition bug fixed.
  */
 function cancel(animation: GAnimation): Promise<any> {
-  return animation.finished.then(() => animation.cancel());
+  return animation.finished.then(() => {
+    // animation.cancel()
+  });
 }
 
 function createUpdateFunction(

--- a/src/runtime/types/component.ts
+++ b/src/runtime/types/component.ts
@@ -175,11 +175,12 @@ export type GuideComponentComponent<O = Record<string, unknown>> =
   G2BaseComponent<GuideComponent, O, GuideComponentProps>;
 
 export type Animation = (
-  shape: DisplayObject,
-  style: Record<string, any>,
+  from: DisplayObject[],
+  to: DisplayObject[],
+  value: Record<string, any>,
   coordinate: Coordinate,
-  defaults: G2Theme['enter' | 'exit' | 'update'],
-) => GAnimation;
+  defaults: G2Theme['enter' | 'exit' | 'enter'],
+) => GAnimation | GAnimation[];
 export type AnimationComponent<O = Record<string, unknown>> = G2BaseComponent<
   Animation,
   O

--- a/src/runtime/types/component.ts
+++ b/src/runtime/types/component.ts
@@ -179,7 +179,7 @@ export type Animation = (
   to: DisplayObject[],
   value: Record<string, any>,
   coordinate: Coordinate,
-  defaults: G2Theme['enter' | 'exit' | 'enter'],
+  defaults: G2Theme['enter' | 'exit' | 'update'],
 ) => GAnimation | GAnimation[];
 export type AnimationComponent<O = Record<string, unknown>> = G2BaseComponent<
   Animation,

--- a/src/spec/geometry.ts
+++ b/src/spec/geometry.ts
@@ -59,7 +59,8 @@ export type ChannelTypes =
   | 'size'
   | 'tooltip'
   | 'title'
-  | 'key';
+  | 'key'
+  | 'groupKey';
 
 export type BaseGeometry<
   T extends GeometryTypes,

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -66,7 +66,7 @@ export class Selection<T = any> {
     elements: Iterable<G2Element> = null,
     data: T[] | [T, G2Element[]][] = null,
     parent: G2Element = null,
-    document: IDocument = null,
+    document: IDocument | null = null,
     selections: [Selection, Selection, Selection, Selection, Selection] = [
       null,
       null,

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -19,8 +19,8 @@ import { error } from './helper';
 
 export type G2Element = DisplayObject & {
   __data__?: any;
-  __to__?: any[];
-  __from__?: DisplayObject[];
+  __toData__?: any[];
+  __fromElements__?: DisplayObject[];
 };
 
 export function select<T = any>(node: Group) {
@@ -128,7 +128,7 @@ export class Selection<T = any> {
         const [datum, from] = Array.isArray(d) ? d : [d, null];
         const newElement = callback(datum, i);
         newElement.__data__ = datum;
-        if (from !== null) newElement.__from__ = from;
+        if (from !== null) newElement.__fromElements__ = from;
         this._parent.appendChild(newElement);
         elements.push(newElement);
       }
@@ -205,8 +205,8 @@ export class Selection<T = any> {
         // groupKey as its key, and bind to datum for it.
       } else if (keyElement.has(groupKey)) {
         const element = keyElement.get(groupKey);
-        if (element.__to__) element.__to__.push(datum);
-        else element.__to__ = [datum];
+        if (element.__toData__) element.__toData__.push(datum);
+        else element.__toData__ = [datum];
         split.add(element);
         exit.delete(element);
       } else {


### PR DESCRIPTION
feat: support merge and split animation. [preview](http://g2-next.antv.vision/keyframe/#split-and-merge)

- Selection
  - _selection_.**data** will accept _groupId_.
  - _selection_.**join** will produce _enter_, _update_, _exit_, _merge_ and _split_ selection.
  - _selection_.**remove** will remove elements after transition ending(if exist).
  - _selection_.**transition** will set transition for each elements.
  - _selection_.**transitions** will return all the transitions.
  - _selection_.**merge** will merge transition of each selection as well.
- Runtime: Handle merge and split selection.
- Morphing: Support merge and split transition.
- Marks: Add _groupKey_ channel.

![interval-to-dot](https://user-images.githubusercontent.com/49330279/176389877-a90f13e7-dc46-4594-a257-5d110ba1790c.gif)

```js
(async () => {
  const response = await fetch(
    'https://gw.alipayobjects.com/os/bmw-prod/fbe4a8c1-ce04-4ba3-912a-0b26d6965333.json',
  );
  const data = await response.json();
  return G2.render({
    type: 'keyframe',
    direction: 'alternate',
    duration: 1000,
    iterationCount: 4,
    children: [
      {
        type: 'interval',
        data,
        transform: [{ type: 'groupX', y: 'mean' }],
        encode: {
          x: 'gender',
          y: 'weight',
          color: 'gender',
          key: 'gender',
        },
      },
      {
        type: 'point',
        data,
        encode: {
          x: 'height',
          y: 'weight',
          color: 'gender',
          groupKey: 'gender',
        },
      },
    ],
  });
})();
```
