### PR TITLE
fix: call destroy & removeChild separately

### DIFF
--- a/src/shape/annotation/text.ts
+++ b/src/shape/annotation/text.ts
@@ -111,8 +111,11 @@ class TextShape extends CustomElement<TextShapeStyleProps> {
   private drawBackground() {
     const { background } = this.style;
     if (!background) {
-      this.background && this.removeChild(this.background, true);
-      this.background = undefined;
+      if (this.background) {
+        this.removeChild(this.background);
+        this.background.destroy();
+        this.background = undefined;
+      }
       return;
     }
 
@@ -138,8 +141,12 @@ class TextShape extends CustomElement<TextShapeStyleProps> {
   private drawConnector() {
     const { connector } = this.style;
     if (!connector) {
-      this.connector && this.removeChild(this.connector, true);
-      this.connector = undefined;
+      if (this.connector) {
+        this.removeChild(this.connector);
+        this.connector.destroy();
+        this.connector = undefined;
+      }
+
       return;
     }
 
@@ -163,7 +170,10 @@ class TextShape extends CustomElement<TextShapeStyleProps> {
   private drawStartMarker(style?: MarkerStyleProps) {
     const shape = this.startMarkerPoint;
     if (!style) {
-      shape && this.removeChild(shape, true);
+      if (shape) {
+        this.removeChild(shape);
+        shape.destroy();
+      }
       this.startMarkerPoint = undefined;
       return;
     }
@@ -178,7 +188,10 @@ class TextShape extends CustomElement<TextShapeStyleProps> {
   private drawEndMarker(style?: MarkerStyleProps) {
     const shape = this.endMarkerPoint;
     if (!style) {
-      shape && this.removeChild(shape, true);
+      if (shape) {
+        this.removeChild(shape);
+        shape.destroy();
+      }
       this.endMarkerPoint = undefined;
       return;
     }


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

1. It's RECOMMENDED to submit PR for typo or tiny bug fix.
2. If this's a FEATURE request, please provide: details, pseudo codes if necessary.
3. If this's a BUG, please provide: course repetition, error log and configuration. Fill in as much of the template below as you're able.
4. It will be nice to use to provide a CodePen Link which can reproduce the issue, we provide a CodePen template [g2-github-issue](https://codepen.io/leungwensen/pen/WXJgox).

感谢您向我们反馈问题。

1. 提交问题前，请先阅读 README 中的贡献帮助文档。
2. 我们推荐如果是小问题（错别字修改，小的 bug fix）直接提交 PR。
3. 如果是一个新需求，请提供：详细需求描述，最好是有伪代码实现。
4. 如果是一个 BUG，请提供：复现步骤，错误日志以及相关配置，并尽量填写下面的模板中的条目。
5. 如果可以，请提供尽可能精简的 CodePen 链接，可使用 CodePen 模板 https://codepen.io/leungwensen/pen/WXJgox，方便我们排查问题。
6. 扩展阅读：[如何向开源项目提交无法解答的问题](https://zhuanlan.zhihu.com/p/25795393)
-->

与 DOM API 保持一致，`removeChild()` 仅移除元素（便于后续加回），如需销毁需要调用 `destroy()`。

<!-- Enter your issue details below this comment. -->