### PR TITLE
fix(scale): 修复 scale 为分类字段 data 分类字段为数值  时 显示错误的问题

### DIFF
--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -1735,9 +1735,11 @@ export default class Geometry<S extends ShapePoint = ShapePoint> extends Base {
 
     const groupedArray = this.groupData(data); // 数据分组
     const beforeAdjust = [];
+    let dataArray = [];
     for (let i = 0, len = groupedArray.length; i < len; i++) {
       const subData = groupedArray[i];
       const arr = [];
+      const initArr = [];
       for (let j = 0, subLen = subData.length; j < subLen; j++) {
         const originData = subData[j];
         const item = {};
@@ -1746,7 +1748,7 @@ export default class Geometry<S extends ShapePoint = ShapePoint> extends Base {
           item[k] = originData[k];
         }
         item[FIELD_ORIGIN] = originData;
-
+        initArr.push({ ...item });
         // 将分类数据翻译成数据, 仅对位置相关的度量进行数字化处理
         for (const scale of categoryScales) {
           const field = scale.field;
@@ -1754,11 +1756,18 @@ export default class Geometry<S extends ShapePoint = ShapePoint> extends Base {
         }
         arr.push(item);
       }
+      dataArray.push(initArr);
       beforeAdjust.push(arr);
     }
+    // 【0，1，2 ] -> [0, 1, 2] | [0.25,0.5,0.75,...] 
+    // {1 => 0 , 2 => 1, 3 => 2 }
+    const afterAdjust = this.adjustData(beforeAdjust); // 进行 adjust 数据调整
 
-    const dataArray = this.adjustData(beforeAdjust); // 进行 adjust 数据调整
-    this.beforeMappingData = dataArray;
+    if (isEqual(afterAdjust, beforeAdjust)) {
+      this.beforeMappingData = dataArray;
+    } else {
+      this.beforeMappingData = afterAdjust;
+    }
 
     return dataArray;
   }

--- a/src/geometry/base.ts
+++ b/src/geometry/base.ts
@@ -1735,7 +1735,7 @@ export default class Geometry<S extends ShapePoint = ShapePoint> extends Base {
 
     const groupedArray = this.groupData(data); // 数据分组
     const beforeAdjust = [];
-    let dataArray = [];
+    const dataArray = [];
     for (let i = 0, len = groupedArray.length; i < len; i++) {
       const subData = groupedArray[i];
       const arr = [];

--- a/src/util/tooltip.ts
+++ b/src/util/tooltip.ts
@@ -39,7 +39,7 @@ function getXValueByPoint(point: Point, geometry: Geometry): number {
   if (coordinate.isPolar && xValue > (1 + rangeMax) / 2) {
     xValue = rangeMin; // 极坐标下，scale 的 range 被做过特殊处理
   }
-  return xScale.translate(xScale.invert(xValue));
+  return xScale.invert(xValue);
 }
 
 function filterYValue(data: Data, point: Point, geometry: Geometry) {

--- a/tests/unit/geometry/interval-spec.ts
+++ b/tests/unit/geometry/interval-spec.ts
@@ -74,9 +74,9 @@ describe('Interval', () => {
 
       dataArray = interval.beforeMappingData;
       expect(dataArray.length).toBe(3);
-      expect(dataArray[0][0].a).toBe(0);
-      expect(dataArray[1][0].a).toBe(1);
-      expect(dataArray[2][0].a).toBe(2);
+      expect(dataArray[0][0].a).toBe('A');
+      expect(dataArray[1][0].a).toBe('B');
+      expect(dataArray[2][0].a).toBe('C');
     });
 
     test('yScale min adjust', () => {


### PR DESCRIPTION
- **bug形成的原因**

主要为 antv/scale 中 Scale.scale 方法中有 translate 方法( 吧 'A' 'B' 分类字符 转化为 0 1 索引, 利用保存在 Map 中的 分类 {‘A’ => 0, 'b' => 1 }  )。 而在 g2 中 数据进行了一次 translate 方法。 g2 中一直错误使用 scale 对象。
例如：
1、字符串分类 g2 中进行 scale.translate :  [{ x: '2', y: 1 }, { x: '3', y: 1 }, { x: '4' , y: 1}] ->  [{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2 , y: 1}] 
g2 中 scale.scale 中再一次scale.translate : [{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2 , y: 1}] -> [{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2 , y: 1}] 
2、数值分类 g2 中进行 scale.translate :  [{ x: 2, y: 1 }, { x: 3, y: 1 }, { x: 4 , y: 1}] ->  [{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2 , y: 1}] 
g2 中 scale.scale 中再一次scale.translate : [{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2 , y: 1}] -> [{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: `0` , y: 1}] 
因为 Map 中查找不到 0 1 2 所以直接返回 0 1 2。 这个明显时错误,因为这个感觉像是利用了 错误返回 从而达成正确的效果而已。
并且有 Adjust 存在 需要 提前进行 translate 来运算 位置  
[{ x: 0, y: 1 }, { x: 1, y: 1 }, { x: 2 , y: 1}] -> [{ x: 0.25, y: 1 }, { x: 0.5, y: 1 }, { x: .75 , y: 1},...]  自主运算位置. 因为 scale 中依然返回
[{ x: 0.25, y: 1 }, { x: 0.5, y: 1 }, { x: .75 , y: 1},...] 。 
![image](https://user-images.githubusercontent.com/65594180/177295098-b6a20173-a10a-43c6-aa25-d5dd4d93faa1.png)

。所以不能直接 关闭 g2中的 scale.translate , 同时上层的数据也是不能更改。

- **scale 对象中的两个方法**

![image](https://user-images.githubusercontent.com/65594180/177292013-e025ee5c-f537-46df-a80c-0dbd97c188b8.png)

- **修改前后对比**

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/65594180/177291259-9ddef8da-6799-4f65-82a4-5e796f90a63e.png) | ![image](https://user-images.githubusercontent.com/65594180/177291285-03566289-65b6-47bb-a7c8-b915ae38627e.png) |



fixed #3837 
fixed https://github.com/antvis/G2Plot/issues/3182
fixed https://github.com/antvis/G2Plot/issues/3135