### PR TITLE
fix(annotation): do not pass className to children

### DIFF
--- a/src/shape/annotation/badge.ts
+++ b/src/shape/annotation/badge.ts
@@ -66,7 +66,8 @@ class BadgeShape extends CustomElement<BadgeShapeStyleProps> {
   }
 
   private drawMarker() {
-    const { size = 24, ...style } = this.attributes;
+    // Do not pass className to children.
+    const { class: className, size = 24, ...style } = this.attributes;
     const symbol = () => getPath(size / 2);
 
     this.badgeMarker = this.badgeMarker || this.appendChild(new Marker({}));

--- a/src/shape/annotation/text.ts
+++ b/src/shape/annotation/text.ts
@@ -86,6 +86,8 @@ class TextShape extends CustomElement<TextShapeStyleProps> {
 
   private drawText() {
     const {
+      // Do not pass className.
+      class: className,
       connector,
       startMarker,
       endMarker,


### PR DESCRIPTION
Custom shape do not pass className to children, otherwise it will be unexpected select as elements.
