### PR TITLE
fix(api): do not clone the value of node when mapping

### DIFF
--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -199,6 +199,16 @@ describe('Chart', () => {
     });
   });
 
+  it('chart.options() should handle date object', () => {
+    const chart = new Chart({});
+    const date = new Date();
+    chart.grid().data([{ date }]);
+    expect(chart.options()).toEqual({
+      type: 'view',
+      children: [{ type: 'grid', data: [{ date }] }],
+    });
+  });
+
   it('chart.nodeName() should build view tree', () => {
     const chart = new Chart();
     chart.interval();

--- a/__tests__/unit/api/node.spec.ts
+++ b/__tests__/unit/api/node.spec.ts
@@ -57,7 +57,7 @@ describe('Node', () => {
     expect(node.children[1]).toBe(n2);
   });
 
-  it('node.call(callback) should apply specified callback to a new cloned node.', () => {
+  it('node.call(callback) should apply specified callback to the node.', () => {
     const node = new Node({ a: 1 });
     const n1 = node.call((node) => {
       node.attr('a', 2);

--- a/src/api/chart.ts
+++ b/src/api/chart.ts
@@ -40,9 +40,8 @@ function normalizeRoot(node: Node) {
 }
 
 function valueOf(node: Node): Record<string, any> {
-  const value = clone(node.value);
   return {
-    ...value,
+    ...node.value,
     type: node.type,
   };
 }

--- a/src/api/node.ts
+++ b/src/api/node.ts
@@ -29,19 +29,18 @@ export class Node<
   }
 
   /**
-   * Apply specified transform to current value and clone a new node.
-   * Mount the cloned node to replace the original one in the tree
-   * and then return it.
+   * Apply specified transform to current value. Mount the node
+   * to replace the original one in the tree and then return it.
    */
   map(transform = (x: Value): Value => x): this {
-    const newValue = transform(clone(this.value));
+    const newValue = transform(this.value as Value);
     this.value = newValue;
     return this;
   }
 
   /**
    * Set or get the specified attribute. It the value is specified, update
-   * the attribute of current value and return a new cloned node. Otherwise
+   * the attribute of current value and return the node. Otherwise
    * return the the attribute of current value.
    */
   attr<T extends Value[keyof Value]>(
@@ -67,7 +66,7 @@ export class Node<
   }
 
   /**
-   * Apply specified callback to a new cloned node.
+   * Apply specified callback to the node value.
    */
   call(
     callback: (node: this, ...params: any[]) => any,


### PR DESCRIPTION
**Bug**

```js
const chart = new Chart({});
const date = new Date();
chart.grid().data([{ date }]);

// Expected 
chart.data(); // [{ date }]

// Received
chart.data(); // [{ date: {} }]
```

**Reason**

To make the chart options immutable, it will use the `clone` of @antv/util every time the options change. But `clone` fail to clone Date object.

```js
import { clone } from '@antv/util';

const date = new Date();
clone({date}); // { date: {} }
```

**Solution**

Remove the clone operation. It is unnecessary to mark the options immutable because it makes no sense to clone data every time. 