### PR TITLE
docs(chore): add sketchy radial & line chart

### DIFF
--- a/site/examples/others/theme/demo/meta.json
+++ b/site/examples/others/theme/demo/meta.json
@@ -26,7 +26,7 @@
         "zh": "手绘风格的饼图",
         "en": "Sketchy Raidal Chart"
       },
-      "screenshot": "https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*kHhLTIDArKIAAAAAAAAAAAAADmJ7AQ"
+      "screenshot": "https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*kJuuQ47YUicAAAAAAAAAAAAADmJ7AQ"
     },
     {
       "filename": "rough-line.ts",

--- a/site/examples/others/theme/demo/meta.json
+++ b/site/examples/others/theme/demo/meta.json
@@ -19,6 +19,22 @@
         "en": "Sketchy Bar Chart"
       },
       "screenshot": "https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*-A5CR4gpOX8AAAAAAAAAAAAADmJ7AQ"
+    },
+    {
+      "filename": "rough-radial.ts",
+      "title": {
+        "zh": "手绘风格的饼图",
+        "en": "Sketchy Raidal Chart"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*kHhLTIDArKIAAAAAAAAAAAAADmJ7AQ"
+    },
+    {
+      "filename": "rough-line.ts",
+      "title": {
+        "zh": "手绘风格的折线图",
+        "en": "Sketchy Line Chart"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*erkgSbo9OdMAAAAAAAAAAAAADmJ7AQ"
     }
   ]
 }

--- a/site/examples/others/theme/demo/rough-line.ts
+++ b/site/examples/others/theme/demo/rough-line.ts
@@ -1,0 +1,37 @@
+import { Chart } from '@antv/g2';
+import { Plugin } from '@antv/g-plugin-rough-canvas-renderer';
+import WebFont from 'webfontloader';
+
+WebFont.load({
+  google: {
+    families: ['Gaegu'],
+  },
+  active: () => {
+    const chart = new Chart({
+      container: 'container',
+      autoFit: true,
+      plugins: [new Plugin()],
+    });
+
+    chart
+      .line()
+      .data({
+        type: 'fetch',
+        value:
+          'https://gw.alipayobjects.com/os/bmw-prod/cb99c4ab-e0a3-4c76-9586-fe7fa2ff1a8c.csv',
+      })
+      .transform({ type: 'groupX', y: 'mean' })
+      .encode('x', (d) => new Date(d.date).getFullYear())
+      .encode('y', 'price')
+      .encode('color', 'symbol')
+      .label({
+        text: 'price',
+        fontSize: 10,
+        fontFamily: 'Gaegu',
+        transform: [{ type: 'dodgeY' }],
+      })
+      .style('roughness', 2);
+
+    chart.render();
+  },
+});

--- a/site/examples/others/theme/demo/rough-radial.ts
+++ b/site/examples/others/theme/demo/rough-radial.ts
@@ -25,10 +25,8 @@ WebFont.load({
       })
       .encode('y', 'value')
       .encode('color', 'name')
-      .style('stroke', 'white')
-      .style('strokeWidth', '4')
-      .style('fillStyle', (_, index) => {
-        return [
+      .scale('color', {
+        range: [
           'hachure',
           'solid',
           'zigzag',
@@ -36,8 +34,12 @@ WebFont.load({
           'dots',
           'dashed',
           'zigzag-line',
-        ][index % 7];
+        ],
       })
+      .style('fill', 'black')
+      .style('stroke', 'black')
+      .style('strokeWidth', '4')
+      .style('colorAttribute', 'fillStyle')
       .legend(false)
       .label({
         text: 'name',
@@ -46,6 +48,7 @@ WebFont.load({
         fontWeight: 'bold',
         fontFamily: 'Gaegu',
         fill: 'black',
+        stroke: 'white',
       })
       .label({
         text: (d, i, data) => (i < data.length - 3 ? d.value : ''),
@@ -53,6 +56,7 @@ WebFont.load({
         fontSize: 12,
         fontFamily: 'Gaegu',
         fill: 'black',
+        stroke: 'white',
         dy: '0.75em',
       });
 

--- a/site/examples/others/theme/demo/rough-radial.ts
+++ b/site/examples/others/theme/demo/rough-radial.ts
@@ -1,0 +1,61 @@
+import { Chart } from '@antv/g2';
+import { Plugin } from '@antv/g-plugin-rough-canvas-renderer';
+import WebFont from 'webfontloader';
+
+WebFont.load({
+  google: {
+    families: ['Gaegu'],
+  },
+  active: () => {
+    const chart = new Chart({
+      container: 'container',
+      height: 480,
+      plugins: [new Plugin()],
+    });
+
+    chart.coordinate({ type: 'theta' });
+
+    chart
+      .interval()
+      .transform({ type: 'stackY' })
+      .data({
+        type: 'fetch',
+        value:
+          'https://gw.alipayobjects.com/os/bmw-prod/79fd9317-d2af-4bc4-90fa-9d07357398fd.csv',
+      })
+      .encode('y', 'value')
+      .encode('color', 'name')
+      .style('stroke', 'white')
+      .style('strokeWidth', '4')
+      .style('fillStyle', (_, index) => {
+        return [
+          'hachure',
+          'solid',
+          'zigzag',
+          'cross-hatch',
+          'dots',
+          'dashed',
+          'zigzag-line',
+        ][index % 7];
+      })
+      .legend(false)
+      .label({
+        text: 'name',
+        radius: 0.8,
+        fontSize: 10,
+        fontWeight: 'bold',
+        fontFamily: 'Gaegu',
+        fill: 'black',
+      })
+      .label({
+        text: (d, i, data) => (i < data.length - 3 ? d.value : ''),
+        radius: 0.8,
+        fontSize: 12,
+        fontFamily: 'Gaegu',
+        fill: 'black',
+        dy: '0.75em',
+      });
+
+    chart.render();
+  },
+});

--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,7 @@
     "preview": "dumi preview"
   },
   "dependencies": {
-    "@antv/dumi-theme-antv": "^0.3.0-beta.5",
+    "@antv/dumi-theme-antv": "0.3.0-beta.14",
     "@antv/g-plugin-rough-canvas-renderer": "^1.7.27",
     "@antv/g-plugin-a11y": "^0.4.27",
     "d3-array": "^3.2.0",

--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,7 @@
     "preview": "dumi preview"
   },
   "dependencies": {
-    "@antv/dumi-theme-antv": "0.3.0-beta.14",
+    "@antv/dumi-theme-antv": "^0.3.0-beta.5",
     "@antv/g-plugin-rough-canvas-renderer": "^1.7.27",
     "@antv/g-plugin-a11y": "^0.4.27",
     "d3-array": "^3.2.0",


### PR DESCRIPTION
饼图中包含大面积填充的图形适合使用 `fillStyle`，起到类似纹理的作用，适合无障碍中的报纸打印需求。目前支持的填充样式详见 [文档](https://github.com/antvis/G/blob/next/packages/site/docs/plugins/rough-canvas-renderer.zh.md#fillstyle)
可以通过 `roughness` 参数（[文档](https://github.com/antvis/G/blob/next/packages/site/docs/plugins/rough-canvas-renderer.zh.md#roughness)）调节手绘风格度，但折线图感觉不太适合过度风格化。

<img width="446" alt="截屏2022-11-14 下午4 19 12" src="https://user-images.githubusercontent.com/3608471/201610164-44910714-3634-458e-b7ee-bc4c3f766254.png">

<img width="689" alt="截屏2022-11-14 下午3 37 00" src="https://user-images.githubusercontent.com/3608471/201602391-f9c770fb-4d52-4c58-b6d5-7ab212bad9f8.png">
