### PR TITLE
feat(component): display axis in polar or transpose coordinate by default

### DIFF
--- a/__tests__/unit/runtime/line.spec.ts
+++ b/__tests__/unit/runtime/line.spec.ts
@@ -293,7 +293,7 @@ describe('line', () => {
         { item: 'UX', user: 'b', score: 60 },
       ],
       coordinate: [{ type: 'polar' }],
-      scale: { y: { zero: true } },
+      scale: { x: { padding: 0.5, align: 0 }, y: { zero: true } },
       encode: {
         x: 'item',
         y: 'score',

--- a/docs/interval.md
+++ b/docs/interval.md
@@ -124,6 +124,10 @@ G2.render({
     { genre: 'Other', sold: 150 },
   ],
   coordinate: [{ type: 'transpose' }, { type: 'polar' }],
+  scale: {
+    y: { guide: { type: 'axisY' }},
+    color: { guide: { position: 'right', size: 65 }},
+  },
   encode: {
     x: 'genre',
     y: 'sold',

--- a/docs/interval.md
+++ b/docs/interval.md
@@ -68,6 +68,7 @@ G2.render({
 
 ```js | dom
 G2.render({
+  paddingLeft: 70,
   type: 'interval',
   data: [
     { genre: 'Sports', sold: 275 },

--- a/docs/line.md
+++ b/docs/line.md
@@ -356,7 +356,7 @@ G2.render({
   coordinate: [{ type: 'polar' }],
   scale: {
     y: { domain: [0, 80] },
-    x: { padding: 0.5, align: 0, guide: { type: 'axisX' } },
+    x: { padding: 0.5, align: 0 },
     color: { guide: { title: null } },
   },
   children: [

--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -31,6 +31,9 @@ function inferPosition(
   verticalFactor: 1 | -1;
   titleOffsetY?: number;
   labelAlign?: 'start' | 'end' | 'center' | 'left' | 'right';
+  label?: boolean;
+  axisLine?: boolean;
+  tickLine?: boolean;
 } {
   const { x, y, width, height } = bbox;
   if (position === 'bottom') {
@@ -72,11 +75,14 @@ function inferPosition(
       startPos: [cx + bbox.x, cy + bbox.y - radius],
       endPos: [cx + bbox.x, cy + bbox.y],
       titlePosition: 'start',
-      titlePadding: -16,
+      titlePadding: -20,
       titleOffsetY: -8,
-      titleRotate: 0,
+      titleRotate: -90,
       labelOffset: 4,
       verticalFactor: -1,
+      label: false,
+      axisLine: true,
+      tickLine: false,
     };
   }
   return {
@@ -137,7 +143,7 @@ function getTicks(
   const ticks = scale.getTicks?.() || domain;
   const formatter = scale.getFormatter?.() || defaultFormatter;
 
-  if (isPolar(coordinate)) {
+  if (isPolar(coordinate) || isTranspose(coordinate)) {
     const axisTicks = ticks.map((d) => {
       const offset = scale.getBandWidth?.(d) / 2 || 0;
       const tick = scale.map(d) + offset;
@@ -188,7 +194,7 @@ const ArcAxis = (options) => {
           },
           tickLine: {
             len: 4,
-            style: { lineWidth: 1 },
+            style: { lineWidth: 1, stroke: '#BFBFBF' },
           },
           label: {
             align: 'tangential',
@@ -223,6 +229,9 @@ export const Axis: GCC<AxisOptions> = (options) => {
       titleRotate,
       verticalFactor,
       titleOffsetY,
+      label = true,
+      axisLine,
+      tickLine = true,
     } = inferPosition(position, bbox, coordinate);
     const ticks = getTicks(scale, domain, formatter, position, coordinate);
     return new Linear({
@@ -232,21 +241,20 @@ export const Axis: GCC<AxisOptions> = (options) => {
           endPos,
           verticalFactor,
           ticks,
-          label: {
-            tickPadding: labelOffset,
-            autoHide: false,
-            style: {},
-          },
-          axisLine: {
-            style: {
-              lineWidth: 0,
-              strokeOpacity: 0,
-            },
-          },
-          tickLine: {
-            len: 4,
-            style: { lineWidth: 1 },
-          },
+          label: label
+            ? {
+                tickPadding: labelOffset,
+                autoHide: false,
+                style: {},
+              }
+            : null,
+          axisLine: axisLine ? { stroke: '#BFBFBF' } : null,
+          tickLine: tickLine
+            ? {
+                len: 4,
+                style: { lineWidth: 1, stroke: '#BFBFBF' },
+              }
+            : null,
           ...(field &&
             title && {
               title: {

--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -198,7 +198,7 @@ const ArcAxis = (options) => {
           },
           label: {
             align: 'tangential',
-            style: { dy: -2 },
+            tickPadding: 2,
           },
         },
         scale.getOptions().guide,

--- a/src/runtime/component.ts
+++ b/src/runtime/component.ts
@@ -106,7 +106,7 @@ export function renderComponent(
   return render(scale, value, coordinate, theme);
 }
 
-// @todo Render components in non-cartesian coordinate.
+// @todo Render axis in polar with parallel coordinate.
 // @todo Infer legend for shape.
 function inferComponentType(
   scale: G2ScaleOptions,
@@ -125,11 +125,10 @@ function inferComponentType(
         return null;
     }
   }
-  if (isTranspose(coordinates)) return null;
-  if (isPolar(coordinates)) return null;
-  if (name.startsWith('x')) return 'axisX';
-  if (name.startsWith('y')) return 'axisY';
-  if (name.startsWith('position')) return 'axisY';
+  if (isTranspose(coordinates) && isPolar(coordinates)) return null;
+  if (name.startsWith('x')) return isTranspose(coordinates) ? 'axisY' : 'axisX';
+  if (name.startsWith('y')) return isTranspose(coordinates) ? 'axisX' : 'axisY';
+  if (name.startsWith('position') && !isPolar(coordinates)) return 'axisY';
   return null;
 }
 


### PR DESCRIPTION
1. **Changes:** Display axis in polar or transpose coordinate by default.
2. **Marks:** Polar, transpose, and parallel coordinates do not adapt fisheye yet.

#### Axis in Polar Coordinate
<img width="539" alt="image" src="https://user-images.githubusercontent.com/15646325/179867396-72c3cca8-3c99-42b4-840a-94807c3cb665.png">

#### Axis in Transpose Coordinate
<img width="634" alt="image" src="https://user-images.githubusercontent.com/15646325/179867424-52f6bf39-bc41-44b5-8a21-4deef5018965.png">

#### Polar and transpose Coordinate
> should specify guide type

```ts
{
   scale: { y: { guide: { type: 'axisY' } } }
}
```
<img width="599" alt="image" src="https://user-images.githubusercontent.com/15646325/179887135-6afe5c1d-d8a0-4393-9f62-2db9132718a4.png">

