### PR TITLE
fix(label): 修复 webworker 执行多条任务时 label 渲染混乱问题

### DIFF
--- a/src/geometry/label/util/createWorker.ts
+++ b/src/geometry/label/util/createWorker.ts
@@ -1,5 +1,39 @@
+import { isFunction } from '@antv/util';
+
+class MyWorker {
+  queue: any[] = [];
+  worker: Worker;
+
+  constructor(url) {
+    this.worker = new Worker(url);
+    this.worker.onmessage = (e: MessageEvent) => {
+      this.queue.shift()?.resolve(e);
+    };
+    this.worker.onmessageerror = (e: MessageEvent) => {
+      console.warn('[AntV G2] Web worker is not available');
+      this.queue.shift()?.reject(e);
+    };
+  }
+
+  post(params, onError?: () => any): Promise<MessageEvent> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ resolve, reject });
+      try {
+        this.worker.postMessage(params);
+      } catch (e) {
+        console.warn('[AntV G2] Web worker is not available');
+        isFunction(onError) && onError();
+      }
+    });
+  }
+
+  destroy() {
+    this.worker.terminate();
+  }
+}
+
 export function createWorker(f: any) {
-  if (typeof window === "undefined") return;
+  if (typeof window === 'undefined') return;
 
   let blob;
   try {
@@ -11,5 +45,5 @@ export function createWorker(f: any) {
     blob = blob.getBlob();
   }
 
-  return new Worker(URL.createObjectURL(blob));
+  return new MyWorker(URL.createObjectURL(blob));
 }


### PR DESCRIPTION
### Description
问题描述：web workers 执行多条任务时，返回结果混乱，导致 label 渲染出错。
解决方法：添加同步 queue 队列，将 worker 的执行结果推送到队列，将顺序 worker 任务结果。


| Before UI   | After UI  |
|  ----  | ----  |
| ![iShot_2022-08-16_11 44 10](https://user-images.githubusercontent.com/109653633/184793546-25dad661-8d7b-4534-ae37-2ac5aa356443.gif)  | ![iShot_2022-08-16_11 39 54](https://user-images.githubusercontent.com/109653633/184793109-86f531d3-9af4-4a99-93f4-c39add9f2522.gif) |

