### PR TITLE
 fix(legend-highlight): reset highlighting after legend filter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -609,7 +609,7 @@ registerInteraction('legend-visible-filter', {
     { trigger: 'legend-item:mouseenter', action: 'cursor:pointer' },
     { trigger: 'legend-item:mouseleave', action: 'cursor:default' },
   ],
-  start: [{ trigger: 'legend-item:click', action: ['list-unchecked:toggle', 'element-filter:filter'] }],
+  start: [{ trigger: 'legend-item:click', action: ['legend-item-highlight:reset', 'element-highlight:reset', 'list-unchecked:toggle', 'element-filter:filter'] }],
 });
 
 // 出现背景框

--- a/src/index.ts
+++ b/src/index.ts
@@ -576,7 +576,7 @@ registerInteraction('legend-filter', {
       isEnable: (context) => {
         return !context.isInShape('legend-item-radio');
       },
-      action: ['list-unchecked:toggle', 'data-filter:filter', 'list-radio:show'],
+      action: ['legend-item-highlight:reset', 'element-highlight:reset', 'list-unchecked:toggle', 'data-filter:filter', 'list-radio:show'],
     },
     //  正反选数据: 只有当 radio === truthy 的时候才会有 legend-item-radio 这个元素
     {


### PR DESCRIPTION
#### 问题

close #3896。
因为click事件改变了 unchecked 状态，然后再触发 legend-highlight 的 mouseleave 而 ListHighlight 当 unchecked 的时候会忽略，所以没有改变回来。

#### 如何解决的

在 unchecked:toogle 之前，加上了 highlight:reset 相关动作。

#### 修改前

![image](https://user-images.githubusercontent.com/25214319/183291743-e140581f-104e-43bc-afd8-262bb4944192.png)

#### 修改后

![image](https://user-images.githubusercontent.com/25214319/183291792-84f2439e-9674-4a3e-a49c-e3cacb89edea.png)

