### PR TITLE
feat(interaction): implement draggable and resizable mask

### DIFF
--- a/__tests__/unit/interaction/index.spec.ts
+++ b/__tests__/unit/interaction/index.spec.ts
@@ -10,7 +10,7 @@ describe('interaction', () => {
         {
           trigger: 'hover',
           action: [
-            { type: 'surfacePointSelection' },
+            { type: 'elementSelection' },
             { type: 'activeElement', color: 'red' },
           ],
         },
@@ -19,7 +19,7 @@ describe('interaction', () => {
         {
           trigger: 'leave',
           action: [
-            { type: 'surfacePointSelection' },
+            { type: 'elementSelection' },
             { type: 'activeElement', color: 'red' },
           ],
         },

--- a/__tests__/unit/interaction/stdlib.spec.ts
+++ b/__tests__/unit/interaction/stdlib.spec.ts
@@ -18,6 +18,8 @@ import {
   RecordRegion,
   RecordState,
   Cursor as CursorAction,
+  RecordCurrentPoint,
+  Move,
 } from '../../../src/interaction/action';
 import {
   MousePosition,
@@ -31,6 +33,7 @@ describe('createInteractionLibrary', () => {
       'action.elementSelection': ElementSelection,
       'action.recordState': RecordState,
       'action.recordPoint': RecordPoint,
+      'action.recordCurrentPoint': RecordCurrentPoint,
       'action.recordRegion': RecordRegion,
       'action.activeElement': ActiveElement,
       'action.highlightElement': HighlightElement,
@@ -45,6 +48,7 @@ describe('createInteractionLibrary', () => {
       'action.cursor': CursorAction,
       'action.mask': Mask,
       'action.button': Button,
+      'action.move': Move,
       'interactor.mousePosition': MousePosition,
       'interactor.touchPosition': TouchPosition,
     });

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@antv/coord": "^0.4.1",
     "@antv/g": "^5.0.20",
     "@antv/g-canvas": "^1.0.13",
+    "@antv/g-plugin-dragndrop": "^1.5.1",
     "@antv/gui": "^0.4.3-alpha.5",
     "@antv/scale": "^0.4.7",
     "@antv/util": "^2.0.17",

--- a/src/interaction/action/index.ts
+++ b/src/interaction/action/index.ts
@@ -16,6 +16,10 @@ export {
 } from './service/legendItemSelection';
 export { RecordState, RecordStateOptions } from './service/recordState';
 export { RecordPoint, RecordPointOptions } from './service/recordPoint';
+export {
+  RecordCurrentPoint,
+  RecordCurrentPointOptions,
+} from './service/recordCurrentPoint';
 export { RecordRegion, RecordRegionOptions } from './service/recordRegion';
 export {
   ActiveElement,
@@ -37,3 +41,4 @@ export { FisheyeFocus, FisheyeFocusOptions } from './service/fisheyeFocus';
 export { Cursor, CursorOptions } from './transformer/cursor';
 export { Mask, MaskOptions } from './transformer/mask';
 export { Button, ButtonOptions } from './transformer/button';
+export { Move, MoveOptions } from './transformer/move';

--- a/src/interaction/action/service/elementSelection.ts
+++ b/src/interaction/action/service/elementSelection.ts
@@ -68,7 +68,7 @@ export const ElementSelection: AC<ElementSelectionOptions> = (options) => {
       selectedElements = elements.filter((element) => {
         return masks.some(({ __data__: { points } }) => {
           const { min, max } = element.getLocalBounds();
-          const polygon = [[min], [min[0], max[1]], [max], [max[0], min[1]]];
+          const polygon = [min, [min[0], max[1]], max, [max[0], min[1]]];
           return isPolygonsIntersect(points, polygon);
         });
       });

--- a/src/interaction/action/service/recordCurrentPoint.ts
+++ b/src/interaction/action/service/recordCurrentPoint.ts
@@ -1,0 +1,22 @@
+import { ActionComponent as AC } from '../../types';
+import { RecordCurrentPointAction } from '../../../spec';
+
+export type RecordCurrentPointOptions = Omit<RecordCurrentPointAction, 'type'>;
+
+export const RecordCurrentPoint: AC<RecordCurrentPointOptions> = (options) => {
+  const { clear } = options;
+  return (context) => {
+    const { shared, event } = context;
+    const { offsetX, offsetY } = event;
+
+    if (clear) {
+      shared.currentPoint = null;
+    } else {
+      shared.currentPoint = [offsetX, offsetY];
+    }
+
+    return context;
+  };
+};
+
+RecordCurrentPoint.props = {};

--- a/src/interaction/action/transformer/cursor.ts
+++ b/src/interaction/action/transformer/cursor.ts
@@ -6,12 +6,13 @@ export type CursorOptions = Omit<CursorAction, 'type'>;
 export const Cursor: AC<CursorOptions> = (options) => {
   const { cursor } = options;
   return (context) => {
-    const { selection } = context;
+    const { selection, event } = context;
+    const { target } = event;
 
     // @ts-ignore
     const canvas = selection.node().getRootNode().defaultView;
     const dom = canvas.getContextService().getDomElement();
-    dom.style.cursor = cursor;
+    dom.style.cursor = cursor || target.style?.cursor;
 
     return context;
   };

--- a/src/interaction/action/transformer/mask.ts
+++ b/src/interaction/action/transformer/mask.ts
@@ -55,7 +55,6 @@ export const Mask: AC<MaskOptions> = (options) => {
       lineWidth: 0.5,
       points,
       cursor: 'move',
-      type: 'selection',
       index,
     }));
 

--- a/src/interaction/action/transformer/mask.ts
+++ b/src/interaction/action/transformer/mask.ts
@@ -1,14 +1,43 @@
 import { path as d3path } from 'd3-path';
-import { Path, CustomEvent } from '@antv/g';
+import { CustomEvent, Path, Rect } from '@antv/g';
 import { appendPolygon } from '../../../shape/utils';
 import { ActionComponent as AC } from '../../types';
 import { MaskAction } from '../../../spec';
 
 export type MaskOptions = Omit<MaskAction, 'type'>;
 
+function getPointsBy(regions) {
+  return regions.map((region) => {
+    const { x1, y1, x2, y2 } = region;
+    return [
+      [x1, y1],
+      [x2, y1],
+      [x2, y2],
+      [x1, y2],
+    ];
+  });
+}
+
+const cursors = {
+  n: 'ns-resize',
+  e: 'ew-resize',
+  s: 'ns-resize',
+  w: 'ew-resize',
+  nw: 'nwse-resize',
+  se: 'nwse-resize',
+  ne: 'nesw-resize',
+  sw: 'nesw-resize',
+};
+
+function getHandleDirections(maskType: string) {
+  if (maskType === 'polygon') return [];
+  if (maskType === 'rectX') return ['w', 'e'];
+  if (maskType === 'rectY') return ['n', 's'];
+  return ['n', 'e', 's', 'w', 'ne', 'se', 'sw', 'nw'];
+}
+
 /**
  * @todo add mask resize handler
- * @todo add mask movable
  */
 export const Mask: AC<MaskOptions> = (options) => {
   const { maskType, fill = '#C5D4EB', fillOpacity = 0.3 } = options;
@@ -16,26 +45,19 @@ export const Mask: AC<MaskOptions> = (options) => {
     const { shared, transientLayer } = context;
     const { regions = [], points = [] } = shared;
 
-    const P =
-      maskType === 'polygon'
-        ? points
-        : regions.map((region) => {
-            const { x1, y1, x2, y2 } = region;
-            return [
-              [x1, y1],
-              [x2, y1],
-              [x2, y2],
-              [x1, y2],
-            ];
-          });
-    const data = P.map((points) => {
-      return {
-        d: appendPolygon(d3path(), points).toString(),
-        fill,
-        fillOpacity,
-        points,
-      };
-    });
+    const P = maskType === 'polygon' ? points : getPointsBy(regions);
+    const data = P.map((points, index) => ({
+      draggable: true,
+      d: appendPolygon(d3path(), points).toString(),
+      fill,
+      fillOpacity,
+      stroke: fill,
+      lineWidth: 0.5,
+      points,
+      cursor: 'move',
+      type: 'selection',
+      index,
+    }));
 
     transientLayer
       .selectAll('.mask')
@@ -47,6 +69,42 @@ export const Mask: AC<MaskOptions> = (options) => {
           update.each(function (datum) {
             this.attr(datum);
             this.dispatchEvent(new CustomEvent('maskChange'));
+          }),
+        (exit) => exit.remove(),
+      );
+
+    const handleSize = 6;
+    const directions = getHandleDirections(maskType);
+    const handles = regions
+      .map((region, index) => {
+        const { x1, y1, x2, y2 } = region;
+        return directions.map((d) => {
+          return {
+            draggable: true,
+            x: d.includes('e') ? x2 - handleSize / 2 : x1 - handleSize / 2,
+            y: d.includes('s') ? y2 - handleSize / 2 : y1 - handleSize / 2,
+            width: d === 'n' || d === 's' ? x2 - x1 + handleSize : handleSize,
+            height: d === 'e' || d === 'w' ? y2 - y1 + handleSize : handleSize,
+            className: `handle handle-${d}`,
+            fill: 'transparent',
+            type: d,
+            cursor: cursors[d],
+            index,
+          };
+        });
+      })
+      .flat();
+    transientLayer
+      .selectAll('.handle')
+      .data(handles, (_, i) => i)
+      .join(
+        (enter) =>
+          enter.append(
+            ({ className, ...style }) => new Rect({ className, style }),
+          ),
+        (update) =>
+          update.each(function (datum) {
+            this.attr(datum);
           }),
         (exit) => exit.remove(),
       );

--- a/src/interaction/action/transformer/move.ts
+++ b/src/interaction/action/transformer/move.ts
@@ -1,0 +1,76 @@
+import { head, last } from '@antv/util';
+import { ActionComponent as AC } from '../../types';
+import { MoveAction } from '../../../spec';
+
+export type MoveOptions = Omit<MoveAction, 'type'>;
+
+const signsX = {
+  selection: +1,
+  n: 0,
+  e: +1,
+  s: 0,
+  w: -1,
+  nw: -1,
+  ne: +1,
+  se: +1,
+  sw: -1,
+};
+
+const signsY = {
+  selection: +1,
+  n: -1,
+  e: 0,
+  s: +1,
+  w: 0,
+  nw: -1,
+  ne: -1,
+  se: +1,
+  sw: +1,
+};
+
+/**
+ * @todo support move view. Now is only support mask, which is related with shared.points.
+ */
+export const Move: AC<MoveOptions> = () => {
+  return (context) => {
+    const { shared, event } = context;
+    const { target, offsetX, offsetY } = event;
+    const [mouseX = offsetX, mouseY = offsetY] = shared.currentPoint || [];
+
+    if (target) {
+      const shiftX = offsetX - mouseX;
+      const shiftY = offsetY - mouseY;
+
+      const { index } = target.style;
+      if (shared.points[index]?.length >= 2 && index >= 0) {
+        const points = shared.points[index];
+
+        if (target.className.includes('handle')) {
+          const { type } = target.style;
+          const signX = signsX[type];
+          const signY = signsY[type];
+
+          let [x1, y1] = head(points);
+          let [x2, y2] = last(points);
+          if (signX < 0) x2 = Math.max((x1 += shiftX), x2);
+          if (signX > 0) x1 = Math.min(x1, (x2 += shiftX));
+          if (signY < 0) y2 = Math.max((y1 += shiftY), y2);
+          if (signY > 0) y1 = Math.min(y1, (y2 += shiftY));
+          shared.points[index] = [
+            [x1, y1],
+            [x2, y2],
+          ];
+        } else {
+          shared.points[index] = points.map(([x, y]) => [
+            x + shiftX,
+            y + shiftY,
+          ]);
+        }
+      }
+    }
+
+    return context;
+  };
+};
+
+Move.props = {};

--- a/src/interaction/builtin/brush.ts
+++ b/src/interaction/builtin/brush.ts
@@ -11,7 +11,7 @@ function isButton(context) {
 
 export const InteractionDescriptor = (options?: BrushOptions) => {
   const { brushType } = options;
-  const maskType = brushType === 'polygon' ? 'polygon' : 'rect';
+  const maskPrefix = brushType === 'polygon' ? 'polygon' : 'rect';
   const dim = brushType === 'rectX' ? 'x' : brushType === 'rectY' ? 'y' : '';
   return {
     start: [
@@ -47,13 +47,13 @@ export const InteractionDescriptor = (options?: BrushOptions) => {
         action: [
           { type: 'recordPoint' },
           { type: 'recordRegion', dim },
-          { type: 'mask', maskType },
+          { type: 'mask', maskType: brushType },
         ],
       },
       {
         trigger: 'plot:maskChange',
         action: [
-          { type: 'elementSelection', from: `${maskType}-mask` },
+          { type: 'elementSelection', from: `${maskPrefix}-mask` },
           { type: 'highlightElement' },
         ],
       },
@@ -62,14 +62,14 @@ export const InteractionDescriptor = (options?: BrushOptions) => {
         isEnable: (context) => !isButton(context),
         action: [
           { type: 'recordState', state: null },
-          { type: 'elementSelection', from: `${maskType}-mask` },
+          { type: 'elementSelection', from: `${maskPrefix}-mask` },
           { type: 'filter' },
           { type: 'plot' },
           { type: 'recordState', state: 'filtered' },
           { type: 'recordPoint', clear: true },
           { type: 'recordRegion' },
           { type: 'mask' },
-          { type: 'elementSelection', from: `${maskType}-mask` },
+          { type: 'elementSelection', from: `${maskPrefix}-mask` },
           { type: 'highlightElement' },
           { type: 'button' },
         ],

--- a/src/interaction/builtin/brushHighlight.ts
+++ b/src/interaction/builtin/brushHighlight.ts
@@ -3,18 +3,45 @@ import { createInteraction } from '../create';
 
 export type BrushHighlightOptions = Omit<BrushHighlightInteraction, 'type'>;
 
+function isMask(context) {
+  const { event } = context;
+  const { target } = event;
+  return target && target.className?.includes('mask');
+}
+
+function isHandle(context) {
+  const { event } = context;
+  const { target } = event;
+  return target && target.className?.includes('handle');
+}
+
+function isInPlot(context) {
+  return !isMask(context) && !isHandle(context);
+}
+
+function dragEnable(context) {
+  return isMask(context) || isHandle(context);
+}
+
 export const InteractionDescriptor = (options?: BrushHighlightOptions) => {
   const { brushType } = options;
-  const maskType = brushType === 'polygon' ? 'polygon' : 'rect';
+  const maskPrefix = brushType === 'polygon' ? 'polygon' : 'rect';
   const dim = brushType === 'rectX' ? 'x' : brushType === 'rectY' ? 'y' : '';
   return {
     start: [
       {
-        trigger: 'plot:pointerenter',
+        trigger: 'plot:pointermove',
+        isEnable: (context) => isInPlot(context),
         action: [{ type: 'cursor', cursor: 'crosshair' }],
       },
       {
+        trigger: 'plot:pointermove',
+        isEnable: (context) => !isInPlot(context),
+        action: [{ type: 'cursor' }],
+      },
+      {
         trigger: 'plot:pointerdown',
+        isEnable: (context) => isInPlot(context),
         action: [
           { type: 'recordPoint', clear: true },
           { type: 'recordPoint', start: true },
@@ -24,23 +51,47 @@ export const InteractionDescriptor = (options?: BrushHighlightOptions) => {
       },
       {
         trigger: 'plot:pointermove',
-        isEnable: (context) => context.shared.currentState === 'brushing',
+        isEnable: (context) =>
+          context.shared.currentState === 'brushing' && !isMask(context),
         action: [
           { type: 'recordPoint' },
           { type: 'recordRegion', dim },
-          { type: 'mask', maskType },
+          { type: 'mask', maskType: brushType },
         ],
       },
       {
         trigger: 'plot:maskChange',
         action: [
-          { type: 'elementSelection', from: `${maskType}-mask` },
+          { type: 'elementSelection', from: `${maskPrefix}-mask` },
           { type: 'highlightElement' },
         ],
       },
       {
         trigger: 'plot:pointerup',
+        isEnable: (context) => context.shared.currentState === 'brushing',
         action: [{ type: 'recordState', state: null }],
+      },
+      // Drag mask.
+      {
+        trigger: 'plot:dragstart',
+        isEnable: (context) => dragEnable(context),
+        action: [{ type: 'recordCurrentPoint' }],
+      },
+      {
+        trigger: 'plot:drag',
+        isEnable: (context) =>
+          dragEnable(context) && context.shared.currentPoint,
+        action: [
+          { type: 'move' },
+          { type: 'recordRegion', dim },
+          { type: 'mask', maskType: brushType },
+          { type: 'recordCurrentPoint' },
+        ],
+      },
+      {
+        trigger: 'plot:dragend',
+        isEnable: (context) => dragEnable(context),
+        action: [{ type: 'recordCurrentPoint', clear: true }],
       },
     ],
     end: [
@@ -51,12 +102,12 @@ export const InteractionDescriptor = (options?: BrushHighlightOptions) => {
       {
         trigger: 'plot:click',
         // dblclick. https://g-next.antv.vision/zh/docs/api/event
-        isEnable: (context) => context.event.detail === 2,
+        isEnable: (context) => context.event.detail === 2 && !isMask(context),
         action: [
           { type: 'recordPoint', clear: true },
           { type: 'recordRegion' },
           { type: 'mask' },
-          { type: 'elementSelection', from: `${maskType}-mask` },
+          { type: 'elementSelection', from: `${maskPrefix}-mask` },
           { type: 'highlightElement' },
         ],
       },

--- a/src/interaction/builtin/brushVisible.ts
+++ b/src/interaction/builtin/brushVisible.ts
@@ -5,7 +5,7 @@ export type BrushVisibleOptions = Omit<BrushVisibleInteraction, 'type'>;
 
 export const InteractionDescriptor = (options?: BrushVisibleOptions) => {
   const { brushType } = options;
-  const maskType = brushType === 'polygon' ? 'polygon' : 'rect';
+  const maskPrefix = brushType === 'polygon' ? 'polygon' : 'rect';
   const dim = brushType === 'rectX' ? 'x' : brushType === 'rectY' ? 'y' : '';
   return {
     start: [
@@ -28,13 +28,13 @@ export const InteractionDescriptor = (options?: BrushVisibleOptions) => {
         action: [
           { type: 'recordPoint' },
           { type: 'recordRegion', dim },
-          { type: 'mask', maskType },
+          { type: 'mask', maskType: brushType },
         ],
       },
       {
         trigger: 'plot:maskChange',
         action: [
-          { type: 'elementSelection', from: `${maskType}-mask` },
+          { type: 'elementSelection', from: `${maskPrefix}-mask` },
           { type: 'highlightElement' },
         ],
       },
@@ -42,7 +42,7 @@ export const InteractionDescriptor = (options?: BrushVisibleOptions) => {
         trigger: 'plot:pointerup',
         action: [
           { type: 'recordState', state: null },
-          { type: 'elementSelection', from: `${maskType}-mask` },
+          { type: 'elementSelection', from: `${maskPrefix}-mask` },
           { type: 'filterElement' },
           // Clear highlight elements, but not to effect elements of mainLayer.
           { type: 'highlightElement', clear: true },

--- a/src/interaction/builtin/elementActive.ts
+++ b/src/interaction/builtin/elementActive.ts
@@ -9,7 +9,7 @@ export const InteractionDescriptor = (options?: ElementActiveOptions) => ({
     {
       trigger: 'hover',
       action: [
-        { type: 'surfacePointSelection' },
+        { type: 'elementSelection' },
         { type: 'activeElement', ...options },
       ],
     },
@@ -18,7 +18,7 @@ export const InteractionDescriptor = (options?: ElementActiveOptions) => ({
     {
       trigger: 'leave',
       action: [
-        { type: 'surfacePointSelection' },
+        { type: 'elementSelection' },
         { type: 'activeElement', ...options },
       ],
     },

--- a/src/interaction/stdlib.ts
+++ b/src/interaction/stdlib.ts
@@ -11,12 +11,14 @@ import {
   SetItemState as SetItemStateAction,
   RecordState,
   RecordPoint,
+  RecordCurrentPoint,
   RecordRegion,
   Cursor as CursorAction,
   Plot,
   Filter,
   Mask,
   Button,
+  Move,
 } from './action';
 import { MousePosition, TouchPosition } from './interactor';
 import { InteractionLibrary } from './types';
@@ -27,6 +29,7 @@ export function createInteractionLibrary(): InteractionLibrary {
     'action.elementSelection': ElementSelection,
     'action.recordState': RecordState,
     'action.recordPoint': RecordPoint,
+    'action.recordCurrentPoint': RecordCurrentPoint,
     'action.recordRegion': RecordRegion,
     'action.activeElement': ActiveElement,
     'action.highlightElement': HighlightElement,
@@ -41,6 +44,7 @@ export function createInteractionLibrary(): InteractionLibrary {
     'action.cursor': CursorAction,
     'action.mask': Mask,
     'action.button': Button,
+    'action.move': Move,
     'interactor.mousePosition': MousePosition,
     'interactor.touchPosition': TouchPosition,
   };

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -1,5 +1,6 @@
 import { Canvas as GCanvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
+import { Plugin as DragAndDropPlugin } from '@antv/g-plugin-dragndrop';
 import { RendererComponent as RC } from '../runtime';
 
 export type CanvasOptions = {
@@ -12,11 +13,14 @@ export type CanvasOptions = {
  * Returns a canvas renderer.
  */
 export const Canvas: RC<CanvasOptions> = ({ width, height, container }) => {
+  const renderer = new CanvasRenderer();
+  renderer.registerPlugin(new DragAndDropPlugin());
+
   return new GCanvas({
     container,
     width,
     height,
-    renderer: new CanvasRenderer(),
+    renderer,
   });
 };
 

--- a/src/runtime/types/component.ts
+++ b/src/runtime/types/component.ts
@@ -21,7 +21,6 @@ export type G2ComponentNamespaces =
   | 'mark'
   | 'infer'
   | 'palette'
-  | 'renderer'
   | 'scale'
   | 'shape'
   | 'statistic'

--- a/src/spec/action.ts
+++ b/src/spec/action.ts
@@ -15,10 +15,13 @@ export type Action =
   | FilterAction
   | CursorAction
   | TooltipAction
+  | RecordPointAction
+  | RecordCurrentPointAction
   | RecordStateAction
   | RecordRegionAction
   | MaskAction
-  | ButtonAction;
+  | ButtonAction
+  | MoveAction;
 
 export type ActionTypes =
   | 'fisheyeFocus'
@@ -36,9 +39,11 @@ export type ActionTypes =
   | 'tooltip'
   | 'recordState'
   | 'recordPoint'
+  | 'recordCurrentPoint'
   | 'recordRegion'
   | 'mask'
   | 'button'
+  | 'move'
   | CustomAction;
 
 export type FisheyeFocusAction = {
@@ -118,6 +123,11 @@ export type RecordStateAction = {
   state?: string;
 };
 
+export type RecordCurrentPointAction = {
+  type?: 'recordCurrentPoint';
+  clear?: boolean;
+};
+
 export type RecordPointAction = {
   type?: 'recordPoint';
   clear?: boolean;
@@ -131,7 +141,7 @@ export type RecordRegionAction = {
 
 export type MaskAction = {
   type?: 'mask';
-  maskType?: 'rect' | 'polygon';
+  maskType?: 'rect' | 'rectX' | 'rectY' | 'polygon';
   fill?: string;
   fillOpacity?: number;
 };
@@ -148,6 +158,10 @@ export type ButtonAction = {
   stroke?: string;
   padding?: number[];
   hide?: boolean;
+};
+
+export type MoveAction = {
+  type?: 'move';
 };
 
 export type CustomAction = {


### PR DESCRIPTION
### Description

- **feat(interaction):** support brush mask draggable and resizable.
- **feat(action):** add `recordCurrentPoint` service ([Docs]( https://www.yuque.com/antv/g2-docs/interaction-plan#OZhO1)) and `move` transformer（[Docs](https://www.yuque.com/antv/g2-docs/interaction-plan#Fq6sy)）
- **update(action):** update `cursor` transformer to use the cursor style of target when cursor option is null.
- **update(interaction):** update `brushHighlight` interactionDescriptor 
- **fix(action):** elementSelection error pickup selectedElements when from is `polygon-mask`

```ts
 const InteractionDescriptor = (options?: BrushHighlightOptions) => {
  const { brushType } = options;
  const maskPrefix = brushType === 'polygon' ? 'polygon' : 'rect';
  const dim = brushType === 'rectX' ? 'x' : brushType === 'rectY' ? 'y' : '';
  return {
    start: [
      {
        trigger: 'plot:pointermove',
        isEnable: (context) => isInPlot(context),
       // 鼠标在 plot 上时， cursor is `crosshair`
        action: [{ type: 'cursor', cursor: 'crosshair' }],
      },
      {
        trigger: 'plot:pointermove',
        isEnable: (context) => !isInPlot(context),
       // 鼠标不在 plot 上时， cursor follow with target.
        action: [{ type: 'cursor' }],
      },
      {
        trigger: 'plot:pointerdown',
        isEnable: (context) => isInPlot(context),
        action: [
          { type: 'recordPoint', clear: true },
          { type: 'recordPoint', start: true },
          { type: 'recordRegion', dim },
          { type: 'recordState', state: 'brushing' },
        ],
      },
      {
        trigger: 'plot:pointermove',
        isEnable: (context) =>
          context.shared.currentState === 'brushing' && !isMask(context),
        action: [
          { type: 'recordPoint' },
          { type: 'recordRegion', dim },
          { type: 'mask', maskType: brushType },
        ],
      },
      {
        trigger: 'plot:maskChange',
        action: [
          { type: 'elementSelection', from: `${maskPrefix}-mask` },
          { type: 'highlightElement' },
        ],
      },
      {
        trigger: 'plot:pointerup',
        isEnable: (context) => context.shared.currentState === 'brushing',
        action: [{ type: 'recordState', state: null }],
      },
      // Drag mask. 增加 drag 交互
      {
        trigger: 'plot:dragstart',
        isEnable: (context) => dragEnable(context),
        action: [{ type: 'recordCurrentPoint' }],
      },
      {
        trigger: 'plot:drag',
        isEnable: (context) =>
          dragEnable(context) && context.shared.currentPoint,
        action: [
          { type: 'move' },
          { type: 'recordRegion', dim },
          { type: 'mask', maskType: brushType },
          { type: 'recordCurrentPoint' },
        ],
      },
      {
        trigger: 'plot:dragend',
        isEnable: (context) => dragEnable(context),
        action: [{ type: 'recordCurrentPoint', clear: true }],
      },
    ],
    end: [
      {
        trigger: 'plot:pointerleave',
        action: [{ type: 'cursor', cursor: 'default' }],
      },
      {
        trigger: 'plot:click',
        // 鼠标在 mask 上时， 双击不取消 brush 圈选
        isEnable: (context) => context.event.detail === 2 && !isMask(context),
        action: [
          { type: 'recordPoint', clear: true },
          { type: 'recordRegion' },
          { type: 'mask' },
          { type: 'elementSelection', from: `${maskPrefix}-mask` },
          { type: 'highlightElement' },
        ],
      },
    ],
  };
};
```

### Demo

#### Basic brushHighlight

![draggable-resizable-brush](https://user-images.githubusercontent.com/15646325/178892716-901936c8-97c1-4ebc-9f12-0f0680a4aa60.gif)

#### BrushHighlight with polygon mask

![brushHighlight-with-polygonMask](https://user-images.githubusercontent.com/15646325/178892947-4cf4b2b3-97a6-48a1-b4ff-82dc7a120cd9.gif)

