### PR TITLE
feat(interaction): implement ellipsisText interaction

### DIFF
--- a/__tests__/unit/interaction/stdlib.spec.ts
+++ b/__tests__/unit/interaction/stdlib.spec.ts
@@ -21,6 +21,8 @@ import {
   RecordCurrentPoint,
   Move,
   ActiveRegion,
+  Poptip,
+  RecordTip,
 } from '../../../src/interaction/action';
 import {
   MousePosition,
@@ -36,12 +38,14 @@ describe('createInteractionLibrary', () => {
       'action.recordPoint': RecordPoint,
       'action.recordCurrentPoint': RecordCurrentPoint,
       'action.recordRegion': RecordRegion,
+      'action.recordTip': RecordTip,
       'action.activeElement': ActiveElement,
       'action.highlightElement': HighlightElement,
       'action.legendItemSelection': LegendItemSelection,
       'action.triggerInfoSelection': TriggerInfoSelection,
       'action.setItemState': SetItemStateAction,
       'action.tooltip': Tooltip,
+      'action.poptip': Poptip,
       'action.fisheyeFocus': FisheyeFocus,
       'action.plot': Plot,
       'action.filter': Filter,

--- a/__tests__/unit/stdlib/index.spec.ts
+++ b/__tests__/unit/stdlib/index.spec.ts
@@ -128,6 +128,7 @@ import {
   BrushHighlight,
   BrushVisible,
   ActiveRegion,
+  EllipsisText,
 } from '../../../src/interaction';
 import {
   Layer,
@@ -330,6 +331,7 @@ describe('stdlib', () => {
       'interaction.elementHighlightByColor': ElementHighlightByColor,
       'interaction.elementListHighlight': ElementListHighlight,
       'interaction.tooltip': Tooltip,
+      'interaction.ellipsisText': EllipsisText,
       'interaction.fisheye': FisheyeInteraction,
       'interaction.legendActive': LegendActive,
       'interaction.legendHighlight': LegendHighlight,

--- a/docs/interaction-more.md
+++ b/docs/interaction-more.md
@@ -212,3 +212,46 @@ G2.render({
   interaction: [{ type: 'brushVisible' }],
 });
 ```
+
+## EllipsisText with custom options
+
+```js | dom
+G2.render({
+  type: 'area',
+  transform: [
+    {
+      type: 'fetch',
+      url: 'https://gw.alipayobjects.com/os/bmw-prod/e58c9758-0a09-4527-aa90-fbf175b45925.json',
+    },
+    { type: 'stackY' },
+    { type: 'normalizeY' },
+  ],
+  paddingTop: 72,
+  scale: {
+    x: { field: 'Date' },
+    color: {
+      guide: {
+        size: 72,
+        autoWrap: true,
+        maxRows: 3,
+        cols: 6,
+      },
+    },
+  },
+  width: 700,
+  interaction: [
+    {
+      type: 'ellipsisText',
+      x: 576,
+      y: 30,
+      htmlStyle: 'max-width:120px;overflow:hidden;',
+    },
+  ],
+  encode: {
+    shape: 'smoothArea',
+    x: (d) => new Date(d.date),
+    y: 'unemployed',
+    color: 'industry',
+  },
+});
+```

--- a/src/component/title.ts
+++ b/src/component/title.ts
@@ -18,9 +18,9 @@ type TitleStyleProps = {
 };
 
 const Title = createComponent<TitleStyleProps>({
-  render(attributes, context) {
+  render(attributes, container) {
     const { text, style, subtitle, subtitleStyle } = attributes;
-    const title = maybeAppend(context, '.title', 'text')
+    const title = maybeAppend(container, '.title', 'text')
       .attr('className', 'title')
       .style('fontSize', 14)
       .style('textBaseline', 'top')
@@ -29,7 +29,7 @@ const Title = createComponent<TitleStyleProps>({
       .node();
 
     const bounds = title.getLocalBounds();
-    maybeAppend(context, '.sub-title', 'text')
+    maybeAppend(container, '.sub-title', 'text')
       .attr('className', 'sub-title')
       .style('y', bounds.max[1] + (subtitleStyle?.spacing || 0))
       .style('fontSize', 12)

--- a/src/component/utils.ts
+++ b/src/component/utils.ts
@@ -3,7 +3,7 @@ import { deepMix } from '@antv/util';
 import { select, Selection, G2Element } from '../utils/selection';
 
 type Descriptor<T> = {
-  render?: (attributes: T, context: CustomElement<T>) => void;
+  render?: (attributes: T, container: CustomElement<T>) => void;
 };
 
 export function createComponent<T>(descriptor: Descriptor<T>): any {

--- a/src/interaction/action/index.ts
+++ b/src/interaction/action/index.ts
@@ -43,3 +43,5 @@ export { Mask, MaskOptions } from './transformer/mask';
 export { Button, ButtonOptions } from './transformer/button';
 export { Move, MoveOptions } from './transformer/move';
 export { ActiveRegion, ActiveRegionOptions } from './transformer/activeRegion';
+export { RecordTip } from './service/recordTip';
+export { Poptip } from './transformer/poptip';

--- a/src/interaction/action/service/recordTip.ts
+++ b/src/interaction/action/service/recordTip.ts
@@ -1,0 +1,20 @@
+import { ActionComponent as AC } from '../../types';
+import { RecordTipAction } from '../../../spec';
+
+export type RecordTipOptions = Omit<RecordTipAction, 'type'>;
+
+/**
+ * If target shape has tip attributes, store in shared variables.
+ * User specified options have more higher priority.
+ */
+export const RecordTip: AC<RecordTipOptions> = (options) => {
+  const { tip } = options;
+  return (context) => {
+    const { shared, event } = context;
+    const { target } = event;
+    shared.tip = tip ?? target.style.tip;
+    return context;
+  };
+};
+
+RecordTip.props = {};

--- a/src/interaction/action/transformer/button.ts
+++ b/src/interaction/action/transformer/button.ts
@@ -9,10 +9,10 @@ export type ButtonOptions = Omit<ButtonAction, 'type'>;
 type ButtonPosition = ButtonOptions['position'];
 
 const ButtonComponent = createComponent<ButtonOptions>({
-  render(attributes, context) {
+  render(attributes, container) {
     const { text, textStyle, fill, stroke, padding = [], radius } = attributes;
     const [pt, pr = pt, pb = pt, pl = pr] = padding;
-    const textShape = maybeAppend(context, '.button-text', 'text')
+    const textShape = maybeAppend(container, '.button-text', 'text')
       .attr('className', 'button-text')
       .style('x', pl)
       .style('y', pt + (textStyle.fontSize || 12) / 2)
@@ -28,7 +28,7 @@ const ButtonComponent = createComponent<ButtonOptions>({
     const { min, halfExtents } = textShape.getLocalBounds();
     const width = halfExtents[0] * 2;
     const height = halfExtents[1] * 2;
-    maybeAppend(context, '.button-rect', 'rect')
+    maybeAppend(container, '.button-rect', 'rect')
       .attr('className', 'button-rect')
       .style('x', min[0] - pl)
       .style('y', min[1] - pt)

--- a/src/interaction/action/transformer/poptip.ts
+++ b/src/interaction/action/transformer/poptip.ts
@@ -1,0 +1,50 @@
+import { HTML } from '@antv/g';
+import { maybeAppend } from '../../../component/utils';
+import { ActionComponent as AC } from '../../types';
+import { PoptipAction } from '../../../spec';
+
+export type PoptipOptions = Omit<PoptipAction, 'type'>;
+
+const getInnerHTML = (content = '', style = '') => `<div style="
+background-color:rgba(0,0,0,0.75);color:#fff;width:max-content;padding:4px;font-size:12px;border-radius:2.5px;
+box-shadow:0 3px 6px -4px rgba(0,0,0,0.12), 0 6px 16px 0 rgba(0,0,0,0.08), 0 9px 28px 8px rgba(0,0,0,0.05);${
+  style || ''
+}
+">${content || ''}</div>`;
+
+export const Poptip: AC<PoptipOptions> = (options = {}) => {
+  const { htmlStyle } = options;
+  return (context) => {
+    const { transientLayer, selection, shared } = context;
+    const { mouseX, mouseY, tip: content } = shared;
+
+    const plot = selection.select('.plot').node();
+    const [x1, y1] = plot.getBounds().min;
+    const [offsetX, offsetY] = [8, 8];
+    let x = mouseX - x1 + offsetX;
+    let y = mouseY - y1 + offsetY;
+    if (options.x !== undefined) x = options.x - x1;
+    if (options.y !== undefined) y = options.y - y1;
+
+    maybeAppend(
+      transientLayer.node(),
+      '.tip-popover',
+      () =>
+        new HTML({
+          className: 'tip-popover',
+          style: {
+            innerHTML: getInnerHTML('', htmlStyle),
+            visibility: 'hidden',
+          },
+        }),
+    )
+      .style('x', x)
+      .style('y', y)
+      .style('innerHTML', getInnerHTML(content, htmlStyle))
+      .style('visibility', content ? 'visible' : 'hidden');
+
+    return context;
+  };
+};
+
+Poptip.props = {};

--- a/src/interaction/builtin/ellipsisText.ts
+++ b/src/interaction/builtin/ellipsisText.ts
@@ -1,0 +1,24 @@
+import { EllipsisTextInteraction } from '../../spec';
+import { createInteraction } from '../create';
+
+export type EllipsisTextOptions = Omit<EllipsisTextInteraction, 'type'>;
+
+export const InteractionDescriptor = (options?: EllipsisTextOptions) => ({
+  start: [
+    {
+      trigger: 'mousemove',
+      throttle: { wait: 50, leading: true, trailing: false },
+      action: [
+        { type: 'surfacePointSelection' },
+        { type: 'recordTip' },
+        { type: 'poptip', ...options },
+      ],
+    },
+  ],
+});
+
+export const EllipsisText = createInteraction<EllipsisTextOptions>(
+  InteractionDescriptor,
+);
+
+EllipsisText.props = {};

--- a/src/interaction/create.ts
+++ b/src/interaction/create.ts
@@ -1,4 +1,3 @@
-import { DisplayObject } from '@antv/g';
 import { group } from 'd3-array';
 import { throttle } from '@antv/util';
 import { G2ViewInstance, InteractionComponent as IC } from '../runtime';
@@ -75,13 +74,18 @@ export function createInteraction<T>(
         // Bind low-level events with composed action.
         const events = interactorEvent.get(trigger) || [[trigger]];
         for (const [event] of events) {
-          const [className, eventName] = event.split(':');
-          selection.selectAll(`.${className}`).on(eventName, (event) => {
-            const ctx = { event, ...context };
-            if (isEnable(ctx)) {
-              handler(ctx);
-            }
-          });
+          const [className, eventName] = (event as string).includes(':')
+            ? (event as string).split(':')
+            : [null, event];
+          (className ? selection.selectAll(`.${className}`) : selection).on(
+            eventName,
+            (event) => {
+              const ctx = { event, ...context };
+              if (isEnable(ctx)) {
+                handler(ctx);
+              }
+            },
+          );
         }
       }
     };

--- a/src/interaction/index.ts
+++ b/src/interaction/index.ts
@@ -15,4 +15,5 @@ export { Brush } from './builtin/brush';
 export { BrushHighlight } from './builtin/brushHighlight';
 export { BrushVisible } from './builtin/brushVisible';
 export { ActiveRegion } from './builtin/activeRegion';
+export { EllipsisText } from './builtin/ellipsisText';
 export * from './types';

--- a/src/interaction/stdlib.ts
+++ b/src/interaction/stdlib.ts
@@ -20,6 +20,8 @@ import {
   Button,
   Move,
   ActiveRegion,
+  RecordTip,
+  Poptip,
 } from './action';
 import { MousePosition, TouchPosition } from './interactor';
 import { InteractionLibrary } from './types';
@@ -47,6 +49,8 @@ export function createInteractionLibrary(): InteractionLibrary {
     'action.button': Button,
     'action.move': Move,
     'action.activeRegion': ActiveRegion,
+    'action.recordTip': RecordTip,
+    'action.poptip': Poptip,
     'interactor.mousePosition': MousePosition,
     'interactor.touchPosition': TouchPosition,
   };

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -754,8 +754,12 @@ function inferTheme(theme: G2ThemeOptions = { type: 'light' }): G2ThemeOptions {
 function inferInteraction(
   interaction: G2InteractionOptions[] = [],
 ): G2InteractionOptions[] {
-  if (interaction.find((d) => d.type === 'tooltip')) return interaction;
-  return [...interaction, { type: 'tooltip' }];
+  const interactions = [...interaction];
+  ['tooltip', 'ellipsisText'].forEach((type) => {
+    if (!interaction.find((d) => d.type === type)) interactions.push({ type });
+  });
+
+  return interactions;
 }
 
 async function applyTransform<T extends G2ViewTree>(

--- a/src/spec/action.ts
+++ b/src/spec/action.ts
@@ -15,6 +15,8 @@ export type Action =
   | FilterAction
   | CursorAction
   | TooltipAction
+  | RecordTipAction
+  | PoptipAction
   | RecordPointAction
   | RecordCurrentPointAction
   | RecordStateAction
@@ -38,6 +40,8 @@ export type ActionTypes =
   | 'filter'
   | 'cursor'
   | 'tooltip'
+  | 'recordTip'
+  | 'poptip'
   | 'recordState'
   | 'recordPoint'
   | 'recordCurrentPoint'
@@ -172,6 +176,19 @@ export type ActiveRegionAction = {
   clear?: boolean;
   fill?: string;
   fillOpacity?: number;
+};
+
+export type RecordTipAction = {
+  type?: 'recordTip';
+  tip?: string;
+};
+
+export type PoptipAction = {
+  type?: 'poptip';
+  // x,y position. If not specified, using mouseX and mouseY position from shared variables.
+  x?: number;
+  y?: number;
+  htmlStyle?: string;
 };
 
 export type CustomAction = {

--- a/src/spec/interaction.ts
+++ b/src/spec/interaction.ts
@@ -1,5 +1,5 @@
 import { InteractionComponent } from '../runtime';
-import { ActiveRegionAction, TooltipAction } from './action';
+import { ActiveRegionAction, PoptipAction, TooltipAction } from './action';
 import { FisheyeCoordinate } from './coordinate';
 
 export type Interaction =
@@ -17,6 +17,7 @@ export type Interaction =
   | BrushHighlightInteraction
   | BrushVisibleInteraction
   | ActiveRegionInteraction
+  | EllipsisTextInteraction
   | CustomInteraction;
 
 export type InteractionTypes =
@@ -33,6 +34,7 @@ export type InteractionTypes =
   | 'brushVisible'
   | 'fisheye'
   | 'activeRegion'
+  | 'ellipsisText'
   | InteractionComponent;
 
 export type BrushInteraction = {
@@ -101,6 +103,10 @@ export type FisheyeInteraction = {
 export type ActiveRegionInteraction = {
   type?: 'activeRegion';
 } & Omit<ActiveRegionAction, 'type' | 'clear'>;
+
+export type EllipsisTextInteraction = {
+  type?: 'ellipsisText';
+} & Omit<PoptipAction, 'type'>;
 
 export type CustomInteraction = {
   type?: InteractionComponent;

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -122,6 +122,7 @@ import {
   BrushHighlight,
   BrushVisible,
   ActiveRegion,
+  EllipsisText,
 } from '../interaction';
 import {
   Layer,
@@ -330,6 +331,7 @@ export function createLibrary(): G2Library {
     'interaction.brushHighlight': BrushHighlight,
     'interaction.brushVisible': BrushVisible,
     'interaction.activeRegion': ActiveRegion,
+    'interaction.ellipsisText': EllipsisText,
     'composition.layer': Layer,
     'composition.flex': Flex,
     'composition.mark': Mark,


### PR DESCRIPTION
### News

**feat(interaction):** implement `ellipsisText` interaction [[Design docs](https://www.yuque.com/antv/g2-docs/interaction-plan#UNJV1)]
- add `recordTip` as a service action to store tip attribute
- add `poptip` as a transformer` action to show a poptip component


### InteractionDescriptor

```ts
export const InteractionDescriptor = (options?: EllipsisTextOptions) => ({
  start: [
    {
      trigger: 'mousemove',
      throttle: { wait: 50, leading: true, trailing: false },
      action: [
        { type: 'surfacePointSelection' },
        { type: 'recordTip' },
        { type: 'poptip', ...options },
      ],
    },
  ],
});
```

### Demo

#### Default (builtin)

<img width="695" alt="image" src="https://user-images.githubusercontent.com/15646325/181735544-1688c10b-89ec-4e06-a19d-3127d12cb438.png">

#### EllipsisText with custom options

<img width="714" alt="image" src="https://user-images.githubusercontent.com/15646325/181735695-bb4d2434-8279-4b0a-8074-e70dd8a1c1b2.png">

```ts
G2.render({
  type: 'area',
  transform: [
    {
      type: 'fetch',
      url: 'https://gw.alipayobjects.com/os/bmw-prod/e58c9758-0a09-4527-aa90-fbf175b45925.json',
    },
    { type: 'stackY' },
    { type: 'normalizeY' },
  ],
  paddingTop: 72,
  scale: {
    x: { field: 'Date' },
    color: {
      guide: {
        size: 72,
        autoWrap: true,
        maxRows: 3,
        cols: 6,
      },
    },
  },
  width: 700,
  interaction: [
    {
      type: 'ellipsisText',
      x: 576,
      y: 30,
      htmlStyle: 'max-width:120px;overflow:hidden;',
    },
  ],
  encode: {
    shape: 'smoothArea',
    x: (d) => new Date(d.date),
    y: 'unemployed',
    color: 'industry',
  },
});
```
