### PR TITLE
feat: add chart and interval api

### DIFF
--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -1,0 +1,70 @@
+import { Chart } from '../../../src';
+import { optionsOf } from '../../../src/api/chart';
+import { Interval } from '../../../src/api/interval';
+import { createDiv } from '../../utils/dom';
+
+describe('Chart', () => {
+  it('Chart() should have expected defaults', () => {
+    const chart = new Chart();
+    expect(chart.type).toBe('view');
+    expect(chart.parentNode).toBeNull();
+    expect(chart.value).toEqual({});
+    expect(chart['container'].nodeName).toBe('DIV');
+  });
+
+  it('Chart({...}) should support HTML container', () => {
+    const container = createDiv();
+    const chart = new Chart({
+      container,
+    });
+    expect(chart['container']).toBe(container);
+  });
+
+  it('Chart({...}) should support id container', () => {
+    const div = document.createElement('div');
+    div.setAttribute('id', 'root');
+    document.body.appendChild(div);
+    const chart = new Chart({
+      container: 'root',
+    });
+    expect(chart['container']).toBe(div);
+  });
+
+  it('Chart({...}) should override default value', () => {
+    const chart = new Chart({
+      data: [1, 2, 3],
+    });
+    expect(chart.value).toEqual({
+      data: [1, 2, 3],
+    });
+  });
+
+  it('chart.interval() should return a interval node', () => {
+    const chart = new Chart();
+    const interval = chart.interval();
+    expect(interval).toBeInstanceOf(Interval);
+    expect(optionsOf(chart)).toEqual({
+      type: 'view',
+      children: [{ type: 'interval' }],
+    });
+  });
+
+  it('chart.render() should render chart', () => {
+    const chart = new Chart({
+      container: createDiv(),
+      data: [
+        { genre: 'Sports', sold: 275 },
+        { genre: 'Strategy', sold: 115 },
+        { genre: 'Action', sold: 120 },
+        { genre: 'Shooter', sold: 350 },
+        { genre: 'Other', sold: 150 },
+      ],
+    });
+    chart
+      .interval()
+      .encode('x', 'genre')
+      .encode('y', 'sold')
+      .encode('color', 'genre');
+    chart.render();
+  });
+});

--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -52,19 +52,22 @@ describe('Chart', () => {
   it('chart.render() should render chart', () => {
     const chart = new Chart({
       container: createDiv(),
-      data: [
-        { genre: 'Sports', sold: 275 },
-        { genre: 'Strategy', sold: 115 },
-        { genre: 'Action', sold: 120 },
-        { genre: 'Shooter', sold: 350 },
-        { genre: 'Other', sold: 150 },
-      ],
     });
+
+    chart.data([
+      { genre: 'Sports', sold: 275 },
+      { genre: 'Strategy', sold: 115 },
+      { genre: 'Action', sold: 120 },
+      { genre: 'Shooter', sold: 350 },
+      { genre: 'Other', sold: 150 },
+    ]);
+
     chart
       .interval()
       .encode('x', 'genre')
       .encode('y', 'sold')
       .encode('color', 'genre');
+
     chart.render();
   });
 });

--- a/__tests__/unit/api/interval.spec.ts
+++ b/__tests__/unit/api/interval.spec.ts
@@ -1,0 +1,27 @@
+import { Interval, props } from '../../../src/api/interval';
+
+describe('Interval', () => {
+  it('Interval() should have expected defaults', () => {
+    const interval = new Interval();
+    expect(interval.type).toBe('interval');
+  });
+
+  it('interval should have expected props', () => {
+    expect(props).toEqual([
+      { name: 'encode', type: 'object' },
+      { name: 'scale', type: 'object' },
+      { name: 'data', type: 'value' },
+      { name: 'key', type: 'value' },
+      { name: 'class', type: 'value' },
+      { name: 'transform', type: 'array' },
+      { name: 'style', type: 'object' },
+      { name: 'animate', type: 'object' },
+      { name: 'theme', type: 'object' },
+    ]);
+  });
+
+  it('interval.create() should return Interval', () => {
+    const interval = new Interval();
+    expect(interval.create()).toBe(Interval);
+  });
+});

--- a/__tests__/unit/api/interval.spec.ts
+++ b/__tests__/unit/api/interval.spec.ts
@@ -19,9 +19,4 @@ describe('Interval', () => {
       { name: 'theme', type: 'object' },
     ]);
   });
-
-  it('interval.create() should return Interval', () => {
-    const interval = new Interval();
-    expect(interval.create()).toBe(Interval);
-  });
 });

--- a/__tests__/unit/api/node.spec.ts
+++ b/__tests__/unit/api/node.spec.ts
@@ -38,6 +38,13 @@ describe('Node', () => {
     expect(node.children[0]).toBe(c1);
   });
 
+  it('node.map() should return a cloned node', () => {
+    class N extends Node {}
+    const n = new N();
+    const n1 = n.map();
+    expect(n1).toBeInstanceOf(N);
+  });
+
   it('node.attr(key, value) should update value and return a new clone node.', () => {
     const node = new Node({ a: 1 });
     const n1 = node.attr('a', 2);

--- a/__tests__/unit/api/node.spec.ts
+++ b/__tests__/unit/api/node.spec.ts
@@ -1,0 +1,89 @@
+import { Node } from '../../../src/api/node';
+
+describe('Node', () => {
+  it('Node() should have expected defaults', () => {
+    const node = new Node();
+    expect(node.type).toBeUndefined();
+    expect(node.parentNode).toBeNull();
+    expect(node.value).toEqual({});
+    expect(node.index).toBe(0);
+  });
+
+  it('Node(value) should override default value', () => {
+    const node = new Node({ a: 1 });
+    expect(node.value).toEqual({ a: 1 });
+  });
+
+  it('node.map(transform) apply specified transform to current value and clone a new node.', () => {
+    const node = new Node({ a: 1 });
+    const n1 = node.map();
+    const n2 = node.map(({ a }) => ({ a: a * 2 }));
+    expect(node.value).toEqual({ a: 1 });
+    expect(n1).toBeInstanceOf(Node);
+    expect(n1.value).toEqual({ a: 1 });
+    expect(n2.value).toEqual({ a: 2 });
+    expect(n1).not.toBe(node);
+    expect(n1).not.toBe(n2);
+    expect(n2).not.toBe(node);
+  });
+
+  it('node.map(transform) should mount the return node to its parentNode.', () => {
+    const node = new Node();
+    const child = node.append(Node);
+    const c1 = child.map();
+    expect(c1.parentNode).toBe(child.parentNode);
+    expect(c1.index).toBe(child.index);
+    expect(c1.children).toBe(child.children);
+    expect(c1.parentNode).toBe(node);
+    expect(node.children[0]).toBe(c1);
+  });
+
+  it('node.attr(key, value) should update value and return a new clone node.', () => {
+    const node = new Node({ a: 1 });
+    const n1 = node.attr('a', 2);
+    expect(node.value).toEqual({ a: 1 });
+    expect(n1).not.toBe(node);
+    expect(n1).toBeInstanceOf(Node);
+    expect(n1.value).toEqual({ a: 2 });
+    expect(n1.parentNode).toBe(node.parentNode);
+    expect(n1.index).toBe(node.index);
+    expect(n1.children).toBe(node.children);
+  });
+
+  it('node.attr(key) should return specified attribute.', () => {
+    const node = new Node({ a: 1 });
+    expect(node.attr('a')).toBe(1);
+  });
+
+  it('node.append(ctor) should append node to children', () => {
+    const node = new Node({ a: 1 });
+    const n1 = node.append(Node);
+    const n2 = node.append(Node);
+    expect(n1.children).toEqual([]);
+    expect(n1.parentNode).toBe(node);
+    expect(n1.index).toBe(0);
+    expect(n2.index).toBe(1);
+    expect(node.children[0]).toBe(n1);
+    expect(node.children[1]).toBe(n2);
+  });
+
+  it('node.pipe(callback) should apply specified callback to a new cloned node.', () => {
+    const node = new Node({ a: 1 });
+    const n1 = node.pipe((node) => node.attr('a', 2));
+    expect(node.value).toEqual({ a: 1 });
+    expect(n1).not.toBe(node);
+    expect(n1).toBeInstanceOf(Node);
+    expect(n1.value).toEqual({ a: 2 });
+    expect(n1.parentNode).toBe(node.parentNode);
+    expect(n1.index).toBe(node.index);
+    expect(n1.children).toBe(node.children);
+  });
+
+  it('node.pipe(callback, ...args) should apply specified callback with args.', () => {
+    const node = new Node({ a: 1 });
+    const multiple = (node, t) => node.attr('a', node.attr('a') * t);
+    const n1 = node.pipe(multiple, 2);
+    expect(node.value).toEqual({ a: 1 });
+    expect(n1.value).toEqual({ a: 2 });
+  });
+});

--- a/__tests__/unit/api/node.spec.ts
+++ b/__tests__/unit/api/node.spec.ts
@@ -14,47 +14,30 @@ describe('Node', () => {
     expect(node.value).toEqual({ a: 1 });
   });
 
-  it('node.map(transform) apply specified transform to current value and clone a new node.', () => {
+  it('node.map(transform) apply specified transform to current value and return itself.', () => {
     const node = new Node({ a: 1 });
-    const n1 = node.map();
-    const n2 = node.map(({ a }) => ({ a: a * 2 }));
     expect(node.value).toEqual({ a: 1 });
-    expect(n1).toBeInstanceOf(Node);
+    const n1 = node.map();
     expect(n1.value).toEqual({ a: 1 });
+    const n2 = node.map(({ a }) => ({ a: a * 2 }));
     expect(n2.value).toEqual({ a: 2 });
-    expect(n1).not.toBe(node);
-    expect(n1).not.toBe(n2);
-    expect(n2).not.toBe(node);
+    expect(n1).toBeInstanceOf(Node);
+    expect(n1).toBe(node);
+    expect(n1).toBe(n2);
   });
 
-  it('node.map(transform) should mount the return node to its parentNode.', () => {
-    const node = new Node();
-    const child = node.append(Node);
-    const c1 = child.map();
-    expect(c1.parentNode).toBe(child.parentNode);
-    expect(c1.index).toBe(child.index);
-    expect(c1.children).toBe(child.children);
-    expect(c1.parentNode).toBe(node);
-    expect(node.children[0]).toBe(c1);
-  });
-
-  it('node.map() should return a cloned node', () => {
+  it('node.map() should return itself.', () => {
     class N extends Node {}
     const n = new N();
     const n1 = n.map();
-    expect(n1).toBeInstanceOf(N);
+    expect(n1).toBe(n1);
   });
 
-  it('node.attr(key, value) should update value and return a new clone node.', () => {
+  it('node.attr(key, value) should update value and return itself.', () => {
     const node = new Node({ a: 1 });
     const n1 = node.attr('a', 2);
-    expect(node.value).toEqual({ a: 1 });
-    expect(n1).not.toBe(node);
-    expect(n1).toBeInstanceOf(Node);
-    expect(n1.value).toEqual({ a: 2 });
-    expect(n1.parentNode).toBe(node.parentNode);
-    expect(n1.index).toBe(node.index);
-    expect(n1.children).toBe(node.children);
+    expect(node.value).toEqual({ a: 2 });
+    expect(n1).toBe(node);
   });
 
   it('node.attr(key) should return specified attribute.', () => {
@@ -77,20 +60,15 @@ describe('Node', () => {
   it('node.pipe(callback) should apply specified callback to a new cloned node.', () => {
     const node = new Node({ a: 1 });
     const n1 = node.pipe((node) => node.attr('a', 2));
-    expect(node.value).toEqual({ a: 1 });
-    expect(n1).not.toBe(node);
-    expect(n1).toBeInstanceOf(Node);
-    expect(n1.value).toEqual({ a: 2 });
-    expect(n1.parentNode).toBe(node.parentNode);
-    expect(n1.index).toBe(node.index);
-    expect(n1.children).toBe(node.children);
+    expect(node.value).toEqual({ a: 2 });
+    expect(n1).toBe(node);
   });
 
   it('node.pipe(callback, ...args) should apply specified callback with args.', () => {
     const node = new Node({ a: 1 });
     const multiple = (node, t) => node.attr('a', node.attr('a') * t);
-    const n1 = node.pipe(multiple, 2);
     expect(node.value).toEqual({ a: 1 });
+    const n1 = node.pipe(multiple, 2);
     expect(n1.value).toEqual({ a: 2 });
   });
 });

--- a/__tests__/unit/api/props.spec.ts
+++ b/__tests__/unit/api/props.spec.ts
@@ -6,29 +6,29 @@ describe('defineProps', () => {
     const N = defineProps([{ type: 'value', name: 'a' }])(Node);
     const n = new N({ a: 1 });
     const n1 = n.a(2);
-    expect(n.a()).toBe(1);
+    expect(n.a()).toBe(2);
     expect(n1.a()).toBe(2);
   });
 
   it('defineProps([...]) should define array prop', () => {
     const N = defineProps([{ type: 'array', name: 'a' }])(Node);
     const n = new N({ a: [1] });
-    const n1 = n.a(2);
-    const n2 = n1.a([1, 2, 3]);
     expect(n.a()).toEqual([1]);
+    const n1 = n.a(2);
     expect(n1.a()).toEqual([1, 2]);
+    const n2 = n1.a([1, 2, 3]);
     expect(n2.a()).toEqual([1, 2, 3]);
   });
 
   it('defineProps([...]) should define object prop', () => {
     const N = defineProps([{ type: 'object', name: 'a' }])(Node);
     const n = new N({ a: { b: 1 } });
+    expect(n.a()).toEqual({ b: 1 });
     const n1 = n.a('b', 2);
+    expect(n1.a()).toEqual({ b: 2 });
     const n2 = n1.a({
       b: 3,
     });
-    expect(n.a()).toEqual({ b: 1 });
-    expect(n1.a()).toEqual({ b: 2 });
     expect(n2.a()).toEqual({ b: 3 });
   });
 

--- a/__tests__/unit/api/props.spec.ts
+++ b/__tests__/unit/api/props.spec.ts
@@ -1,0 +1,43 @@
+import { defineProps } from '../../../src/api/props';
+import { Node } from '../../../src/api/node';
+
+describe('defineProps', () => {
+  it('defineProps([...]) should define value prop', () => {
+    const N = defineProps([{ type: 'value', name: 'a' }])(Node);
+    const n = new N({ a: 1 });
+    const n1 = n.a(2);
+    expect(n.a()).toBe(1);
+    expect(n1.a()).toBe(2);
+  });
+
+  it('defineProps([...]) should define array prop', () => {
+    const N = defineProps([{ type: 'array', name: 'a' }])(Node);
+    const n = new N({ a: [1] });
+    const n1 = n.a(2);
+    const n2 = n1.a([1, 2, 3]);
+    expect(n.a()).toEqual([1]);
+    expect(n1.a()).toEqual([1, 2]);
+    expect(n2.a()).toEqual([1, 2, 3]);
+  });
+
+  it('defineProps([...]) should define object prop', () => {
+    const N = defineProps([{ type: 'object', name: 'a' }])(Node);
+    const n = new N({ a: { b: 1 } });
+    const n1 = n.a('b', 2);
+    const n2 = n1.a({
+      b: 3,
+    });
+    expect(n.a()).toEqual({ b: 1 });
+    expect(n1.a()).toEqual({ b: 2 });
+    expect(n2.a()).toEqual({ b: 3 });
+  });
+
+  it('defineProps([...]) should define node prop', () => {
+    const N = defineProps([{ type: 'node', ctor: Node, name: 'a' }])(Node);
+    const n = new N();
+    const n1 = n.a();
+    expect(n1.parentNode).toBe(n);
+    expect(n.children[0]).toBe(n1);
+    expect(n1).toBeInstanceOf(Node);
+  });
+});

--- a/src/api/chart.ts
+++ b/src/api/chart.ts
@@ -2,8 +2,9 @@ import { clone } from '@antv/util';
 import { render } from '../runtime';
 import { ViewComposition } from '../spec';
 import { Node } from './node';
-import { defineProps } from './props';
+import { defineProps, NodePropertyDescriptor } from './props';
 import { Interval } from './interval';
+import { ValueAttribute, Concrete } from './types';
 
 function normalizeContainer(container: string | HTMLElement): HTMLElement {
   if (container === undefined) return document.createElement('div');
@@ -45,13 +46,21 @@ export type ChartOptions = ViewComposition & {
   container?: string | HTMLElement;
 };
 
+type ChartProps = Concrete<ViewComposition>;
+
 export interface Chart {
   render(): void;
   interval(): Interval;
   node(): HTMLElement;
+  data: ValueAttribute<ChartProps['data'], Chart>;
 }
 
-@defineProps([{ name: 'interval', type: 'node', ctor: Interval }])
+export const props: NodePropertyDescriptor[] = [
+  { name: 'interval', type: 'node', ctor: Interval },
+  { name: 'data', type: 'value' },
+];
+
+@defineProps(props)
 export class Chart extends Node<ChartOptions> {
   private container: HTMLElement;
 

--- a/src/api/chart.ts
+++ b/src/api/chart.ts
@@ -2,7 +2,7 @@ import { clone } from '@antv/util';
 import { render } from '../runtime';
 import { ViewComposition } from '../spec';
 import { Node } from './node';
-import { defineProps, defineCreate } from './props';
+import { defineProps } from './props';
 import { Interval } from './interval';
 
 function normalizeContainer(container: string | HTMLElement): HTMLElement {
@@ -51,7 +51,6 @@ export interface Chart {
   node(): HTMLElement;
 }
 
-@defineCreate
 @defineProps([{ name: 'interval', type: 'node', ctor: Interval }])
 export class Chart extends Node<ChartOptions> {
   private container: HTMLElement;

--- a/src/api/chart.ts
+++ b/src/api/chart.ts
@@ -1,0 +1,73 @@
+import { clone } from '@antv/util';
+import { render } from '../runtime';
+import { ViewComposition } from '../spec';
+import { Node } from './node';
+import { defineProps, defineCreate } from './props';
+import { Interval } from './interval';
+
+function normalizeContainer(container: string | HTMLElement): HTMLElement {
+  if (container === undefined) return document.createElement('div');
+  if (typeof container === 'string') {
+    const node = document.getElementById(container);
+    return node;
+  }
+  return container;
+}
+
+function valueOf(node: Node): Record<string, any> {
+  const value = clone(node.value);
+  return {
+    ...value,
+    type: node.type,
+  };
+}
+
+export function optionsOf(root: Node): Record<string, any> {
+  const discovered: Node[] = [root];
+  const nodeValue = new Map<Node, Record<string, any>>();
+  nodeValue.set(root, valueOf(root));
+  while (discovered.length) {
+    const node = discovered.pop();
+    const value = nodeValue.get(node);
+    for (const child of node.children) {
+      const childValue = valueOf(child);
+      const { children = [] } = value;
+      children.push(childValue);
+      discovered.push(child);
+      nodeValue.set(child, childValue);
+      value.children = children;
+    }
+  }
+  return nodeValue.get(root);
+}
+
+export type ChartOptions = ViewComposition & {
+  container?: string | HTMLElement;
+};
+
+export interface Chart {
+  render(): void;
+  interval(): Interval;
+  node(): HTMLElement;
+}
+
+@defineCreate
+@defineProps([{ name: 'interval', type: 'node', ctor: Interval }])
+export class Chart extends Node<ChartOptions> {
+  private container: HTMLElement;
+
+  constructor(options: ChartOptions = {}) {
+    const { container, ...rest } = options;
+    super(rest, 'view');
+    this.container = normalizeContainer(container);
+  }
+
+  render() {
+    const node = render(optionsOf(this));
+    this.container.append(node);
+  }
+
+  node() {
+    return this.container;
+  }
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,1 @@
+export { Chart } from './chart';

--- a/src/api/interval.ts
+++ b/src/api/interval.ts
@@ -1,6 +1,6 @@
 import { IntervalGeometry } from '../spec';
 import { Node } from './node';
-import { defineProps, defineCreate, NodePropertyDescriptor } from './props';
+import { defineProps, NodePropertyDescriptor } from './props';
 import {
   ValueAttribute,
   ObjectAttribute,
@@ -34,7 +34,6 @@ export const props: NodePropertyDescriptor[] = [
   { name: 'theme', type: 'object' },
 ];
 
-@defineCreate
 @defineProps(props)
 export class Interval extends Node<IntervalGeometry> {
   constructor(options?: IntervalGeometry) {

--- a/src/api/interval.ts
+++ b/src/api/interval.ts
@@ -1,0 +1,43 @@
+import { IntervalGeometry } from '../spec';
+import { Node } from './node';
+import { defineProps, defineCreate, NodePropertyDescriptor } from './props';
+import {
+  ValueAttribute,
+  ObjectAttribute,
+  ArrayAttribute,
+  Concrete,
+} from './types';
+
+type IntervalProps = Concrete<IntervalGeometry>;
+
+export interface Interval {
+  data: ValueAttribute<IntervalProps['data'], Interval>;
+  encode: ObjectAttribute<IntervalProps['encode'], Interval>;
+  scale: ObjectAttribute<IntervalProps['scale'], Interval>;
+  transform: ArrayAttribute<IntervalProps['transform'], Interval>;
+  animate: ObjectAttribute<IntervalProps['animate'], Interval>;
+  theme: ObjectAttribute<IntervalProps['theme'], Interval>;
+  key: ValueAttribute<IntervalProps['key'], Interval>;
+  class: ValueAttribute<IntervalProps['class'], Interval>;
+  style: ObjectAttribute<IntervalProps['style'], Interval>;
+}
+
+export const props: NodePropertyDescriptor[] = [
+  { name: 'encode', type: 'object' },
+  { name: 'scale', type: 'object' },
+  { name: 'data', type: 'value' },
+  { name: 'key', type: 'value' },
+  { name: 'class', type: 'value' },
+  { name: 'transform', type: 'array' },
+  { name: 'style', type: 'object' },
+  { name: 'animate', type: 'object' },
+  { name: 'theme', type: 'object' },
+];
+
+@defineCreate
+@defineProps(props)
+export class Interval extends Node<IntervalGeometry> {
+  constructor(options?: IntervalGeometry) {
+    super(options, 'interval');
+  }
+}

--- a/src/api/node.ts
+++ b/src/api/node.ts
@@ -37,7 +37,11 @@ export class Node<
     transform = (x: Value): Value => x,
   ): Node<Value, ParentValue, ChildValue> {
     const newValue = transform(clone(this.value));
-    const Ctor = this.create();
+    const Ctor = this.constructor as new (...args: any[]) => Node<
+      Value,
+      ParentValue,
+      ChildValue
+    >;
     const newNode = new Ctor(newValue);
     newNode.children = this.children;
     newNode.parentNode = this.parentNode;
@@ -82,12 +86,5 @@ export class Node<
     ...params: any[]
   ): Node<Value, ParentValue, ChildValue> {
     return callback(this.map(), ...params);
-  }
-
-  /**
-   * Return a constructor for cloning node.
-   */
-  create(): new (value: Value) => Node<Value, ParentValue, ChildValue> {
-    return Node<Value, ParentValue, ChildValue>;
   }
 }

--- a/src/api/node.ts
+++ b/src/api/node.ts
@@ -33,21 +33,10 @@ export class Node<
    * Mount the cloned node to replace the original one in the tree
    * and then return it.
    */
-  map(
-    transform = (x: Value): Value => x,
-  ): Node<Value, ParentValue, ChildValue> {
+  map(transform = (x: Value): Value => x): this {
     const newValue = transform(clone(this.value));
-    const Ctor = this.constructor as new (...args: any[]) => Node<
-      Value,
-      ParentValue,
-      ChildValue
-    >;
-    const newNode = new Ctor(newValue);
-    newNode.children = this.children;
-    newNode.parentNode = this.parentNode;
-    newNode.index = this.index;
-    if (this.parentNode) this.parentNode.children[this.index] = newNode;
-    return newNode;
+    this.value = newValue;
+    return this;
   }
 
   /**
@@ -58,7 +47,7 @@ export class Node<
   attr<T extends Value[keyof Value]>(
     key: keyof Value,
     value?: T,
-  ): T extends undefined ? T : Node<Value, ParentValue, ChildValue> {
+  ): T extends undefined ? T : this {
     if (value === undefined) return this.value[key];
     return this.map((v) => ((v[key] = value), v)) as any;
   }
@@ -66,7 +55,9 @@ export class Node<
   /**
    * Create a new node and append to children nodes.
    */
-  append(Ctor: new (value: Record<string, any>) => Node<ChildValue, Value>) {
+  append(
+    Ctor: new (value: Record<string, any>) => Node<ChildValue, Value>,
+  ): Node<ChildValue, Value> {
     const node = new Ctor({});
     node.children = [];
     node.parentNode = this;
@@ -79,12 +70,9 @@ export class Node<
    * Apply specified callback to a new cloned node.
    */
   pipe(
-    callback: (
-      node: Node<Value>,
-      ...params: any[]
-    ) => Node<Value, ParentValue, ChildValue>,
+    callback: (node: Node<Value>, ...params: any[]) => this,
     ...params: any[]
-  ): Node<Value, ParentValue, ChildValue> {
+  ): this {
     return callback(this.map(), ...params);
   }
 }

--- a/src/api/node.ts
+++ b/src/api/node.ts
@@ -1,0 +1,93 @@
+import { clone } from '@antv/util';
+
+/**
+ * Hierarchy container.
+ */
+export class Node<
+  Value extends Record<string, any> = Record<string, any>,
+  ParentValue extends Record<string, any> = Record<string, any>,
+  ChildValue extends Record<string, any> = Record<string, any>,
+> {
+  // The parent node.
+  parentNode: Node<ParentValue, Record<string, any>, Value> = null;
+
+  // The children nodes.
+  children: Node<ChildValue, Value, Record<string, any>>[] = [];
+
+  // The index of parent children.
+  index = 0;
+
+  // The value of the node.
+  value: Partial<Value>;
+
+  // The type of the node.
+  type: string;
+
+  constructor(value: Partial<Value> = {}, type?: string) {
+    this.type = type;
+    this.value = value;
+  }
+
+  /**
+   * Apply specified transform to current value and clone a new node.
+   * Mount the cloned node to replace the original one in the tree
+   * and then return it.
+   */
+  map(
+    transform = (x: Value): Value => x,
+  ): Node<Value, ParentValue, ChildValue> {
+    const newValue = transform(clone(this.value));
+    const Ctor = this.create();
+    const newNode = new Ctor(newValue);
+    newNode.children = this.children;
+    newNode.parentNode = this.parentNode;
+    newNode.index = this.index;
+    if (this.parentNode) this.parentNode.children[this.index] = newNode;
+    return newNode;
+  }
+
+  /**
+   * Set or get the specified attribute. It the value is specified, update
+   * the attribute of current value and return a new cloned node. Otherwise
+   * return the the attribute of current value.
+   */
+  attr<T extends Value[keyof Value]>(
+    key: keyof Value,
+    value?: T,
+  ): T extends undefined ? T : Node<Value, ParentValue, ChildValue> {
+    if (value === undefined) return this.value[key];
+    return this.map((v) => ((v[key] = value), v)) as any;
+  }
+
+  /**
+   * Create a new node and append to children nodes.
+   */
+  append(Ctor: new (value: Record<string, any>) => Node<ChildValue, Value>) {
+    const node = new Ctor({});
+    node.children = [];
+    node.parentNode = this;
+    node.index = this.children.length;
+    this.children.push(node);
+    return node;
+  }
+
+  /**
+   * Apply specified callback to a new cloned node.
+   */
+  pipe(
+    callback: (
+      node: Node<Value>,
+      ...params: any[]
+    ) => Node<Value, ParentValue, ChildValue>,
+    ...params: any[]
+  ): Node<Value, ParentValue, ChildValue> {
+    return callback(this.map(), ...params);
+  }
+
+  /**
+   * Return a constructor for cloning node.
+   */
+  create(): new (value: Value) => Node<Value, ParentValue, ChildValue> {
+    return Node<Value, ParentValue, ChildValue>;
+  }
+}

--- a/src/api/props.ts
+++ b/src/api/props.ts
@@ -1,0 +1,64 @@
+import { isObject, clone } from '@antv/util';
+
+export type NodePropertyDescriptor = {
+  type: 'object' | 'value' | 'array' | 'node';
+  name: string;
+  ctor?: new (...args: any[]) => any;
+};
+
+function defineValueProp(Node, { name }: NodePropertyDescriptor) {
+  Node.prototype[name] = function (value) {
+    return this.attr(name, value);
+  };
+}
+
+function defineArrayProp(Node, { name }: NodePropertyDescriptor) {
+  Node.prototype[name] = function (value) {
+    if (Array.isArray(value) || value === undefined) {
+      return this.attr(name, value);
+    }
+    const array = this.attr(name);
+    const newArray = [...(Array.isArray(array) ? array : [])];
+    newArray.push(value);
+    return this.attr(name, newArray);
+  };
+}
+
+function defineObjectProp(Node, { name }: NodePropertyDescriptor) {
+  Node.prototype[name] = function (key, value) {
+    if (isObject(key) || key === undefined) {
+      return this.attr(name, key);
+    }
+    const newObject = clone(this.attr(name) || {});
+    newObject[key] = value;
+    return this.attr(name, newObject);
+  };
+}
+
+function defineNodeProp(Node, { name, ctor }: NodePropertyDescriptor) {
+  Node.prototype[name] = function () {
+    return this.append(ctor);
+  };
+}
+
+/**
+ * A decorator to define different type of attribute setter or
+ * getter for current node.
+ */
+export function defineProps(descriptors: NodePropertyDescriptor[]) {
+  return (Node) => {
+    for (const descriptor of descriptors) {
+      const { type } = descriptor;
+      if (type === 'value') defineValueProp(Node, descriptor);
+      else if (type === 'array') defineArrayProp(Node, descriptor);
+      else if (type === 'object') defineObjectProp(Node, descriptor);
+      else if (type === 'node') defineNodeProp(Node, descriptor);
+    }
+    return Node;
+  };
+}
+
+export function defineCreate(Node) {
+  Node.prototype.create = () => Node;
+  return Node;
+}

--- a/src/api/props.ts
+++ b/src/api/props.ts
@@ -57,8 +57,3 @@ export function defineProps(descriptors: NodePropertyDescriptor[]) {
     return Node;
   };
 }
-
-export function defineCreate(Node) {
-  Node.prototype.create = () => Node;
-  return Node;
-}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,20 @@
+type ValueOf<T> = T[keyof T];
+
+type ElementOf<T> = T extends Array<any> ? T[number] : never;
+
+type Chainable<K, V, N> = K extends undefined ? V : N;
+
+export type ValueAttribute<V, N> = <T extends V>(
+  value?: T,
+) => Chainable<T, V, N>;
+
+export type ObjectAttribute<V, N> = <T extends ValueOf<V>>(
+  key: V | keyof V,
+  value?: T,
+) => Chainable<T, V, N>;
+
+export type ArrayAttribute<V, N> = <T extends V | ElementOf<V>>(
+  value?: T,
+) => Chainable<T, V, N>;
+
+export type Concrete<T> = { [Key in keyof T]-?: T[Key] };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './runtime';
 export { createLibrary } from './stdlib';
+export { Chart } from './api';
 export type { G2Spec } from './spec';


### PR DESCRIPTION
feat(api): add part of chart and interval api

![image](https://user-images.githubusercontent.com/49330279/180144015-bd60c54d-0993-452b-a6d4-321d7e5d7cef.png)

```js
const chart = new Chart({
  container: 'container',
});

chart.data([
  { genre: 'Sports', sold: 275 },
  { genre: 'Strategy', sold: 115 },
  { genre: 'Action', sold: 120 },
  { genre: 'Shooter', sold: 350 },
  { genre: 'Other', sold: 150 },
]);

chart
  .interval()
  .encode('x', 'genre')
  .encode('y', 'sold')
  .encode('color', 'genre');

chart.render();
```