### PR TITLE
feat(interaction): implement activeRegion interaction and add docs

### DIFF
--- a/.genjirc
+++ b/.genjirc
@@ -29,6 +29,7 @@
     "Animation": "animation",
     "Interaction": {
       "Element": "interaction-element",
+      "Component": "interaction-component",
       "Tooltip": "interaction-tooltip",
       "More": "interaction-more"
     },

--- a/__tests__/unit/interaction/action/transformer/button.spec.ts
+++ b/__tests__/unit/interaction/action/transformer/button.spec.ts
@@ -1,0 +1,26 @@
+import { Button } from '../../../../../src/interaction/action/transformer/button';
+import { createContext } from '../../helper';
+
+describe('Button action', () => {
+  it('Button({...}) renders a button component', async () => {
+    const context = createContext({ width: 200, height: 100 });
+    Button({})(context);
+  });
+
+  it('Button({...}) renders a button component with custom options', async () => {
+    const context = createContext({ width: 200, height: 100 });
+    Button({
+      text: 'Hello',
+      textStyle: { fontSize: 12, fill: 'red' },
+      fill: 'pink',
+      stroke: 'green',
+      padding: [2, 4],
+      radius: 0,
+    })(context);
+  });
+
+  it('Button({...}) renders a button component with specified position', async () => {
+    const context = createContext({ width: 200, height: 100 });
+    Button({ position: 'top-left' })(context);
+  });
+});

--- a/__tests__/unit/interaction/action/transformer/mask.spec.ts
+++ b/__tests__/unit/interaction/action/transformer/mask.spec.ts
@@ -1,0 +1,72 @@
+import { Mask } from '../../../../../src/interaction/action/transformer/mask';
+import { createContext } from '../../helper';
+
+describe('Mask action', () => {
+  it('Mask({...}) renders a mask component with resize handles.', async () => {
+    const context = createContext({
+      width: 100,
+      height: 100,
+      shared: { regions: [{ x1: 20, y1: 20, x2: 50, y2: 50 }] },
+    });
+    Mask({})(context);
+  });
+
+  it('Mask({...}) renders a mask component with custom options', async () => {
+    const context = createContext({
+      width: 100,
+      height: 100,
+      shared: { regions: [{ x1: 20, y1: 20, x2: 50, y2: 50 }] },
+    });
+    Mask({ fill: 'red', fillOpacity: 0.28 })(context);
+  });
+
+  it('Mask({...}) renders a x-mask component, which only has ew two directions resize handles.', async () => {
+    const context = createContext({
+      width: 100,
+      height: 100,
+      shared: { regions: [{ x1: 20, y1: 0, x2: 40, y2: 100 }] },
+    });
+    Mask({ maskType: 'rectX' })(context);
+  });
+
+  it('Mask({...}) renders a y-mask component, which only has ns two directions resize handles.', async () => {
+    const context = createContext({
+      width: 100,
+      height: 100,
+      shared: { regions: [{ x1: 0, y1: 10, x2: 100, y2: 30 }] },
+    });
+    Mask({ maskType: 'rectY' })(context);
+  });
+
+  it('Mask({...}) renders a polygon mask component, which is relied on shared.points variable.', async () => {
+    const context = createContext({
+      width: 100,
+      height: 100,
+      shared: {
+        points: [
+          [
+            [10, 10],
+            [20, 20],
+            [30, 62],
+            [80, 24],
+          ],
+        ],
+      },
+    });
+    Mask({ maskType: 'polygon' })(context);
+  });
+
+  it('Mask({...}) renders multiple mask components.', async () => {
+    const context = createContext({
+      width: 100,
+      height: 100,
+      shared: {
+        regions: [
+          { x1: 20, y1: 20, x2: 40, y2: 50 },
+          { x1: 60, y1: 42, x2: 80, y2: 60 },
+        ],
+      },
+    });
+    Mask({})(context);
+  });
+});

--- a/__tests__/unit/interaction/builtin/brush.spec.ts
+++ b/__tests__/unit/interaction/builtin/brush.spec.ts
@@ -1,7 +1,7 @@
-import { G2Spec, render } from '../../../src';
-import { createDiv, mount } from '../../utils/dom';
+import { G2Spec, render } from '../../../../src';
+import { createDiv, mount } from '../../../utils/dom';
 
-describe('Brush', () => {
+describe('Interactions of brush', () => {
   it('render({...} renders chart with brushHighlight interaction', () => {
     const chart = render<G2Spec>({
       title: 'BrushHighlight',

--- a/__tests__/unit/interaction/builtin/elementHightlight.spec.ts
+++ b/__tests__/unit/interaction/builtin/elementHightlight.spec.ts
@@ -1,5 +1,5 @@
-import { G2Spec, render } from '../../../src';
-import { createDiv, mount } from '../../utils/dom';
+import { G2Spec, render } from '../../../../src';
+import { createDiv, mount } from '../../../utils/dom';
 
 describe('Interactions of ElementHighlight', () => {
   it('render({...} renders chart with elementHighlight interaction', () => {

--- a/__tests__/unit/interaction/builtin/legend.spec.ts
+++ b/__tests__/unit/interaction/builtin/legend.spec.ts
@@ -1,5 +1,5 @@
-import { G2Spec, render } from '../../../src';
-import { createDiv, mount } from '../../utils/dom';
+import { G2Spec, render } from '../../../../src';
+import { createDiv, mount } from '../../../utils/dom';
 
 describe('Interaction of legend', () => {
   it('render({...} renders chart with legendActive interaction.', () => {

--- a/__tests__/unit/interaction/builtin/tooltip.spec.ts
+++ b/__tests__/unit/interaction/builtin/tooltip.spec.ts
@@ -1,5 +1,5 @@
-import { G2Spec, render } from '../../../src';
-import { createDiv, mount } from '../../utils/dom';
+import { G2Spec, render } from '../../../../src';
+import { createDiv, mount } from '../../../utils/dom';
 
 describe('Interactions of tooltip', () => {
   it('render({...} renders line chart with tooltip interaction', () => {

--- a/__tests__/unit/interaction/helper.ts
+++ b/__tests__/unit/interaction/helper.ts
@@ -1,0 +1,48 @@
+import { Coordinate } from '@antv/coord';
+import { Cartesian } from '../../../src/coordinate';
+import { InteractionContext } from '../../../src/interaction';
+import { Canvas } from '../../../src/renderer';
+import { select } from '../../../src/utils/selection';
+import { createDiv } from '../../utils/dom';
+
+export function createContext({
+  x = 0,
+  y = 0,
+  width = 600,
+  height = 400,
+  transform = [],
+  shared = {},
+}): InteractionContext {
+  const coordinate = new Coordinate({
+    x,
+    y,
+    width,
+    height,
+    transformations: [...transform.flat(), Cartesian()[0]],
+  });
+
+  const canvas = Canvas({ width, height, container: createDiv() });
+  const mainLayer = select(canvas.document.documentElement)
+    .append('rect')
+    .attr('className', 'main');
+  const selectionLayer = select(canvas.document.documentElement)
+    .append('rect')
+    .attr('className', 'selection');
+  const transientLayer = select(canvas.document.documentElement)
+    .append('rect')
+    .attr('className', 'transient');
+  return {
+    scale: {},
+    coordinate,
+    theme: {},
+    markState: new Map(),
+    components: [],
+    layout: {},
+    key: 'id',
+    frame: false,
+    selection: mainLayer,
+    selectionLayer,
+    transientLayer,
+    shared,
+  };
+}

--- a/__tests__/unit/interaction/index.spec.ts
+++ b/__tests__/unit/interaction/index.spec.ts
@@ -1,6 +1,7 @@
 import { InteractionDescriptor as Fisheye } from '../../../src/interaction/builtin/fisheye';
 import { InteractionDescriptor as Tooltip } from '../../../src/interaction/builtin/tooltip';
 import { InteractionDescriptor as ElementActive } from '../../../src/interaction/builtin/elementActive';
+import { InteractionDescriptor as ElementSelected } from '../../../src/interaction/builtin/elementSelected';
 
 describe('interaction', () => {
   it('ElementActive() returns expected defaults', () => {
@@ -21,6 +22,20 @@ describe('interaction', () => {
           action: [
             { type: 'elementSelection' },
             { type: 'activeElement', color: 'red' },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('ElementSelected() returns expected defaults', () => {
+    expect(ElementSelected({ border: 3, color: 'red' })).toEqual({
+      start: [
+        {
+          trigger: 'plot:pointerdown',
+          action: [
+            { type: 'elementSelection', multiple: true, toggle: true },
+            { type: 'activeElement', border: 3, color: 'red' },
           ],
         },
       ],

--- a/__tests__/unit/interaction/stdlib.spec.ts
+++ b/__tests__/unit/interaction/stdlib.spec.ts
@@ -20,6 +20,7 @@ import {
   Cursor as CursorAction,
   RecordCurrentPoint,
   Move,
+  ActiveRegion,
 } from '../../../src/interaction/action';
 import {
   MousePosition,
@@ -49,6 +50,7 @@ describe('createInteractionLibrary', () => {
       'action.mask': Mask,
       'action.button': Button,
       'action.move': Move,
+      'action.activeRegion': ActiveRegion,
       'interactor.mousePosition': MousePosition,
       'interactor.touchPosition': TouchPosition,
     });

--- a/__tests__/unit/stdlib/index.spec.ts
+++ b/__tests__/unit/stdlib/index.spec.ts
@@ -127,6 +127,7 @@ import {
   Brush,
   BrushHighlight,
   BrushVisible,
+  ActiveRegion,
 } from '../../../src/interaction';
 import {
   Layer,
@@ -335,6 +336,7 @@ describe('stdlib', () => {
       'interaction.brush': Brush,
       'interaction.brushHighlight': BrushHighlight,
       'interaction.brushVisible': BrushVisible,
+      'interaction.activeRegion': ActiveRegion,
       'composition.layer': Layer,
       'composition.flex': Flex,
       'composition.keyframe': Keyframe,

--- a/docs/annotation.md
+++ b/docs/annotation.md
@@ -52,6 +52,7 @@ G2.render({
         dy: 30,
         dx: -174,
         fontSize: 10,
+        lineWidth: 0,
         background: {
           fill: '#416180',
           fillOpacity: 0.15,

--- a/docs/interaction-component.md
+++ b/docs/interaction-component.md
@@ -1,0 +1,43 @@
+# Component Interaction
+
+## LegendActive
+
+```js | dom
+G2.render({
+  type: 'interval',
+  data: [
+    { genre: 'Sports', sold: 275, type: 'A' },
+    { genre: 'Strategy', sold: 115, type: 'B' },
+    { genre: 'Action', sold: 120, type: 'C' },
+    { genre: 'Shooter', sold: 350, type: 'D' },
+    { genre: 'Other', sold: 150, type: 'E' },
+  ],
+  encode: {
+    x: 'genre',
+    y: 'sold',
+    color: 'genre',
+  },
+  interaction: [{ type: 'legendActive' }],
+});
+```
+
+## LegendHighlight
+
+```js | dom
+G2.render({
+  type: 'interval',
+  data: [
+    { genre: 'Sports', sold: 275, type: 'A' },
+    { genre: 'Strategy', sold: 115, type: 'B' },
+    { genre: 'Action', sold: 120, type: 'C' },
+    { genre: 'Shooter', sold: 350, type: 'D' },
+    { genre: 'Other', sold: 150, type: 'E' },
+  ],
+  encode: {
+    x: 'genre',
+    y: 'sold',
+    color: 'genre',
+  },
+  interaction: [{ type: 'legendHighlight' }],
+});
+```

--- a/docs/interaction-element.md
+++ b/docs/interaction-element.md
@@ -44,6 +44,91 @@ G2.render({
 });
 ```
 
+## ElementHighlight
+
+```js | dom
+G2.render({
+  type: 'interval',
+  data: [
+    { genre: 'Sports', sold: 275, type: 'A' },
+    { genre: 'Strategy', sold: 115, type: 'B' },
+    { genre: 'Action', sold: 120, type: 'C' },
+    { genre: 'Shooter', sold: 350, type: 'D' },
+    { genre: 'Other', sold: 150, type: 'E' },
+  ],
+  encode: {
+    x: 'genre',
+    y: 'sold',
+    color: 'genre',
+  },
+  interaction: [{ type: 'elementHighlight' }],
+});
+```
+
+## ElementHighlightByX
+
+```js | dom
+G2.render({
+  type: 'interval',
+  data: [
+    { city: 'London', month: 'Jan.', rainfall: 18.9 },
+    { city: 'London', month: 'Feb.', rainfall: 28.8 },
+    { city: 'London', month: 'Mar.', rainfall: 39.3 },
+    { city: 'London', month: 'Apr.', rainfall: 81.4 },
+    { city: 'London', month: 'May', rainfall: 47 },
+    { city: 'London', month: 'Jun.', rainfall: 20.3 },
+    { city: 'London', month: 'Jul.', rainfall: 24 },
+    { city: 'London', month: 'Aug.', rainfall: 35.6 },
+    { city: 'Berlin', month: 'Jan.', rainfall: 12.4 },
+    { city: 'Berlin', month: 'Feb.', rainfall: 23.2 },
+    { city: 'Berlin', month: 'Mar.', rainfall: 34.5 },
+    { city: 'Berlin', month: 'Apr.', rainfall: 99.7 },
+    { city: 'Berlin', month: 'May', rainfall: 52.6 },
+    { city: 'Berlin', month: 'Jun.', rainfall: 35.5 },
+    { city: 'Berlin', month: 'Jul.', rainfall: 37.4 },
+    { city: 'Berlin', month: 'Aug.', rainfall: 42.4 },
+  ],
+  encode: {
+    x: 'month',
+    y: 'rainfall',
+    color: 'city',
+  },
+  interaction: [{ type: 'elementHighlightByX' }],
+});
+```
+
+## ElementHighlightByColor
+
+```js | dom
+G2.render({
+  type: 'interval',
+  data: [
+    { city: 'London', month: 'Jan.', rainfall: 18.9 },
+    { city: 'London', month: 'Feb.', rainfall: 28.8 },
+    { city: 'London', month: 'Mar.', rainfall: 39.3 },
+    { city: 'London', month: 'Apr.', rainfall: 81.4 },
+    { city: 'London', month: 'May', rainfall: 47 },
+    { city: 'London', month: 'Jun.', rainfall: 20.3 },
+    { city: 'London', month: 'Jul.', rainfall: 24 },
+    { city: 'London', month: 'Aug.', rainfall: 35.6 },
+    { city: 'Berlin', month: 'Jan.', rainfall: 12.4 },
+    { city: 'Berlin', month: 'Feb.', rainfall: 23.2 },
+    { city: 'Berlin', month: 'Mar.', rainfall: 34.5 },
+    { city: 'Berlin', month: 'Apr.', rainfall: 99.7 },
+    { city: 'Berlin', month: 'May', rainfall: 52.6 },
+    { city: 'Berlin', month: 'Jun.', rainfall: 35.5 },
+    { city: 'Berlin', month: 'Jul.', rainfall: 37.4 },
+    { city: 'Berlin', month: 'Aug.', rainfall: 42.4 },
+  ],
+  encode: {
+    x: 'month',
+    y: 'rainfall',
+    color: 'city',
+  },
+  interaction: [{ type: 'elementHighlightByColor' }],
+});
+```
+
 ## ElementSelected
 
 **Basic ElementSelected.**
@@ -117,5 +202,61 @@ G2.render({
     color: 'genre',
   },
   interaction: [{ type: 'elementSelected', singleMode: true }],
+});
+```
+
+## ActiveRegion
+
+**Basic activeRegion.**
+
+```js | dom
+G2.render({
+  type: 'interval',
+  data: [
+    { genre: 'Sports', sold: 275, type: 'A' },
+    { genre: 'Strategy', sold: 115, type: 'B' },
+    { genre: 'Action', sold: 120, type: 'C' },
+    { genre: 'Shooter', sold: 350, type: 'D' },
+    { genre: 'Other', sold: 150, type: 'E' },
+  ],
+  encode: {
+    x: 'genre',
+    y: 'sold',
+    color: 'genre',
+  },
+  coordinate: [{ type: 'transpose' }],
+  interaction: [{ type: 'activeRegion' }],
+});
+```
+
+**Series interval with activeRegion.**
+
+```js | dom
+G2.render({
+  type: 'interval',
+  data: [
+    { city: 'London', month: 'Jan.', rainfall: 18.9 },
+    { city: 'London', month: 'Feb.', rainfall: 28.8 },
+    { city: 'London', month: 'Mar.', rainfall: 39.3 },
+    { city: 'London', month: 'Apr.', rainfall: 81.4 },
+    { city: 'London', month: 'May', rainfall: 47 },
+    { city: 'London', month: 'Jun.', rainfall: 20.3 },
+    { city: 'London', month: 'Jul.', rainfall: 24 },
+    { city: 'London', month: 'Aug.', rainfall: 35.6 },
+    { city: 'Berlin', month: 'Jan.', rainfall: 12.4 },
+    { city: 'Berlin', month: 'Feb.', rainfall: 23.2 },
+    { city: 'Berlin', month: 'Mar.', rainfall: 34.5 },
+    { city: 'Berlin', month: 'Apr.', rainfall: 99.7 },
+    { city: 'Berlin', month: 'May', rainfall: 52.6 },
+    { city: 'Berlin', month: 'Jun.', rainfall: 35.5 },
+    { city: 'Berlin', month: 'Jul.', rainfall: 37.4 },
+    { city: 'Berlin', month: 'Aug.', rainfall: 42.4 },
+  ],
+  encode: {
+    x: 'month',
+    y: 'rainfall',
+    color: 'city',
+  },
+  interaction: [{ type: 'activeRegion' }],
 });
 ```

--- a/docs/normalize.md
+++ b/docs/normalize.md
@@ -81,7 +81,18 @@ G2.render({
     { type: 'stackY' },
     { type: 'normalizeY' },
   ],
-  scale: { x: { field: 'Date' } },
+  paddingTop: 72,
+  scale: {
+    x: { field: 'Date' },
+    color: {
+      guide: {
+        size: 72,
+        autoWrap: true,
+        maxRows: 3,
+        cols: 6,
+      },
+    },
+  },
   encode: {
     shape: 'smoothArea',
     x: (d) => new Date(d.date),

--- a/src/component/legendCategory.ts
+++ b/src/component/legendCategory.ts
@@ -45,6 +45,8 @@ export const LegendCategory: GCC<LegendCategoryOptions> = (options) => {
           style: {
             fontSize: 12,
             fillOpacity: 1,
+            fill: '#000',
+            fontWeight: 'lighter',
             active: {
               fillOpacity: 0.8,
             },

--- a/src/interaction/action/index.ts
+++ b/src/interaction/action/index.ts
@@ -42,3 +42,4 @@ export { Cursor, CursorOptions } from './transformer/cursor';
 export { Mask, MaskOptions } from './transformer/mask';
 export { Button, ButtonOptions } from './transformer/button';
 export { Move, MoveOptions } from './transformer/move';
+export { ActiveRegion, ActiveRegionOptions } from './transformer/activeRegion';

--- a/src/interaction/action/transformer/activeRegion.ts
+++ b/src/interaction/action/transformer/activeRegion.ts
@@ -1,0 +1,66 @@
+import { Band as BandScale } from '@antv/scale';
+import { ActionComponent as AC } from '../../types';
+import { ActiveRegionAction } from '../../../spec';
+
+export type ActiveRegionOptions = Omit<ActiveRegionAction, 'type'>;
+
+export const ActiveRegion: AC<ActiveRegionOptions> = (options) => {
+  const { clear, fill = '#CCD6EC', fillOpacity = 0.3 } = options;
+  return (context) => {
+    const { coordinate, event, scale, selection, transientLayer } = context;
+    const scaleX = scale.x as BandScale;
+    // If scale.x is not BandScale, do not show shadow activeRegion.
+    // @todo Maybe should support it, when scale.x is not BandScale.
+    if (!scaleX?.getBandWidth) return context;
+
+    const plot = selection.select('.plot').node();
+    const [x0, y0] = plot.getBounds().min;
+    const { offsetX, offsetY } = event;
+    const [value] = coordinate.invert([offsetX - x0, offsetY - y0]);
+
+    const range = scaleX.getRange();
+
+    const data = [];
+    for (let i = 0; !clear && i < range.length; i++) {
+      const x = range[i];
+      const invertX = scaleX.invert(x);
+      const bandW = scaleX.getBandWidth(invertX);
+      const step = scaleX.getStep(invertX);
+      const gap = (step - bandW) / 2;
+
+      if (value >= x - gap && value < x + bandW + gap) {
+        const w1 = gap;
+        const w2 = bandW + gap;
+        const [x1, y1] = coordinate.map([x - w1, 0]);
+        const [x2, y2] = coordinate.map([x + w2, 1]);
+        data.push({ x: x1, y: y1, width: x2 - x1, height: y2 - y1 });
+        break;
+      }
+    }
+
+    transientLayer
+      .style('zIndex', -1)
+      .selectAll('.active-region')
+      .data(data, (_, i) => i)
+      .join(
+        (enter) =>
+          enter
+            .append('rect')
+            .attr('className', 'active-region')
+            .style('fill', fill)
+            .style('fillOpacity', fillOpacity)
+            .each(function (datum) {
+              this.attr(datum);
+            }),
+        (update) =>
+          update.each(function (datum) {
+            this.attr(datum);
+          }),
+        (exit) => exit.remove(),
+      );
+
+    return context;
+  };
+};
+
+ActiveRegion.props = {};

--- a/src/interaction/action/transformer/activeRegion.ts
+++ b/src/interaction/action/transformer/activeRegion.ts
@@ -9,8 +9,7 @@ export const ActiveRegion: AC<ActiveRegionOptions> = (options) => {
   return (context) => {
     const { coordinate, event, scale, selection, transientLayer } = context;
     const scaleX = scale.x as BandScale;
-    // If scale.x is not BandScale, do not show shadow activeRegion.
-    // @todo Maybe should support it, when scale.x is not BandScale.
+    // If scale.x is not a band scale, do not show shadow activeRegion. @todo Maybe should support it.
     if (!scaleX?.getBandWidth) return context;
 
     const plot = selection.select('.plot').node();

--- a/src/interaction/builtin/activeRegion.ts
+++ b/src/interaction/builtin/activeRegion.ts
@@ -1,0 +1,25 @@
+import { ActiveRegionInteraction } from '../../spec';
+import { createInteraction } from '../create';
+
+export type ActiveRegionOptions = Omit<ActiveRegionInteraction, 'type'>;
+
+export const InteractionDescriptor = (options: ActiveRegionOptions = {}) => {
+  return {
+    start: [
+      {
+        trigger: 'plot:mousemove',
+        action: [{ type: 'activeRegion', ...options }],
+      },
+      {
+        trigger: 'plot:mouseleave',
+        action: [{ type: 'activeRegion', clear: true }],
+      },
+    ],
+  };
+};
+
+export const ActiveRegion = createInteraction<ActiveRegionOptions>(
+  InteractionDescriptor,
+);
+
+ActiveRegion.props = {};

--- a/src/interaction/create.ts
+++ b/src/interaction/create.ts
@@ -107,7 +107,7 @@ function createInteractionContext(
   const transientLayer = selection
     .select('.plot')
     .append('g')
-    .attr('className', 'transparent')
+    .attr('className', 'transient')
     .style('fill', 'transparent');
 
   return {

--- a/src/interaction/index.ts
+++ b/src/interaction/index.ts
@@ -14,4 +14,5 @@ export { LegendHighlight } from './builtin/legendHighlight';
 export { Brush } from './builtin/brush';
 export { BrushHighlight } from './builtin/brushHighlight';
 export { BrushVisible } from './builtin/brushVisible';
+export { ActiveRegion } from './builtin/activeRegion';
 export * from './types';

--- a/src/interaction/stdlib.ts
+++ b/src/interaction/stdlib.ts
@@ -19,6 +19,7 @@ import {
   Mask,
   Button,
   Move,
+  ActiveRegion,
 } from './action';
 import { MousePosition, TouchPosition } from './interactor';
 import { InteractionLibrary } from './types';
@@ -45,6 +46,7 @@ export function createInteractionLibrary(): InteractionLibrary {
     'action.mask': Mask,
     'action.button': Button,
     'action.move': Move,
+    'action.activeRegion': ActiveRegion,
     'interactor.mousePosition': MousePosition,
     'interactor.touchPosition': TouchPosition,
   };

--- a/src/spec/action.ts
+++ b/src/spec/action.ts
@@ -21,7 +21,8 @@ export type Action =
   | RecordRegionAction
   | MaskAction
   | ButtonAction
-  | MoveAction;
+  | MoveAction
+  | ActiveRegionAction;
 
 export type ActionTypes =
   | 'fisheyeFocus'
@@ -44,6 +45,7 @@ export type ActionTypes =
   | 'mask'
   | 'button'
   | 'move'
+  | 'activeRegion'
   | CustomAction;
 
 export type FisheyeFocusAction = {
@@ -162,6 +164,13 @@ export type ButtonAction = {
 
 export type MoveAction = {
   type?: 'move';
+};
+
+export type ActiveRegionAction = {
+  type?: 'activeRegion';
+  clear?: boolean;
+  fill?: string;
+  fillOpacity?: number;
 };
 
 export type CustomAction = {

--- a/src/spec/action.ts
+++ b/src/spec/action.ts
@@ -150,7 +150,7 @@ export type MaskAction = {
 
 export type ButtonAction = {
   type?: 'button';
-  position?: string;
+  position?: 'top-left' | 'top-right';
   text?: string;
   textStyle?: {
     fontSize?: number;
@@ -158,6 +158,7 @@ export type ButtonAction = {
   };
   fill?: string;
   stroke?: string;
+  radius?: number;
   padding?: number[];
   hide?: boolean;
 };

--- a/src/spec/interaction.ts
+++ b/src/spec/interaction.ts
@@ -1,5 +1,5 @@
 import { InteractionComponent } from '../runtime';
-import { TooltipAction } from './action';
+import { ActiveRegionAction, TooltipAction } from './action';
 import { FisheyeCoordinate } from './coordinate';
 
 export type Interaction =
@@ -16,6 +16,7 @@ export type Interaction =
   | BrushInteraction
   | BrushHighlightInteraction
   | BrushVisibleInteraction
+  | ActiveRegionInteraction
   | CustomInteraction;
 
 export type InteractionTypes =
@@ -31,6 +32,7 @@ export type InteractionTypes =
   | 'brushHighlight'
   | 'brushVisible'
   | 'fisheye'
+  | 'activeRegion'
   | InteractionComponent;
 
 export type BrushInteraction = {
@@ -95,6 +97,10 @@ export type TooltipInteraction = Omit<TooltipAction, 'type'> & {
 export type FisheyeInteraction = {
   type?: 'fisheye';
 } & Omit<FisheyeCoordinate, 'type'>;
+
+export type ActiveRegionInteraction = {
+  type?: 'activeRegion';
+} & Omit<ActiveRegionAction, 'type' | 'clear'>;
 
 export type CustomInteraction = {
   type?: InteractionComponent;

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -121,6 +121,7 @@ import {
   Brush,
   BrushHighlight,
   BrushVisible,
+  ActiveRegion,
 } from '../interaction';
 import {
   Layer,
@@ -328,6 +329,7 @@ export function createLibrary(): G2Library {
     'interaction.brush': Brush,
     'interaction.brushHighlight': BrushHighlight,
     'interaction.brushVisible': BrushVisible,
+    'interaction.activeRegion': ActiveRegion,
     'composition.layer': Layer,
     'composition.flex': Flex,
     'composition.mark': Mark,


### PR DESCRIPTION
### News

- **feat(interactions):** implement `ActiveRegion` interaction with `ActiveRegion` transformer action (with the same name), which is only supported when x scale is a band scale.

```ts
export const InteractionDescriptor = (options: ActiveRegionOptions = {}) => {
  return {
    start: [
      {
        trigger: 'plot:mousemove',
        action: [{ type: 'activeRegion', ...options }],
      },
      {
        trigger: 'plot:mouseleave',
        action: [{ type: 'activeRegion', clear: true }],
      },
    ],
  };
};
```

### Demo

**Active region in transpose coordinate.**
<img width="638" alt="image" src="https://user-images.githubusercontent.com/15646325/180790258-1d339e71-5f80-4064-91d9-16840d98c515.png">

**Active region with flex band scale and custom options.**

<img width="646" alt="image" src="https://user-images.githubusercontent.com/15646325/180790614-4735f172-228e-42a5-99be-711c830272cc.png">

```ts
G2.render({
  type: "interval",
  data: [
    { genre: "Sports", sold: 275 },
    { genre: "Strategy", sold: 115 },
    { genre: "Action", sold: 120 },
    { genre: "Shooter", sold: 350 },
    { genre: "Other", sold: 150 },
  ],
  scale: {
    x: { flex: [2, 3, 1, 4, 2] },
  },
  encode: {
    x: "genre",
    y: "sold",
    color: "genre",
  },
  interaction: [{ type: "activeRegion", fill: "red" }],
});
```


