### PR TITLE
fix: transform and guide

### DIFF
--- a/src/component/axis.ts
+++ b/src/component/axis.ts
@@ -311,6 +311,7 @@ const LinearAxis: GCC<AxisOptions> = (options) => {
       tickLine = true,
     } = inferPosition(position, bbox, coordinate);
     const ticks = getTicks(scale, domain, formatter, position, coordinate);
+    const anchor = scale.getTicks ? titlePosition : 'center';
 
     const guideOptions = scale.getOptions().guide || {};
     // Display axis grid for non-discrete values.
@@ -351,8 +352,13 @@ const LinearAxis: GCC<AxisOptions> = (options) => {
             title && {
               title: {
                 content: Array.isArray(field) ? field[0] : field,
-                titleAnchor: scale.getTicks ? titlePosition : 'center',
-                style: { fontWeight: 'bold', fillOpacity: 1, dy: titleOffsetY },
+                titleAnchor: anchor,
+                style: {
+                  fontWeight: 'bold',
+                  fillOpacity: 1,
+                  dy: titleOffsetY,
+                  textAnchor: anchor,
+                },
                 titlePadding,
                 rotate: titleRotate,
               },

--- a/src/interaction/action/transformer/tooltip.ts
+++ b/src/interaction/action/transformer/tooltip.ts
@@ -241,12 +241,13 @@ function getMarkerPoint(datum: any, scale, coordinate): [number, number] {
   const Y = valuesByDim(datum, 'y');
 
   const { x: scaleX } = scale;
-  const sumX = X.reduce(
-    (r, x) => r + x + (scaleX.getBandWidth?.(scaleX.invert(x)) || 0) / 2,
-    0,
-  );
+  const sumX = X.reduce((r, x) => r + x + bandWidth(scaleX, x) / 2, 0);
 
   return coordinate.map([sumX / X.length, Math.min.apply(null, Y)]);
+}
+
+function bandWidth(scale, x): number {
+  return scale?.getBandWidth?.(scale.invert(x)) || 0;
 }
 
 /**
@@ -299,9 +300,7 @@ function getTooltipData(
   const invertCoordX = coordinate.invert([pointX, pointY])[0];
   const closestPoint = least(
     data,
-    ({ datum: { x } }) =>
-      (x + (scaleX.getBandWidth?.(scaleX.invert(x)) || 0) / 2 - invertCoordX) **
-      2,
+    ({ datum: { x } }) => (x + bandWidth(scaleX, x) / 2 - invertCoordX) ** 2,
   );
 
   if (!closestPoint) return null;
@@ -345,6 +344,7 @@ export type TooltipOptions = Omit<TooltipAction, 'type'>;
 
 /**
  * @todo Using the color(fill or stroke) attribute of each
+ * @todo Add tooltip for parallel coordinate
  * shape as the item.
  */
 export const Tooltip: AC<TooltipOptions> = (options) => {

--- a/src/transform/statistic/select.ts
+++ b/src/transform/statistic/select.ts
@@ -9,7 +9,7 @@ export type SelectOptions = Omit<SelectTransform, 'type'>;
 type SelectorFunction = (I: number[], V: number[]) => number[];
 
 function first(I: number[], V: number[]): number[] {
-  return [0];
+  return [I[0]];
 }
 
 function last(I: number[], V: number[]): number[] {


### PR DESCRIPTION
- selectFirst return the first index for each series.
- set textAnchor for axis.
-  tooltip throw an error in parallel coordinates for undefined x scale.

|Before      |After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/49330279/184347463-b65e2066-0694-43bf-906b-1e72f74f4a56.png)    | ![image](https://user-images.githubusercontent.com/49330279/184347868-c78f0ba5-3ac2-434d-8310-5fca5976426a.png)     |




