### PR TITLE
chore(website): update genji to 0.1.0 and adjust the outline

### DIFF
--- a/.genjirc
+++ b/.genjirc
@@ -2,7 +2,8 @@
   "title": "G2 5.0",
   "outline": {
     "Overview": "overview",
-    "Dimension": "dimension",
+    "Layout": "dimension",
+    "Data": "data",
     "Transform": {
       "Stack": "stack",
       "Dodge": "dodge",
@@ -12,20 +13,19 @@
       "Select": "select",
       "Group": "group"
     },
-    "Encode": "encode",
-    "Scale": "scale",
-    "Coordinate": "coordinate",
-    "Geometry": {
+    "Mark": {
       "Interval": "interval",
       "Point": "point",
       "Line": "line",
       "Area": "area",
       "Text": "text",
       "Grid": "grid",
-      "Vector": "vector"
+      "Vector": "vector",
+      "Annotation": "annotation",
+      "Component": "component"
     },
-    "Annotation": "annotation",
-    "Adjust": "adjust",
+    "Scale": "scale",
+    "Coordinate": "coordinate",
     "Animation": "animation",
     "Interaction": {
       "Element": "interaction-element",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^7.22.0",
     "eslint-plugin-import": "^2.22.1",
-    "genji-notebook": "^0.0.11",
+    "genji-notebook": "^0.1.0",
     "husky": "^7.0.0",
     "jest": "^26.0.1",
     "jest-electron": "^0.1.12",


### PR DESCRIPTION
Update genji-notebook to 0.1.0 to support interactive notebook and adjust the outline as follows: 

![image](https://user-images.githubusercontent.com/49330279/182320581-bad591f6-2b3a-454b-9a9e-1166c6a42be6.png)
