### PR TITLE
fix(area-shape): fix marker fillOpacity

### DIFF
--- a/src/geometry/shape/area/index.ts
+++ b/src/geometry/shape/area/index.ts
@@ -41,6 +41,7 @@ registerShape('area', 'area', {
       style: {
         r: 5,
         fill: color,
+        fillOpacity: 1,
       },
     };
   },

--- a/src/geometry/shape/area/smooth.ts
+++ b/src/geometry/shape/area/smooth.ts
@@ -28,6 +28,7 @@ registerShape('area', 'smooth', {
       style: {
         r: 5,
         fill: color,
+        fillOpacity: 1,
       },
     };
   },

--- a/tests/unit/geometry/shape/area-spec.ts
+++ b/tests/unit/geometry/shape/area-spec.ts
@@ -63,6 +63,7 @@ describe('Area shapes', () => {
     });
     expect(areaMarker.style.fill).toBe('red');
     expect(areaMarker.symbol).toBeFunction();
+    expect(areaMarker.style.fillOpacity).toBe(1);
 
     const lineMarker = AreaShapeFactory.getMarker('line', {
       color: 'red',
@@ -77,6 +78,7 @@ describe('Area shapes', () => {
     });
     expect(smoothMarker.style.fill).toBe('red');
     expect(smoothMarker.symbol).toBeFunction();
+    expect(areaMarker.style.fillOpacity).toBe(1);
 
     const smoothLineMarker = AreaShapeFactory.getMarker('smooth-line', {
       color: 'red',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [✅ ] `npm test` passes
- [ ✅] tests and/or benchmarks are included
- [✅ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->


before | after
-- | --
 <img width="884" alt="截屏2022-06-30 下午12 36 52" src="https://user-images.githubusercontent.com/20794675/176593815-00fc1fcc-efb9-4112-9126-72d3aa717f5b.png"> | <img width="652" alt="截屏2022-06-30 下午12 32 59" src="https://user-images.githubusercontent.com/20794675/176593374-78dec0aa-7672-410f-92b9-cee49509e65e.png">


area-area 和 area-smooth 这两种内置shape的默认getMarker没有初始的的fillOpacity值，导致使用了默认主题中areaFillOpacity=0.25的值
fixed https://github.com/antvis/G2/issues/3123
