### PR TITLE
fix: use attributes from style instead of parsed style

### DIFF
--- a/__tests__/unit/animation/scaleInX.spec.ts
+++ b/__tests__/unit/animation/scaleInX.spec.ts
@@ -22,9 +22,9 @@ describe('ScaleInX', () => {
       'scale(0.0001, 1)',
       'scale(1, 1)',
     ]);
-    expect(keyframes(animation, 'fillOpacity')).toEqual([0, 1, undefined]);
-    expect(keyframes(animation, 'strokeOpacity')).toEqual([0, 1, undefined]);
-    expect(keyframes(animation, 'opacity')).toEqual([0, 1, undefined]);
+    expect(keyframes(animation, 'fillOpacity')).toEqual([0, '', undefined]);
+    expect(keyframes(animation, 'strokeOpacity')).toEqual([0, '', undefined]);
+    expect(keyframes(animation, 'opacity')).toEqual([0, '', undefined]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.01, null]);
 
     await (animation as Animation).finished;

--- a/__tests__/unit/animation/scaleInY.spec.ts
+++ b/__tests__/unit/animation/scaleInY.spec.ts
@@ -22,9 +22,9 @@ describe('ScaleInY', () => {
       'scale(1, 0.0001)',
       'scale(1, 1)',
     ]);
-    expect(keyframes(animation, 'fillOpacity')).toEqual([0, 1, undefined]);
-    expect(keyframes(animation, 'strokeOpacity')).toEqual([0, 1, undefined]);
-    expect(keyframes(animation, 'opacity')).toEqual([0, 1, undefined]);
+    expect(keyframes(animation, 'fillOpacity')).toEqual([0, '', undefined]);
+    expect(keyframes(animation, 'strokeOpacity')).toEqual([0, '', undefined]);
+    expect(keyframes(animation, 'opacity')).toEqual([0, '', undefined]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.01, null]);
 
     await (animation as Animation).finished;

--- a/__tests__/unit/animation/scaleOutX.spec.ts
+++ b/__tests__/unit/animation/scaleOutX.spec.ts
@@ -22,9 +22,9 @@ describe('ScaleOutX', () => {
       'scale(0.0001, 1)',
       'scale(0.0001, 1)',
     ]);
-    expect(keyframes(animation, 'fillOpacity')).toEqual([undefined, 1, 0]);
-    expect(keyframes(animation, 'strokeOpacity')).toEqual([undefined, 1, 0]);
-    expect(keyframes(animation, 'opacity')).toEqual([undefined, 1, 0]);
+    expect(keyframes(animation, 'fillOpacity')).toEqual([undefined, '', 0]);
+    expect(keyframes(animation, 'strokeOpacity')).toEqual([undefined, '', 0]);
+    expect(keyframes(animation, 'opacity')).toEqual([undefined, '', 0]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.99, null]);
 
     await (animation as Animation).finished;

--- a/__tests__/unit/animation/scaleOutY.spec.ts
+++ b/__tests__/unit/animation/scaleOutY.spec.ts
@@ -22,9 +22,9 @@ describe('ScaleOutY', () => {
       'scale(1, 0.0001)',
       'scale(1, 0.0001)',
     ]);
-    expect(keyframes(animation, 'fillOpacity')).toEqual([undefined, 1, 0]);
-    expect(keyframes(animation, 'strokeOpacity')).toEqual([undefined, 1, 0]);
-    expect(keyframes(animation, 'opacity')).toEqual([undefined, 1, 0]);
+    expect(keyframes(animation, 'fillOpacity')).toEqual([undefined, '', 0]);
+    expect(keyframes(animation, 'strokeOpacity')).toEqual([undefined, '', 0]);
+    expect(keyframes(animation, 'opacity')).toEqual([undefined, '', 0]);
     expect(keyframes(animation, 'offset')).toEqual([null, 0.99, null]);
 
     await (animation as Animation).finished;

--- a/package.json
+++ b/package.json
@@ -103,9 +103,9 @@
   },
   "dependencies": {
     "@antv/coord": "^0.4.1",
-    "@antv/g": "^5.0.20",
-    "@antv/g-canvas": "^1.0.13",
-    "@antv/g-plugin-dragndrop": "^1.5.1",
+    "@antv/g": "^5.7.4",
+    "@antv/g-canvas": "^1.7.4",
+    "@antv/g-plugin-dragndrop": "^1.6.1",
     "@antv/gui": "^0.4.3-alpha.5",
     "@antv/scale": "^0.4.7",
     "@antv/util": "^2.0.17",

--- a/src/animation/fadeIn.ts
+++ b/src/animation/fadeIn.ts
@@ -10,16 +10,14 @@ export type FadeInOptions = Animation;
 export const FadeIn: AC<FadeInOptions> = (options) => {
   return (from, to, value, coordinate, defaults) => {
     const [shape] = from;
-    // shape.animate() can not process `opacity = ""`;
-    // todo: When G's bug fixed, modify to `shape.style`.
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
+    const { fillOpacity, strokeOpacity, opacity } = shape.style;
 
     const keyframes = [
       { fillOpacity: 0, strokeOpacity: 0, opacity: 0 },
       {
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
+        fillOpacity,
+        strokeOpacity,
+        opacity,
       },
     ];
 

--- a/src/animation/fadeOut.ts
+++ b/src/animation/fadeOut.ts
@@ -10,12 +10,12 @@ export type FadeOutOptions = Animation;
 export const FadeOut: AC<FadeOutOptions> = (options) => {
   return (from, to, value, coordinate, defaults) => {
     const [shape] = from;
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
+    const { fillOpacity, strokeOpacity, opacity } = shape.style;
     const keyframes = [
       {
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
+        fillOpacity,
+        strokeOpacity,
+        opacity,
       },
       { fillOpacity: 0, strokeOpacity: 0, opacity: 0 },
     ];

--- a/src/animation/morphing.ts
+++ b/src/animation/morphing.ts
@@ -158,15 +158,14 @@ function multipleToOne(
   split: SplitFunction,
 ) {
   const D = split(to, from.length);
-  // @todo Replace with to.style.
-  const { fillOpacity, strokeOpacity, opacity } = to.parsedStyle;
+  const { fillOpacity, strokeOpacity, opacity } = to.style;
   const keyframes = [
     { fillOpacity: 0, strokeOpacity: 0, opacity: 0 },
     { fillOpacity: 0, strokeOpacity: 0, opacity: 0, offset: 0.99 },
     {
-      fillOpacity: fillOpacity.value,
-      strokeOpacity: strokeOpacity.value,
-      opacity: opacity.value,
+      fillOpacity,
+      strokeOpacity,
+      opacity,
     },
   ];
   const animation = to.animate(keyframes, timeEffect);

--- a/src/animation/scaleInX.ts
+++ b/src/animation/scaleInX.ts
@@ -16,8 +16,12 @@ export const ScaleInX: AC<ScaleInXOptions> = (options) => {
   return (from, to, value, coordinate, defaults) => {
     const [shape] = from;
     const { height } = shape.getBoundingClientRect();
-    const { transform: prefix } = shape.style;
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
+    const {
+      transform: prefix,
+      fillOpacity,
+      strokeOpacity,
+      opacity,
+    } = shape.style;
     const [transformOrigin, transform]: [[number, number], string] =
       isTranspose(coordinate)
         ? [[0, height], `scale(1, ${ZERO})`] // left-bottom corner
@@ -34,9 +38,9 @@ export const ScaleInX: AC<ScaleInXOptions> = (options) => {
       },
       {
         transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
+        fillOpacity,
+        strokeOpacity,
+        opacity,
         offset: 0.01,
       },
       {

--- a/src/animation/scaleInY.ts
+++ b/src/animation/scaleInY.ts
@@ -16,8 +16,12 @@ export const ScaleInY: AC<ScaleInYOptions> = (options) => {
   return (from, to, value, coordinate, defaults) => {
     const [shape] = from;
     const { height } = shape.getBoundingClientRect();
-    const { transform: prefix } = shape.style;
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
+    const {
+      transform: prefix,
+      fillOpacity,
+      strokeOpacity,
+      opacity,
+    } = shape.style;
     const [transformOrigin, transform]: [[number, number], string] =
       isTranspose(coordinate)
         ? [[0, 0], `scale(${ZERO}, 1)`] // left-top corner
@@ -34,9 +38,9 @@ export const ScaleInY: AC<ScaleInYOptions> = (options) => {
       },
       {
         transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
+        fillOpacity,
+        strokeOpacity,
+        opacity,
         offset: 0.01,
       },
       {

--- a/src/animation/scaleOutX.ts
+++ b/src/animation/scaleOutX.ts
@@ -16,8 +16,12 @@ export const ScaleOutX: AC<ScaleOutXOptions> = (options) => {
   return (from, to, value, coordinate, defaults) => {
     const [shape] = from;
     const { height } = shape.getBoundingClientRect();
-    const { transform: prefix } = shape.style;
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
+    const {
+      transform: prefix,
+      fillOpacity,
+      strokeOpacity,
+      opacity,
+    } = shape.style;
     const [transformOrigin, transform]: [[number, number], string] =
       isTranspose(coordinate)
         ? [[0, height], `scale(1, ${ZERO})`] // left-bottom corner
@@ -31,9 +35,9 @@ export const ScaleOutX: AC<ScaleOutXOptions> = (options) => {
       },
       {
         transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
+        fillOpacity,
+        strokeOpacity,
+        opacity,
         offset: 0.99,
       },
       {

--- a/src/animation/scaleOutY.ts
+++ b/src/animation/scaleOutY.ts
@@ -16,8 +16,12 @@ export const ScaleOutY: AC<ScaleOutYOptions> = (options) => {
   return (from, to, value, coordinate, defaults) => {
     const [shape] = from;
     const { height } = shape.getBoundingClientRect();
-    const { transform: prefix } = shape.style;
-    const { fillOpacity, strokeOpacity, opacity } = shape.parsedStyle;
+    const {
+      transform: prefix,
+      fillOpacity,
+      strokeOpacity,
+      opacity,
+    } = shape.style;
     const [transformOrigin, transform]: [[number, number], string] =
       isTranspose(coordinate)
         ? [[0, 0], `scale(${ZERO}, 1)`] // left-top corner
@@ -31,9 +35,9 @@ export const ScaleOutY: AC<ScaleOutYOptions> = (options) => {
       },
       {
         transform: `${prefix} ${transform}`.trimStart(),
-        fillOpacity: fillOpacity.value,
-        strokeOpacity: strokeOpacity.value,
-        opacity: opacity.value,
+        fillOpacity,
+        strokeOpacity,
+        opacity,
         offset: 0.99,
       },
       {


### PR DESCRIPTION
和 CSS 保持一致，动画 keyframe 内支持使用 `''` 作为属性值，其含义等同于`unset`，因此无需从 `parsedStyle` 中获取。
```js
const {
  fillOpacity,
  strokeOpacity,
  opacity,
} = shape.style;
// = shape.parsedStyle

{
  fillOpacity,
  strokeOpacity,
  opacity,
  offset: 0.99,
},
```