### PR TITLE
fix(pie): 修复扇形 变化时 角度按照反方向变化的问题

### DIFF
--- a/src/animate/animation/sector-path-update.ts
+++ b/src/animate/animation/sector-path-update.ts
@@ -8,7 +8,7 @@ import { AnimateExtraCfg } from '../interface';
 import { getArcPath, getSectorPath } from '../../util/graphics';
 
 function getAngle(startPoint: number[], arcPath: PathCommand) {
-  let { startAngle, endAngle, arcFlag } = getArcParams(startPoint, arcPath);
+  let { startAngle, endAngle } = getArcParams(startPoint, arcPath);
 
   if (!isNumberEqual(startAngle, -Math.PI * 0.5) && startAngle < -Math.PI * 0.5) {
     startAngle += Math.PI * 2;
@@ -26,7 +26,8 @@ function getAngle(startPoint: number[], arcPath: PathCommand) {
     startAngle = Math.PI * -0.5;
   }
 
-  if (isNumberEqual(endAngle, Math.PI * -0.5) && arcFlag) {
+  // 当 startAngle, endAngle 接近相等时，不进行 endAngle = Math.PI * 1.5 防止变化从整个圆开始
+  if (isNumberEqual(endAngle, Math.PI * -0.5) && !isNumberEqual(startAngle, endAngle)) {
     endAngle = Math.PI * 1.5;
   }
 


### PR DESCRIPTION




- [x] 原先的 arcFlag 用 !isNumberEqual(startAngle, endAngle) 代替


| 不正确变化 | 正常变化 |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/65594180/177514679-85346fa3-03e6-41a2-989c-11f50ff7004c.png)| ![image](https://user-images.githubusercontent.com/65594180/177515339-0d138490-f28f-4da6-af8b-2b750e1c7f50.png)|