### PR TITLE
fix: use custom transition instead of morphing in wavein animation

### DIFF
--- a/__tests__/integration/charts/population2015-interval-pie.ts
+++ b/__tests__/integration/charts/population2015-interval-pie.ts
@@ -33,5 +33,11 @@ export function population2015IntervalPie(): G2Spec {
         dy: '0.75em',
       },
     ],
+    animate: {
+      enter: {
+        type: 'waveIn',
+        duration: 1000,
+      },
+    },
   };
 }

--- a/src/animation/waveIn.ts
+++ b/src/animation/waveIn.ts
@@ -40,21 +40,22 @@ export const WaveIn: AC<WaveInOptions> = (options) => {
     const path = arc().cornerRadius(radius as number);
     const arcObject = getArcObject(coordinate, points, [y, y1]);
     const { startAngle, endAngle } = arcObject;
+    const pathForConversion = new Path({});
 
     const createArcPath = (arcParams: {
       startAngle: number;
       endAngle: number;
       innerRadius: number;
       outerRadius: number;
-    }) =>
-      convertToPath(
-        new Path({
-          style: {
-            d: path(arcParams),
-            transform: `translate(${center[0]}, ${center[1]})`,
-          },
-        }),
-      );
+    }) => {
+      pathForConversion.attr({
+        d: path(arcParams),
+        transform: `translate(${center[0]}, ${center[1]})`,
+      });
+      const convertedPathDefinition = convertToPath(pathForConversion);
+      pathForConversion.style.transform = 'none';
+      return convertedPathDefinition;
+    };
 
     const keyframes = [
       // Use custom interpolable CSS property.

--- a/src/animation/waveIn.ts
+++ b/src/animation/waveIn.ts
@@ -6,6 +6,7 @@ import { Animation } from '../spec';
 import { getArcObject } from '../shape/utils';
 import { isPolar } from '../utils/coordinate';
 import { effectTiming } from './utils';
+import { ScaleInX } from './scaleInX';
 
 export type WaveInOptions = Animation;
 
@@ -28,7 +29,7 @@ export const WaveIn: AC<WaveInOptions> = (options) => {
     const [shape] = from;
 
     if (!isPolar(coordinate)) {
-      return shape.animate([]);
+      return ScaleInX(options)(from, to, value, coordinate, defaults);
     }
 
     const center = coordinate.getCenter();

--- a/src/animation/waveIn.ts
+++ b/src/animation/waveIn.ts
@@ -1,70 +1,88 @@
 import { arc } from 'd3-shape';
-import { Linear } from '@antv/scale';
-import { convertToPath, Path } from '@antv/g';
-import { G2Element, select } from '../utils/selection';
+import { Path, CSS, PropertySyntax, convertToPath } from '@antv/g';
+import { G2Element } from '../utils/selection';
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from '../spec';
 import { getArcObject } from '../shape/utils';
 import { isPolar } from '../utils/coordinate';
-import { attributeKeys, attributeOf, effectTiming } from './utils';
-import { ScaleInX } from './scaleInX';
+import { effectTiming } from './utils';
 
-export type WaveInOptions = Animation & {
-  /** Count of keyframe animations */
-  frameCount?: number;
-};
+export type WaveInOptions = Animation;
 
 /**
  * Transform mark from transparent to solid.
  */
 export const WaveIn: AC<WaveInOptions> = (options) => {
   const ZERO = 0.0001;
-  const { frameCount = 10 } = options;
+
+  // @see https://g-next.antv.vision/zh/docs/api/css/css-properties-values-api#%E8%87%AA%E5%AE%9A%E4%B9%89%E5%B1%9E%E6%80%A7
+  CSS.registerProperty({
+    name: 'waveInArcAngle',
+    inherits: false,
+    initialValue: '',
+    interpolable: true,
+    syntax: PropertySyntax.NUMBER,
+  });
 
   return (from, to, value, coordinate, defaults) => {
     const [shape] = from;
 
-    // Animation reuse scaleInX in the cartesian coordinate.
     if (!isPolar(coordinate)) {
-      ScaleInX(options)(from, to, value, coordinate, defaults);
-      return shape.animate([], effectTiming(defaults, value, options));
+      return shape.animate([]);
     }
 
     const center = coordinate.getCenter();
     const { __data__, style } = shape as G2Element;
-    const { radius = 0, transform } = style;
+    const { radius = 0 } = style;
     const { points, y, y1 } = __data__;
-    const attributes = attributeOf(shape, attributeKeys);
 
     const path = arc().cornerRadius(radius as number);
     const arcObject = getArcObject(coordinate, points, [y, y1]);
     const { startAngle, endAngle } = arcObject;
-    const createArcPath = (arcParams) =>
+
+    const createArcPath = (arcParams: {
+      startAngle: number;
+      endAngle: number;
+      innerRadius: number;
+      outerRadius: number;
+    }) =>
       convertToPath(
-        select(new Path({}))
-          .style('path', path(arcParams))
-          .style('transform', `translate(${center[0]}, ${center[1]})`)
-          .node(),
+        new Path({
+          style: {
+            d: path(arcParams),
+            transform: `translate(${center[0]}, ${center[1]})`,
+          },
+        }),
       );
 
-    const x = new Linear({
-      domain: [0, frameCount - 1],
-      range: [startAngle + ZERO, endAngle],
-    });
+    const keyframes = [
+      // Use custom interpolable CSS property.
+      {
+        waveInArcAngle: startAngle + ZERO,
+      },
+      {
+        waveInArcAngle: endAngle,
+      },
+    ];
+    const animation = shape.animate(
+      keyframes,
+      effectTiming(defaults, value, options),
+    );
 
-    /**
-     * TODO: Use this method of creating new Path temporarily.
-     * Reason: Keyframe transform does not take effect when it has path.
-     */
-    const keyframes = Array.from({ length: frameCount }, (_, i) => ({
-      path: createArcPath({
+    animation.onframe = function () {
+      shape.style.path = createArcPath({
         ...arcObject,
-        endAngle: x.map(i),
-      }),
-      ...attributes,
-    }));
+        endAngle: Number(shape.style.waveInArcAngle),
+      });
+    };
+    animation.onfinish = function () {
+      shape.style.path = createArcPath({
+        ...arcObject,
+        endAngle: endAngle,
+      });
+    };
 
-    return shape.animate(keyframes, effectTiming(defaults, value, options));
+    return animation;
   };
 };
 


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

1. It's RECOMMENDED to submit PR for typo or tiny bug fix.
2. If this's a FEATURE request, please provide: details, pseudo codes if necessary.
3. If this's a BUG, please provide: course repetition, error log and configuration. Fill in as much of the template below as you're able.
4. It will be nice to use to provide a CodePen Link which can reproduce the issue, we provide a CodePen template [g2-github-issue](https://codepen.io/leungwensen/pen/WXJgox).

感谢您向我们反馈问题。

1. 提交问题前，请先阅读 README 中的贡献帮助文档。
2. 我们推荐如果是小问题（错别字修改，小的 bug fix）直接提交 PR。
3. 如果是一个新需求，请提供：详细需求描述，最好是有伪代码实现。
4. 如果是一个 BUG，请提供：复现步骤，错误日志以及相关配置，并尽量填写下面的模板中的条目。
5. 如果可以，请提供尽可能精简的 CodePen 链接，可使用 CodePen 模板 https://codepen.io/leungwensen/pen/WXJgox，方便我们排查问题。
6. 扩展阅读：[如何向开源项目提交无法解答的问题](https://zhuanlan.zhihu.com/p/25795393)
-->

<!-- Enter your issue details below this comment. -->

`waveIn` 并不是一种形变动画，至少它对于过程中的效果有严格要求，例如固定扇形的圆心。因此使用 `onframe` 回调配合可插值的自定义属性来实现比较合适。

* 自定义属性注册：https://g-next.antv.vision/zh/docs/api/css/css-properties-values-api#%E8%87%AA%E5%AE%9A%E4%B9%89%E5%B1%9E%E6%80%A7
* animation 对象的 `onframe` 回调：https://g-next.antv.vision/zh/docs/api/animation#onframe

效果类似：https://g-next.antv.vision/zh/examples/ecosystem#d3-piechart

![Oct-08-2022 13-50-14](https://user-images.githubusercontent.com/3608471/194691361-bf0fa04a-57b8-45c7-93ea-4e5fdd51ff7b.gif)
