### PR TITLE
refactor(animation): abstract scale animation

### DIFF
--- a/__tests__/unit/animation/scaleInX.spec.ts
+++ b/__tests__/unit/animation/scaleInX.spec.ts
@@ -16,9 +16,9 @@ describe('ScaleInX', () => {
       animate: ScaleInX({ fill: 'both', duration: 300 }),
       container,
     });
-    expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
+    expect(shape.style.transformOrigin).toBe('left top');
     expect(keyframes(animation, 'transform')).toEqual([
-      'scale(0.0001, 1)',
+      undefined,
       'scale(0.0001, 1)',
       'scale(1, 1)',
     ]);
@@ -27,14 +27,8 @@ describe('ScaleInX', () => {
     expect(keyframes(animation, 'opacity')).toEqual([0, 1, undefined]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.01, null]);
 
-    const { onfinish } = animation;
-    return new Promise<void>((resolve) => {
-      animation.onfinish = (e) => {
-        onfinish.call(animation, e);
-        expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
-        resolve();
-      };
-    });
+    await animation.finished;
+    expect(shape.style.transformOrigin).toBe('left top');
   });
 
   it('ScaleInX({...}) should scale in different origin in transpose coordinate', async () => {
@@ -50,9 +44,9 @@ describe('ScaleInX', () => {
       container,
     });
 
-    expect(shape.getOrigin()).toEqual(new Float32Array([0, 200, 0]));
+    expect(shape.style.transformOrigin).toBe('left bottom');
     expect(keyframes(animation, 'transform')).toEqual([
-      'scale(1, 0.0001)',
+      undefined,
       'scale(1, 0.0001)',
       'scale(1, 1)',
     ]);

--- a/__tests__/unit/animation/scaleInY.spec.ts
+++ b/__tests__/unit/animation/scaleInY.spec.ts
@@ -16,9 +16,9 @@ describe('ScaleInY', () => {
       animate: ScaleInY({ fill: 'both', duration: 300 }),
       container,
     });
-    expect(shape.getOrigin()).toEqual(new Float32Array([0, 200, 0]));
+    expect(shape.style.transformOrigin).toBe('left bottom');
     expect(keyframes(animation, 'transform')).toEqual([
-      'scale(1, 0.0001)',
+      undefined,
       'scale(1, 0.0001)',
       'scale(1, 1)',
     ]);
@@ -27,14 +27,8 @@ describe('ScaleInY', () => {
     expect(keyframes(animation, 'opacity')).toEqual([0, 1, undefined]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.01, null]);
 
-    const { onfinish } = animation;
-    return new Promise<void>((resolve) => {
-      animation.onfinish = (e) => {
-        onfinish.call(animation, e);
-        expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
-        resolve();
-      };
-    });
+    await animation.finished;
+    expect(shape.style.transformOrigin).toBe('left top');
   });
 
   it('ScaleInY({...}) should scale in different origin in transpose coordinate', async () => {
@@ -50,9 +44,9 @@ describe('ScaleInY', () => {
       container,
     });
 
-    expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
+    expect(shape.style.transformOrigin).toBe('left top');
     expect(keyframes(animation, 'transform')).toEqual([
-      'scale(0.0001, 1)',
+      undefined,
       'scale(0.0001, 1)',
       'scale(1, 1)',
     ]);

--- a/__tests__/unit/animation/scaleOutX.spec.ts
+++ b/__tests__/unit/animation/scaleOutX.spec.ts
@@ -16,25 +16,19 @@ describe('ScaleOutX', () => {
       animate: ScaleOutX({ fill: 'both', duration: 300 }),
       container,
     });
-    expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
+    expect(shape.style.transformOrigin).toBe('left top');
     expect(keyframes(animation, 'transform')).toEqual([
       'scale(1, 1)',
       'scale(0.0001, 1)',
-      'scale(0.0001, 1)',
+      undefined,
     ]);
     expect(keyframes(animation, 'fillOpacity')).toEqual([undefined, 1, 0]);
     expect(keyframes(animation, 'strokeOpacity')).toEqual([undefined, 1, 0]);
     expect(keyframes(animation, 'opacity')).toEqual([undefined, 1, 0]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.99, null]);
 
-    const { onfinish } = animation;
-    return new Promise<void>((resolve) => {
-      animation.onfinish = (e) => {
-        onfinish.call(animation, e);
-        expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
-        resolve();
-      };
-    });
+    await animation.finished;
+    expect(shape.style.transformOrigin).toBe('left top');
   });
 
   it('ScaleOutX({...}) should scale in different origin in transpose coordinate', async () => {
@@ -50,11 +44,11 @@ describe('ScaleOutX', () => {
       container,
     });
 
-    expect(shape.getOrigin()).toEqual(new Float32Array([0, 200, 0]));
+    expect(shape.style.transformOrigin).toBe('left bottom');
     expect(keyframes(animation, 'transform')).toEqual([
       'scale(1, 1)',
       'scale(1, 0.0001)',
-      'scale(1, 0.0001)',
+      undefined,
     ]);
   });
 

--- a/__tests__/unit/animation/scaleOutY.spec.ts
+++ b/__tests__/unit/animation/scaleOutY.spec.ts
@@ -16,25 +16,19 @@ describe('ScaleOutY', () => {
       animate: ScaleOutY({ fill: 'both', duration: 300 }),
       container,
     });
-    expect(shape.getOrigin()).toEqual(new Float32Array([0, 200, 0]));
+    expect(shape.style.transformOrigin).toBe('left bottom');
     expect(keyframes(animation, 'transform')).toEqual([
       'scale(1, 1)',
       'scale(1, 0.0001)',
-      'scale(1, 0.0001)',
+      undefined,
     ]);
     expect(keyframes(animation, 'fillOpacity')).toEqual([undefined, 1, 0]);
     expect(keyframes(animation, 'strokeOpacity')).toEqual([undefined, 1, 0]);
     expect(keyframes(animation, 'opacity')).toEqual([undefined, 1, 0]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.99, null]);
 
-    const { onfinish } = animation;
-    return new Promise<void>((resolve) => {
-      animation.onfinish = (e) => {
-        onfinish.call(animation, e);
-        expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
-        resolve();
-      };
-    });
+    await animation.finished;
+    expect(shape.style.transformOrigin).toBe('left top');
   });
 
   it('ScaleOutY({...}) should scale in different origin in transpose coordinate', async () => {
@@ -50,11 +44,11 @@ describe('ScaleOutY', () => {
       container,
     });
 
-    expect(shape.getOrigin()).toEqual(new Float32Array([0, 0, 0]));
+    expect(shape.style.transformOrigin).toBe('left top');
     expect(keyframes(animation, 'transform')).toEqual([
       'scale(1, 1)',
       'scale(0.0001, 1)',
-      'scale(0.0001, 1)',
+      undefined,
     ]);
   });
 

--- a/src/animation/fadeIn.ts
+++ b/src/animation/fadeIn.ts
@@ -1,3 +1,4 @@
+import { DisplayObject } from '@antv/g';
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from '../spec';
 import { effectTiming } from './utils';
@@ -5,24 +6,27 @@ import { effectTiming } from './utils';
 export type FadeInOptions = Animation;
 
 /**
+ * @todo shape.animate() can not process `opacity = ""`;
+ * When G's bug fixed, modify to `shape.style`.
+ */
+export function fadeIn(shape: DisplayObject) {
+  const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
+  return [
+    { fillOpacity: 0, strokeOpacity: 0, opacity: 0 },
+    {
+      fillOpacity: fillOpacity.value,
+      strokeOpacity: strokeOpacity.value,
+      opacity: opacity.value,
+    },
+  ];
+}
+
+/**
  * Transform mark from transparent to solid.
  */
 export const FadeIn: AC<FadeInOptions> = (options) => {
   return (shape, value, coordinate, defaults) => {
-    // shape.animate() can not process `opacity = ""`;
-    // todo: When G's bug fixed, modify to `shape.style`.
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
-
-    const keyframes = [
-      { fillOpacity: 0, strokeOpacity: 0, opacity: 0 },
-      {
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
-      },
-    ];
-
-    return shape.animate(keyframes, effectTiming(defaults, value, options));
+    return shape.animate(fadeIn(shape), effectTiming(defaults, value, options));
   };
 };
 

--- a/src/animation/fadeOut.ts
+++ b/src/animation/fadeOut.ts
@@ -1,24 +1,24 @@
+import { DisplayObject } from '@antv/g';
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from '../spec';
+import { fadeIn } from './fadeIn';
 import { effectTiming } from './utils';
 
 export type FadeOutOptions = Animation;
+
+export function fadeOut(shape: DisplayObject) {
+  return fadeIn(shape).reverse();
+}
 
 /**
  * Transform mark from solid to transparent.
  */
 export const FadeOut: AC<FadeOutOptions> = (options) => {
   return (shape, value, coordinate, defaults) => {
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
-    const keyframes = [
-      {
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
-      },
-      { fillOpacity: 0, strokeOpacity: 0, opacity: 0 },
-    ];
-    return shape.animate(keyframes, effectTiming(defaults, value, options));
+    return shape.animate(
+      fadeOut(shape),
+      effectTiming(defaults, value, options),
+    );
   };
 };
 

--- a/src/animation/scaleInX.ts
+++ b/src/animation/scaleInX.ts
@@ -1,59 +1,93 @@
+import { DisplayObject } from '@antv/g';
+import { Coordinate } from '@antv/coord';
 import { isTranspose } from '../utils/coordinate';
-import { Animation } from '../spec';
-import { AnimationComponent as AC } from '../runtime';
+import { AnimationComponent as AC, Animation } from '../runtime';
+import { Animation as AnimationOptions } from '../spec';
 import { effectTiming } from './utils';
+import { fadeIn } from './fadeIn';
 
-export type ScaleInXOptions = Animation;
+export type ScaleInXOptions = AnimationOptions;
+
+type Keyframe = Record<string, any>;
+
+type Direction = (scale: Keyframe[], fade: Keyframe[]) => Keyframe[];
+
+type Transform = (coordinate: Coordinate) => [string, string];
+
+// Small enough to hide or show very small part of mark,
+// but bigger enough to not cause bug.
+const ZERO = 0.0001;
+
+function concatKeyframes(
+  K0: Keyframe[],
+  K1: Keyframe[],
+  offset: number,
+): Keyframe[] {
+  const [prefix, k0] = [K0.slice(0, -1), K0.pop()];
+  const [k1, ...suffix] = K1;
+  return [...prefix, { ...k1, ...k0, offset }, ...suffix];
+}
+
+function appendTransform(shape: DisplayObject, transform: string): string {
+  const { transform: prefix } = shape.style;
+  return `${prefix} ${transform}`.trimStart();
+}
+
+export function transformX(coordinate: Coordinate): [string, string] {
+  return isTranspose(coordinate)
+    ? ['left bottom', `scale(1, ${ZERO})`]
+    : ['left top', `scale(${ZERO}, 1)`];
+}
+
+export function transformY(coordinate: Coordinate): [string, string] {
+  return isTranspose(coordinate)
+    ? ['left top', `scale(${ZERO}, 1)`]
+    : ['left bottom', `scale(1, ${ZERO})`];
+}
+
+export function directionIn(
+  scaleIn: Keyframe[],
+  fadeIn: Keyframe[],
+): Keyframe[] {
+  return concatKeyframes(fadeIn, scaleIn, 0.01);
+}
+
+export function directionOut(
+  scaleIn: Keyframe[],
+  fadeIn: Keyframe[],
+): Keyframe[] {
+  return concatKeyframes(scaleIn.reverse(), fadeIn.reverse(), 0.99);
+}
+
+export function AbstractScale<T>(
+  direction: Direction,
+  transform: Transform,
+  options: T,
+): Animation {
+  return (shape, value, coordinate, defaults) => {
+    const [origin, from] = transform(coordinate);
+    const S = [
+      { transform: appendTransform(shape, from) },
+      { transform: appendTransform(shape, 'scale(1, 1)') },
+    ];
+    const F = fadeIn(shape);
+    const keyframes = direction(S, F);
+    // Change transform origin for correct transform.
+    shape.style.transformOrigin = origin;
+    const animation = shape.animate(
+      keyframes,
+      effectTiming(defaults, value, options),
+    );
+    // Reset transform origin to eliminate side effect
+    // for following animations.
+    animation.finished.then(() => (shape.style.transformOrigin = 'left top'));
+    return animation;
+  };
+}
 
 /**
  * Scale mark from nothing to desired shape in x direction.
  */
 export const ScaleInX: AC<ScaleInXOptions> = (options) => {
-  // Small enough to hide or show very small part of mark,
-  // but bigger enough to not cause bug.
-  const ZERO = 0.0001;
-
-  return (shape, value, coordinate, defaults) => {
-    const { height } = shape.getBoundingClientRect();
-    const { transform: prefix } = shape.style;
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
-    const [transformOrigin, transform]: [[number, number], string] =
-      isTranspose(coordinate)
-        ? [[0, height], `scale(1, ${ZERO})`] // left-buttom corner
-        : [[0, 0], `scale(${ZERO}, 1)`]; // left-top corner
-
-    // Using a short fadeIn transition to hide element with scale(0.001)
-    // which is still visible.
-    const keyframes = [
-      {
-        transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: 0,
-        strokeOpacity: 0,
-        opacity: 0,
-      },
-      {
-        transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
-        offset: 0.01,
-      },
-      {
-        transform: `${prefix} scale(1, 1)`.trimStart(),
-      },
-    ];
-
-    // Change transform origin for correct transform.
-    shape.setOrigin(transformOrigin);
-
-    const animation = shape.animate(
-      keyframes,
-      effectTiming(defaults, value, options),
-    );
-
-    // Reset transform origin to eliminate side effect for following animations.
-    animation.onfinish = () => shape.setOrigin(0, 0);
-
-    return animation;
-  };
+  return AbstractScale<ScaleInXOptions>(directionIn, transformX, options);
 };

--- a/src/animation/scaleInY.ts
+++ b/src/animation/scaleInY.ts
@@ -1,7 +1,6 @@
-import { isTranspose } from '../utils/coordinate';
 import { Animation } from '../spec';
 import { AnimationComponent as AC } from '../runtime';
-import { effectTiming } from './utils';
+import { AbstractScale, transformY, directionIn } from './scaleInX';
 
 export type ScaleInYOptions = Animation;
 
@@ -9,51 +8,5 @@ export type ScaleInYOptions = Animation;
  * Scale mark from nothing to desired shape in y direction.
  */
 export const ScaleInY: AC<ScaleInYOptions> = (options) => {
-  // Small enough to hide or show very small part of mark,
-  // but bigger enough to not cause bug.
-  const ZERO = 0.0001;
-
-  return (shape, value, coordinate, defaults) => {
-    const { height } = shape.getBoundingClientRect();
-    const { transform: prefix } = shape.style;
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
-    const [transformOrigin, transform]: [[number, number], string] =
-      isTranspose(coordinate)
-        ? [[0, 0], `scale(${ZERO}, 1)`] // left-top corner
-        : [[0, height], `scale(1, ${ZERO})`]; // left-bottom corner
-
-    // Using a short fadeIn transition to hide element with scale(0.001)
-    // which is still visible.
-    const keyframes = [
-      {
-        transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: 0,
-        strokeOpacity: 0,
-        opacity: 0,
-      },
-      {
-        transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
-        offset: 0.01,
-      },
-      {
-        transform: `${prefix} scale(1, 1)`.trimStart(),
-      },
-    ];
-
-    // Change transform origin for correct transform.
-    shape.setOrigin(transformOrigin);
-
-    const animation = shape.animate(
-      keyframes,
-      effectTiming(defaults, value, options),
-    );
-
-    // Reset transform origin to eliminate side effect for following animations.
-    animation.onfinish = () => shape.setOrigin(0, 0);
-
-    return animation;
-  };
+  return AbstractScale<ScaleInYOptions>(directionIn, transformY, options);
 };

--- a/src/animation/scaleOutX.ts
+++ b/src/animation/scaleOutX.ts
@@ -2,6 +2,7 @@ import { isTranspose } from '../utils/coordinate';
 import { Animation } from '../spec';
 import { AnimationComponent as AC } from '../runtime';
 import { effectTiming } from './utils';
+import { AbstractScale, transformX, directionOut } from './scaleInX';
 
 export type ScaleOutXOptions = Animation;
 
@@ -9,51 +10,5 @@ export type ScaleOutXOptions = Animation;
  * Scale mark from desired shape to nothing in x direction.
  */
 export const ScaleOutX: AC<ScaleOutXOptions> = (options) => {
-  // Small enough to hide or show very small part of mark,
-  // but bigger enough to not cause bug.
-  const ZERO = 0.0001;
-
-  return (shape, value, coordinate, defaults) => {
-    const { height } = shape.getBoundingClientRect();
-    const { transform: prefix } = shape.style;
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
-    const [transformOrigin, transform]: [[number, number], string] =
-      isTranspose(coordinate)
-        ? [[0, height], `scale(1, ${ZERO})`] // left-buttom corner
-        : [[0, 0], `scale(${ZERO}, 1)`]; // left-top corner
-
-    // Using a short fadeIn transition to hide element with scale(0.001)
-    // which is still visible.
-    const keyframes = [
-      {
-        transform: `${prefix} scale(1, 1)`.trimStart(),
-      },
-      {
-        transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
-        offset: 0.99,
-      },
-      {
-        transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: 0,
-        strokeOpacity: 0,
-        opacity: 0,
-      },
-    ];
-
-    // Change transform origin for correct transform.
-    shape.setOrigin(transformOrigin);
-
-    const animation = shape.animate(
-      keyframes,
-      effectTiming(defaults, value, options),
-    );
-
-    // Reset transform origin to eliminate side effect for following animations.
-    animation.onfinish = () => shape.setOrigin(0, 0);
-
-    return animation;
-  };
+  return AbstractScale<ScaleOutXOptions>(directionOut, transformX, options);
 };

--- a/src/animation/scaleOutY.ts
+++ b/src/animation/scaleOutY.ts
@@ -2,6 +2,7 @@ import { isTranspose } from '../utils/coordinate';
 import { Animation } from '../spec';
 import { AnimationComponent as AC } from '../runtime';
 import { effectTiming } from './utils';
+import { AbstractScale, transformY, directionOut } from './scaleInX';
 
 export type ScaleOutYOptions = Animation;
 
@@ -9,51 +10,5 @@ export type ScaleOutYOptions = Animation;
  * Scale mark from desired shape to nothing in y direction.
  */
 export const ScaleOutY: AC<ScaleOutYOptions> = (options) => {
-  // Small enough to hide or show very small part of mark,
-  // but bigger enough to not cause bug.
-  const ZERO = 0.0001;
-
-  return (shape, value, coordinate, defaults) => {
-    const { height } = shape.getBoundingClientRect();
-    const { transform: prefix } = shape.style;
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
-    const [transformOrigin, transform]: [[number, number], string] =
-      isTranspose(coordinate)
-        ? [[0, 0], `scale(${ZERO}, 1)`] // left-top corner
-        : [[0, height], `scale(1, ${ZERO})`]; // left-bottom corner
-
-    // Using a short fadeIn transition to hide element with scale(0.001)
-    // which is still visible.
-    const keyframes = [
-      {
-        transform: `${prefix} scale(1, 1)`.trimStart(),
-      },
-      {
-        transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
-        offset: 0.99,
-      },
-      {
-        transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: 0,
-        strokeOpacity: 0,
-        opacity: 0,
-      },
-    ];
-
-    // Change transform origin for correct transform.
-    shape.setOrigin(transformOrigin);
-
-    const animation = shape.animate(
-      keyframes,
-      effectTiming(defaults, value, options),
-    );
-
-    // Reset transform origin to eliminate side effect for following animations.
-    animation.onfinish = () => shape.setOrigin(0, 0);
-
-    return animation;
-  };
+  return AbstractScale<ScaleOutYOptions>(directionOut, transformY, options);
 };


### PR DESCRIPTION
- Abstract a _AbstractScale_ function for _ScaleInX_, _ScaleInY_, _ScaleOutX_, _ScaleOutY_.
- Use `shape.style.transformOrigin` instead of `shape.setOrigin`.