### PR TITLE
fix(active-region): Fix type error when importing on demand

### DIFF
--- a/src/interaction/action/active-region.ts
+++ b/src/interaction/action/active-region.ts
@@ -1,5 +1,5 @@
 import { each, head, isEqual, last, get, flatten, isArray, uniq, isNil } from '@antv/util';
-import { View } from 'src/chart';
+import View from '../../chart/view';
 import { findItemsFromViewRecurisive } from '../../util/tooltip';
 import { IShape, Point, ShapeAttrs } from '../../dependents';
 import Element from '../../geometry/element';


### PR DESCRIPTION
Need: 
使用以下代码按需引入
```javascript
import ActiveRegion from '@antv/g2/lib/interaction/action/active-region'
```
Updating Reason: 
上述代码tsc编译会报错，原因是用户环境直接引入该文件，无法识别src/chart的路径。所以这里更改了引入的路径
Related Testing: 
只修改了模块的引入路径，不涉及到功能的调整，暂无测试用例
