### PR TITLE
feat(component): support axis grid

### DIFF
--- a/docs/interval.md
+++ b/docs/interval.md
@@ -99,7 +99,7 @@ G2.render({
     { genre: 'Other', sold: 150 },
   ],
   coordinate: [{ type: 'polar' }],
-  scale: { x: { padding: 0.05 } },
+  scale: { x: { padding: 0.05 }, y: { guide: null } },
   encode: {
     x: 'genre',
     y: 'sold',

--- a/docs/spatial.md
+++ b/docs/spatial.md
@@ -148,6 +148,7 @@ G2.render({
         {
           type: 'interval',
           coordinate: [{ type: 'polar' }],
+          scale: { y: { guide: null } },
           encode: {
             x: 'genre',
             y: 'sold',

--- a/docs/view.md
+++ b/docs/view.md
@@ -110,6 +110,9 @@ G2.render({
     {
       type: 'line',
       scale: {
+        y: {
+          guide: { grid: null },
+        },
         color: {
           domain: ['value', 'count'],
           range: ['#5B8FF9', '#5AD8A6'],
@@ -126,6 +129,7 @@ G2.render({
       scale: {
         y: {
           independent: true,
+          guide: { grid: null },
         },
       },
       encode: {
@@ -154,6 +158,7 @@ G2.render({
     {
       type: 'interval',
       scale: {
+        y: { guide: { grid: null } },
         color: {
           domain: ['value', 'count'],
           range: ['#5B8FF9', '#5AD8A6'],
@@ -170,7 +175,7 @@ G2.render({
       scale: {
         y: {
           independent: true,
-          guide: { position: 'right' },
+          guide: { position: 'right', grid: null },
         },
         x: {
           independent: true,
@@ -207,6 +212,7 @@ G2.render({
     {
       type: 'interval',
       scale: {
+        y: { guide: { grid: null } },
         color: {
           domain: ['value', 'count'],
           range: ['#5B8FF9', '#5AD8A6'],
@@ -227,7 +233,7 @@ G2.render({
       scale: {
         y: {
           independent: true,
-          guide: { position: 'right' },
+          guide: { position: 'right', grid: null },
         },
       },
       encode: {

--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -207,18 +207,9 @@ const ArcAxis = (options) => {
   };
 };
 
-/**
- * Guide Component for position channel(e.g. x, y).
- * @todo Render Circular in polar coordinate.
- * @todo Custom style.
- */
-export const Axis: GCC<AxisOptions> = (options) => {
+const LinearAxis: GCC<AxisOptions> = (options) => {
   const { position, title = true, formatter = (d) => `${d}` } = options;
   return (scale, value, coordinate, theme) => {
-    if (position === 'arc') {
-      return ArcAxis(options)(scale, value, coordinate, theme);
-    }
-
     const { domain, field, bbox } = value;
     const {
       startPos,
@@ -269,6 +260,20 @@ export const Axis: GCC<AxisOptions> = (options) => {
         scale.getOptions().guide || {},
       ),
     });
+  };
+};
+
+/**
+ * Guide Component for position channel(e.g. x, y).
+ * @todo Render Circular in polar coordinate.
+ * @todo Custom style.
+ */
+export const Axis: GCC<AxisOptions> = (options) => {
+  const { position } = options;
+  return (scale, value, coordinate, theme) => {
+    return position === 'arc'
+      ? ArcAxis(options)(scale, value, coordinate, theme)
+      : LinearAxis(options)(scale, value, coordinate, theme);
   };
 };
 

--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -337,7 +337,7 @@ const LinearAxis: GCC<AxisOptions> = (options) => {
             items: gridItems,
             lineStyle: {
               stroke: '#1b1e23',
-              strokeOpacity: 0.1,
+              strokeOpacity: 0.05,
               lineDash: [0, 0],
             },
           },

--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -75,14 +75,12 @@ function inferPosition(
       startPos: [cx + bbox.x, cy + bbox.y - radius],
       endPos: [cx + bbox.x, cy + bbox.y],
       titlePosition: 'start',
-      titlePadding: -20,
-      titleOffsetY: -8,
+      titlePadding: 4,
+      titleOffsetY: 0,
       titleRotate: -90,
       labelOffset: 4,
       verticalFactor: -1,
-      label: false,
-      axisLine: true,
-      tickLine: false,
+      axisLine: false,
     };
   }
   return {
@@ -170,26 +168,114 @@ function getTicks(
   });
 }
 
+function getTickGridItem(
+  tick: number,
+  position: GuideComponentPosition,
+  coordinate: Coordinate,
+  startPos: Vector2,
+  endPos: Vector2,
+) {
+  const [sx, sy] = startPos;
+  const [ex, ey] = endPos;
+  const [width, height] = coordinate.getSize();
+  let x1, x2, y1, y2;
+  if (position === 'bottom' || position === 'top') {
+    x1 = x2 = sx + (ex - sx) * tick;
+    y1 = sy;
+    y2 = position === 'bottom' ? sy - height : sy + height;
+  } else {
+    y1 = y2 = sy + (ey - sy) * tick;
+    x1 = sx;
+    x2 = position === 'left' ? sx + width : sx - width;
+  }
+  return [
+    [x1, y1],
+    [x2, y2],
+  ];
+}
+
+function getArcGridItems(
+  ticks: any[],
+  center: [number, number],
+  startAngle: number,
+  endAngle: number,
+  radius: number,
+) {
+  const [cx, cy] = center;
+  return ticks.map(({ value }) => {
+    const angle = (endAngle - startAngle) * value + startAngle;
+    return {
+      points: [
+        [cx, cy],
+        [
+          cx + radius * Math.cos((angle * Math.PI) / 180),
+          cy + radius * Math.sin((angle * Math.PI) / 180),
+        ],
+      ],
+    };
+  });
+}
+
+/**
+ * @todo render grid in arcY positioned axis.
+ */
+function getGridItems(
+  ticks: any[],
+  position: GuideComponentPosition,
+  coordinate: any,
+  startPos: Vector2,
+  endPos: Vector2,
+) {
+  if (isPolar(coordinate) || isParallel(coordinate)) return [];
+  return ticks.map((tick) => {
+    const points = getTickGridItem(
+      tick.value,
+      position,
+      coordinate,
+      startPos,
+      endPos,
+    );
+    return { points };
+  });
+}
+
 const ArcAxis = (options) => {
   const { position, formatter = (d) => `${d}` } = options;
   return (scale, value, coordinate, theme) => {
     const [cx, cy] = coordinate.getCenter() as Vector2;
     const { domain, bbox } = value;
+    const center = [cx + bbox.x, cy + bbox.y] as [number, number];
     const ticks = getTicks(scale, domain, formatter, position, coordinate);
     const radius = Math.min(bbox.width, bbox.height) / 2;
+    const startAngle = -90;
+    const endAngle = 270;
+
+    const guideOptions = scale.getOptions().guide || {};
+    const { grid: showGrid } = guideOptions;
+    const gridItems = showGrid
+      ? getArcGridItems(ticks, center, startAngle, endAngle, radius)
+      : [];
     return new Arc({
       style: deepMix(
         {},
         {
-          center: [cx + bbox.x, cy + bbox.y],
+          center,
           radius,
-          startAngle: -90,
-          endAngle: 270,
+          startAngle,
+          endAngle,
           ticks,
           axisLine: {
             style: {
               lineWidth: 0,
               strokeOpacity: 0,
+            },
+          },
+          grid: {
+            items: gridItems,
+            lineStyle: {
+              stroke: '#1b1e23',
+              strokeOpacity: 0.1,
+              lineDash: [0, 0],
             },
           },
           tickLine: {
@@ -201,7 +287,7 @@ const ArcAxis = (options) => {
             tickPadding: 2,
           },
         },
-        scale.getOptions().guide,
+        guideOptions,
       ),
     });
   };
@@ -225,6 +311,13 @@ const LinearAxis: GCC<AxisOptions> = (options) => {
       tickLine = true,
     } = inferPosition(position, bbox, coordinate);
     const ticks = getTicks(scale, domain, formatter, position, coordinate);
+
+    const guideOptions = scale.getOptions().guide || {};
+    // Display axis grid for non-discrete values.
+    const { grid: showGrid = !!scale.getTicks } = guideOptions;
+    const gridItems = showGrid
+      ? getGridItems(ticks, position, coordinate, startPos, endPos)
+      : [];
     return new Linear({
       style: deepMix(
         {
@@ -240,6 +333,14 @@ const LinearAxis: GCC<AxisOptions> = (options) => {
               }
             : null,
           axisLine: axisLine ? { stroke: '#BFBFBF' } : null,
+          grid: {
+            items: gridItems,
+            lineStyle: {
+              stroke: '#1b1e23',
+              strokeOpacity: 0.1,
+              lineDash: [0, 0],
+            },
+          },
           tickLine: tickLine
             ? {
                 len: 4,
@@ -257,7 +358,7 @@ const LinearAxis: GCC<AxisOptions> = (options) => {
               },
             }),
         },
-        scale.getOptions().guide || {},
+        guideOptions,
       ),
     });
   };

--- a/src/composition/matrix.ts
+++ b/src/composition/matrix.ts
@@ -4,7 +4,13 @@ import { MatrixComposition } from '../spec';
 import { Container } from '../utils/container';
 import { calcBBox } from '../utils/vector';
 import { indexOf } from '../utils/array';
-import { inferColor, setAnimation, setStyle, toGrid } from './rect';
+import {
+  createInnerGuide,
+  inferColor,
+  setAnimation,
+  setStyle,
+  toGrid,
+} from './rect';
 import { useDefaultAdaptor, useOverrideAdaptor } from './utils';
 
 export type MatrixOptions = Omit<MatrixComposition, 'type'>;
@@ -70,8 +76,8 @@ const setChildren = useOverrideAdaptor<G2ViewTree>((options) => {
           },
         };
         const newScale = {
-          x: { guide: createGuideX(guideX)(facet) },
-          y: { guide: createGuideY(guideY)(facet) },
+          x: { guide: createGuideX(guideX)(facet, data) },
+          y: { guide: createGuideY(guideY)(facet, data) },
         };
         return {
           data,
@@ -127,20 +133,20 @@ const setData = (options: G2ViewTree) => {
 function createGuideX(guideX) {
   if (typeof guideX === 'function') return guideX;
   if (guideX === null) return () => null;
-  return (facet) => {
+  return (facet, data) => {
     const { rowIndex, rowValuesLength } = facet;
     // Only the bottom-most facet show axisX.
-    if (rowIndex !== rowValuesLength - 1) return null;
+    if (rowIndex !== rowValuesLength - 1) return createInnerGuide(guideX, data);
   };
 }
 
 function createGuideY(guideY) {
   if (typeof guideY === 'function') return guideY;
   if (guideY === null) return () => null;
-  return (facet) => {
+  return (facet, data) => {
     const { columnIndex } = facet;
     // Only the left-most facet show axisY.
-    if (columnIndex !== 0) return null;
+    if (columnIndex !== 0) return createInnerGuide(guideY, data);
   };
 }
 


### PR DESCRIPTION
- **feat(component):** GUI axis supports `grid` options. In G2, should calculate grid.items by the actual ticks, now support non-discrete scale to display grid by default.
- **change(facet):** modify the createGuide method of `rect` and `matrix`, make sure axis grid display elegant by default.

### Demo of basic (default)

<img width="671" alt="image" src="https://user-images.githubusercontent.com/15646325/180136742-3d59b9c0-b021-4e40-9ff8-4334fef5d1bd.png">

<img width="648" alt="image" src="https://user-images.githubusercontent.com/15646325/180136765-86a99510-b9e8-4980-8d4d-026c6512d4f5.png">

<img width="525" alt="image" src="https://user-images.githubusercontent.com/15646325/180136815-eb74f38f-67a9-477a-81a0-9f3556408487.png">

<img width="634" alt="image" src="https://user-images.githubusercontent.com/15646325/180136870-55a70bd9-0aed-446b-80e0-571f6c663211.png">

### Demo of composition

<img width="640" alt="image" src="https://user-images.githubusercontent.com/15646325/180137018-fe61cdc9-4344-4d23-bd6a-36c86fb4d963.png">

<img width="647" alt="image" src="https://user-images.githubusercontent.com/15646325/180137049-2ec9cbfd-bd1e-49fa-b8ef-b503602ef030.png">

<img width="633" alt="image" src="https://user-images.githubusercontent.com/15646325/180137072-4d72e821-7771-4fd5-a750-a9ccf900938c.png">

<img width="780" alt="image" src="https://user-images.githubusercontent.com/15646325/180137120-b56ad7c3-9e2d-447b-a2f5-a21b1fe4d4e5.png">

<img width="774" alt="image" src="https://user-images.githubusercontent.com/15646325/180137153-634fa272-b497-4325-999e-03bd888a93be.png">

