### PR TITLE
docs: add vector api

### DIFF
--- a/site/docs/api/common/style.en.md
+++ b/site/docs/api/common/style.en.md
@@ -1,0 +1,1 @@
+<embed src="@/docs/api/common/style.zh.md"></embed>

--- a/site/docs/api/common/style.zh.md
+++ b/site/docs/api/common/style.zh.md
@@ -1,0 +1,18 @@
+---
+desc: 通用的 G shape 属性样式
+---
+
+| 属性            | 描述                                           | 类型                 | 默认值      |
+|----------------|------------------------------------------------|---------------------|------------|
+| fill          | 图形的填充色                                                   | `string`          |   -   |
+| fillOpacity   | 图形的填充透明度                                                | `number`          |   -   |
+| stroke        | 图形的描边                                                     | `string`          |   -   |
+| lineWidth     | 图形描边的宽度                                                  | `number`          |   -   |
+| lineDash      | 描边的虚线配置，第一个值为虚线每个分段的长度，第二个值为分段间隔的距离。lineDash 设为[0,0]的效果为没有描边。 | `[number,number]` |   -   |
+| lineOpacity   | 描边透明度                                                      | `number`          |   -   |
+| opacity       | 图形的整体透明度                                                 | `number`          |   -   |
+| shadowColor   | 图形阴影颜色                                                    | `string`          |   -   |
+| shadowBlur    | 图形阴影的高斯模糊系数                                            | `number`          |   -   |
+| shadowOffsetX | 设置阴影距图形的水平距离                                          | `number`          |   -   |
+| shadowOffsetY | 设置阴影距图形的垂直距离                                          | `number`          |   -   |
+| cursor        | 鼠标样式。同 css 的鼠标样式，默认 'default'。                      | `string`          |   `default`  |

--- a/site/docs/api/mark/interval.en.md
+++ b/site/docs/api/mark/interval.en.md
@@ -1,5 +1,5 @@
 ---
-title: Interval
+title: interval
 order: 1
 ---
 

--- a/site/docs/api/mark/interval.zh.md
+++ b/site/docs/api/mark/interval.zh.md
@@ -1,5 +1,5 @@
 ---
-title: Interval
+title: interval
 order: 1
 ---
 

--- a/site/docs/api/mark/vector.en.md
+++ b/site/docs/api/mark/vector.en.md
@@ -1,0 +1,6 @@
+---
+title: vector
+order: 1
+---
+
+<embed src="@/docs/api/mark/vector.zh.md"></embed>

--- a/site/docs/api/mark/vector.zh.md
+++ b/site/docs/api/mark/vector.zh.md
@@ -1,0 +1,90 @@
+---
+title: vector
+order: 1
+---
+
+Vector 图形是将数据映射成为`箭头`的样式去可视化展示，通过控制箭头的位置、大小、颜色、角度等信息，去可视化一些向量场数据。它具备有以下视觉通道：
+
+- `x`：水平方向的位置，对 x 轴刻度对应
+- `y`：垂直方向的位置，对 y 轴刻度对应，位置锚点定位为箭头的中心
+- `color`：箭头的颜色
+- `size`：箭头的长度
+- `rotate`：箭头的旋转角度，起始角度为直角坐标系中的 `右边`，旋转方向为 `顺时针`
+
+Vector 图形标记会将数据通过上述通道映射成向量数据：`[start, end]`。
+
+<img src="https://gw.alipayobjects.com/zos/antfincdn/c9nPWlX5Au/vector.png" width="300" />
+
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*5NgBQYJrTUEAAAAAAAAAAAAADmJ7AQ/fmt.webp" width="600" />
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+});
+
+chart
+  .vector()
+  .data({
+    type: 'fetch',
+    value: 'https://gw.alipayobjects.com/os/antfincdn/F5VcgnqRku/wind.json',
+  })
+  .encode('x', 'longitude')
+  .encode('y', 'latitude')
+  .encode('rotate', ({ u, v }) => (Math.atan2(v, u) * 180) / Math.PI)
+  .encode('size', ({ u, v }) => Math.hypot(v, u))
+  .encode('color', ({ u, v }) => Math.hypot(v, u))
+  .scale('size', { range: [6, 20] })
+  .scale('color', { type: 'sequential', palette: 'viridis' })
+  .axis('x', { grid: false })
+  .axis('y', { grid: false })
+  .legend(false);
+
+chart.render();
+```
+
+更多的案例，可以查看[图表示例](/examples)页面。
+
+## 选项
+
+目前仅有一种同名的图形 `vector`，下面描述一下所有的 `style` 配置项。
+
+### vector
+
+| 属性            | 描述                                           | 类型                 | 默认值      |
+|----------------|------------------------------------------------|---------------------|------------|
+| arrowSize      | 箭头图标的大小，可以指定像素值、也可以指定箭头长度的相对值。          | `string` \| `number`  | '40%'      |
+| fill          | 图形的填充色                                                   | `string`          |   -   |
+| fillOpacity   | 图形的填充透明度                                                | `number`          |   -   |
+| stroke        | 图形的描边                                                     | `string`          |   -   |
+| lineWidth     | 图形描边的宽度                                                  | `number`          |   -   |
+| lineDash      | 描边的虚线配置，第一个值为虚线每个分段的长度，第二个值为分段间隔的距离。lineDash 设为[0, 0]的效果为没有描边。 | `[number,number]` |   -   |
+| lineOpacity   | 描边透明度                                                      | `number`          |   -   |
+| opacity       | 图形的整体透明度                                                 | `number`          |   -   |
+| shadowColor   | 图形阴影颜色                                                    | `string`          |   -   |
+| shadowBlur    | 图形阴影的高斯模糊系数                                            | `number`          |   -   |
+| shadowOffsetX | 设置阴影距图形的水平距离                                          | `number`          |   -   |
+| shadowOffsetY | 设置阴影距图形的垂直距离                                          | `number`          |   -   |
+| cursor        | 鼠标样式。同 css 的鼠标样式，默认 'default'。                      | `string`          |   'default'  |
+
+## FAQ
+
+- 怎么指定箭头图标的长度？
+
+有两种指定箭头图标长度的方式，一种是通过填写像素值，比如 `40`，来指定为固定长度；另外一种是通过指定一个百分比，比如 `30%`，来指定参考箭头长度的相对长度。默认值为 `40%`。如下示例：
+
+```ts
+chart
+  .vector()
+  // ...
+  .shape('vector')
+  .style({
+    arrowSize: 40,
+    // arrowSize: '30%',
+  });
+```

--- a/site/docs/api/mark/vector.zh.md
+++ b/site/docs/api/mark/vector.zh.md
@@ -13,12 +13,12 @@ Vector 图形是将数据映射成为`箭头`的样式去可视化展示，通�
 
 Vector 图形标记会将数据通过上述通道映射成向量数据：`[start, end]`。
 
-<img src="https://gw.alipayobjects.com/zos/antfincdn/c9nPWlX5Au/vector.png" width="300" />
+<img alt="vector" src="https://gw.alipayobjects.com/zos/antfincdn/c9nPWlX5Au/vector.png" width="300" />
 
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*5NgBQYJrTUEAAAAAAAAAAAAADmJ7AQ/fmt.webp" width="600" />
+<img alt="wind vector" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*5NgBQYJrTUEAAAAAAAAAAAAADmJ7AQ/fmt.webp" width="600" />
 
 ```ts
 import { Chart } from '@antv/g2';

--- a/site/docs/api/mark/vector.zh.md
+++ b/site/docs/api/mark/vector.zh.md
@@ -18,7 +18,7 @@ Vector 图形标记会将数据通过上述通道映射成向量数据：`[start
 
 ## 开始使用
 
-<img alt="wind vector" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*5NgBQYJrTUEAAAAAAAAAAAAADmJ7AQ/fmt.webp" width="600" />
+<img alt="wind vector" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*6fDIT50ZKnEAAAAAAAAAAAAADmJ7AQ/fmt.webp" width="600" />
 
 ```ts
 import { Chart } from '@antv/g2';

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -22,7 +22,7 @@ G2 是一个简介的、渐进式可视化语法，文档将按照下面的顺�
   * [mark.cell](./mark/cell) - 
   * [mark.rect](./mark/rect) - 
   * [mark.link](./mark/link) - 
-  * [mark.vector](./mark/vector) - 
+  * [mark.vector](/api/mark/vector) - 用 `start`，`end` 两个点来表示一个向量，通常用于绘制具备向量含义的数据，比如风向量场等。
   * [mark.polygon](./mark/polygon) - 
   * [mark.box](./mark/box) - 
   * [mark.boxplot](./mark/boxplot) - 

--- a/site/examples/general/vector/demo/meta.json
+++ b/site/examples/general/vector/demo/meta.json
@@ -10,7 +10,7 @@
         "zh": "风向量场",
         "en": "Wind Vector"
       },
-      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*5NgBQYJrTUEAAAAAAAAAAAAADmJ7AQ/original"
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*6fDIT50ZKnEAAAAAAAAAAAAADmJ7AQ/fmt.webp"
     },
     {
       "filename": "poisson.ts",

--- a/site/examples/general/vector/demo/wind.ts
+++ b/site/examples/general/vector/demo/wind.ts
@@ -1,26 +1,25 @@
 import { Chart } from '@antv/g2';
 
-fetch('https://gw.alipayobjects.com/os/antfincdn/F5VcgnqRku/wind.json')
-  .then((res) => res.json())
-  .then((data) => {
-    const chart = new Chart({
-      container: 'container',
-      autoFit: true,
-    });
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+});
 
-    chart
-      .vector()
-      .data(data)
-      .encode('x', 'longitude')
-      .encode('y', 'latitude')
-      .encode('rotate', ({ u, v }) => (Math.atan2(v, u) * 180) / Math.PI)
-      .encode('size', ({ u, v }) => Math.hypot(v, u))
-      .encode('color', ({ u, v }) => Math.hypot(v, u))
-      .scale('size', { range: [6, 20] })
-      .scale('color', { type: 'sequential', palette: 'viridis' })
-      .axis('x', { grid: false })
-      .axis('y', { grid: false })
-      .legend(false);
+chart
+  .vector()
+  .data({
+    type: 'fetch',
+    value: 'https://gw.alipayobjects.com/os/antfincdn/F5VcgnqRku/wind.json',
+  })
+  .encode('x', 'longitude')
+  .encode('y', 'latitude')
+  .encode('rotate', ({ u, v }) => (Math.atan2(v, u) * 180) / Math.PI)
+  .encode('size', ({ u, v }) => Math.hypot(v, u))
+  .encode('color', ({ u, v }) => Math.hypot(v, u))
+  .scale('size', { range: [6, 20] })
+  .scale('color', { type: 'sequential', palette: 'viridis' })
+  .axis('x', { grid: false })
+  .axis('y', { grid: false })
+  .legend(false);
 
-    chart.render();
-  });
+chart.render();


### PR DESCRIPTION
建议：

-  table 的样式，参考此篇保持一致
- 文档的 pr 不用等 ci，可以强行合并

----
# vector

Vector 图形是将数据映射成为`箭头`的样式去可视化展示，通过控制箭头的位置、大小、颜色、角度等信息，去可视化一些向量场数据。它具备有以下视觉通道：

- `x`：水平方向的位置，对 x 轴刻度对应
- `y`：垂直方向的位置，对 y 轴刻度对应，位置锚点定位为箭头的中心
- `color`：箭头的颜色
- `size`：箭头的长度
- `rotate`：箭头的旋转角度，起始角度为直角坐标系中的 `右边`，旋转方向为 `顺时针`

Vector 图形标记会将数据通过上述通道映射成向量数据：`[start, end]`。

<img src="https://gw.alipayobjects.com/zos/antfincdn/c9nPWlX5Au/vector.png" width="300" />


## 开始使用

<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*5NgBQYJrTUEAAAAAAAAAAAAADmJ7AQ/fmt.webp" width="600" />

```ts
import { Chart } from '@antv/g2';

const chart = new Chart({
  container: 'container',
  autoFit: true,
});

chart
  .vector()
  .data({
    type: 'fetch',
    value: 'https://gw.alipayobjects.com/os/antfincdn/F5VcgnqRku/wind.json',
  })
  .encode('x', 'longitude')
  .encode('y', 'latitude')
  .encode('rotate', ({ u, v }) => (Math.atan2(v, u) * 180) / Math.PI)
  .encode('size', ({ u, v }) => Math.hypot(v, u))
  .encode('color', ({ u, v }) => Math.hypot(v, u))
  .scale('size', { range: [6, 20] })
  .scale('color', { type: 'sequential', palette: 'viridis' })
  .axis('x', { grid: false })
  .axis('y', { grid: false })
  .legend(false);

chart.render();
```

更多的案例，可以查看[图表示例](/examples)页面。

## 选项

目前仅有一种同名的图形 `vector`，下面描述一下所有的 `style` 配置项。

### vector

| 属性            | 描述                                           | 类型                 | 默认值      |
|----------------|------------------------------------------------|---------------------|------------|
| arrowSize      | 箭头图标的大小，可以指定像素值、也可以指定箭头长度的相对值。          | `string` \| `number`  | '40%'      |
| fill          | 图形的填充色                                                   | `string`          |   -   |
| fillOpacity   | 图形的填充透明度                                                | `number`          |   -   |
| stroke        | 图形的描边                                                     | `string`          |   -   |
| lineWidth     | 图形描边的宽度                                                  | `number`          |   -   |
| lineDash      | 描边的虚线配置，第一个值为虚线每个分段的长度，第二个值为分段间隔的距离。lineDash 设为[0, 0]的效果为没有描边。 | `[number,number]` |   -   |
| lineOpacity   | 描边透明度                                                      | `number`          |   -   |
| opacity       | 图形的整体透明度                                                 | `number`          |   -   |
| shadowColor   | 图形阴影颜色                                                    | `string`          |   -   |
| shadowBlur    | 图形阴影的高斯模糊系数                                            | `number`          |   -   |
| shadowOffsetX | 设置阴影距图形的水平距离                                          | `number`          |   -   |
| shadowOffsetY | 设置阴影距图形的垂直距离                                          | `number`          |   -   |
| cursor        | 鼠标样式。同 css 的鼠标样式，默认 'default'。                      | `string`          |   'default'  |

## FAQ

- 怎么指定箭头图标的长度？

有两种指定箭头图标长度的方式，一种是通过填写像素值，比如 `40`，来指定为固定长度；另外一种是通过指定一个百分比，比如 `30%`，来指定参考箭头长度的相对长度。默认值为 `40%`。如下示例：

```ts
chart
  .vector()
  // ...
  .shape('vector')
  .style({
    arrowSize: 40,
    // arrowSize: '30%',
  });
```
