### PR TITLE
docs: add transform api

### DIFF
--- a/site/docs/api/label/overview.zh.md
+++ b/site/docs/api/label/overview.zh.md
@@ -11,7 +11,7 @@ Label 是将图形的一些数据信息，比如值，名称等映射到图形�
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*Cx8zT7vT5bUAAAAAAAAAAAAADmJ7AQ/original" width="400" alt="revenue-flow-waterfall" />
+<img alt="label" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*Cx8zT7vT5bUAAAAAAAAAAAAADmJ7AQ/original" width="400" alt="revenue-flow-waterfall" />
 
 ```ts
 import { Chart } from '@antv/g2';

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -44,7 +44,7 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
 * Transform - 对视觉通道 encode 进行变换。
   * [transform.bin](/api/transform/bin) - 对连续的 x 和 连续的 y 通道进行分箱，并且对通道根据指定的 redcuer 进行聚合。
   * [transform.binX](/api/transform/binx) - 对 x 通道进行分箱，如果希望对 y 通道进行分箱，使用 binX + transpose 坐标系。
-  * [transform.diffY](./transform/diffY) - 对 y 和 y1 通道求差集。
+  * [transform.diffY](/api/transform/diffy) - 对 y 和 y1 通道求差集。
   * [transform.dodgeX](./transform/dodgeX) - 生成 series 通道值为 color 通道的值，根据 series 通道实现分组效果。
   * [transform.flexX](./transform/flexX) - 根据指定通道设置 x 比例尺的 flex 属性，实现不等宽矩形的效果。
   * [transform.group](./transform/group) - 对离散的 x 和 连续的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -53,7 +53,7 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.groupY](/api/transform/groupy) - 对离散的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.jitter](/api/transform/jitter) - 根据离散的 x 和 离散的 y 比例尺，生成 dy 和 dx 通道，实现在某个区域散开的效果。
   * [transform.jitterX](/api/transform/jitterx) - 根据离散的 x 比例尺，生成 dx 通道，实现在某个区域的 x 方向散开的效果。
-  * [transform.normalizeY](./transform/normalizeY) - 对 y 和 y1 通道根据指定的 basis 进行归一化处理。
+  * [transform.normalizeY](/api/transform/normalizey) - 对 y 和 y1 通道根据指定的 basis 进行归一化处理。
   * [transform.select](./transform/select) - 按照指定通道进行分组，根据指定通道和 selector 从每组选择出数据。
   * [transform.selectX](./transform/selectX) - 按照指定通道进行分组，根据 x 通道和 selector 从每组选择出数据。
   * [transform.selectY](./transform/selectY) - 按照指定的通道进行分组，根据 y 通道和 selector 从每组选择出数据。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -43,7 +43,7 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [mark.wordcloud](./mark/wordcloud) - 
 * Transform - 对视觉通道 encode 进行变换。
   * [transform.bin](/api/transform/bin) - 对连续的 x 和 连续的 y 通道进行分箱，并且对通道根据指定的 redcuer 进行聚合。
-  * [transform.binX](./transform/binX) - 对 x 通道进行分箱，如果希望对 y 通道进行分箱，使用 binX + transpose 坐标系。
+  * [transform.binX](/api/transform/binx) - 对 x 通道进行分箱，如果希望对 y 通道进行分箱，使用 binX + transpose 坐标系。
   * [transform.diffY](./transform/diffY) - 对 y 和 y1 通道求差集。
   * [transform.dodgeX](./transform/dodgeX) - 生成 series 通道值为 color 通道的值，根据 series 通道实现分组效果。
   * [transform.flexX](./transform/flexX) - 根据指定通道设置 x 比例尺的 flex 属性，实现不等宽矩形的效果。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -47,7 +47,7 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.diffY](/api/transform/diffy) - 对 y 和 y1 通道求差集。
   * [transform.dodgeX](/api/transform/dodgex) - 生成 series 通道值为 color 通道的值，根据 series 通道实现分组效果。
   * [transform.flexX](/api/transform/flexx) - 根据指定通道设置 x 比例尺的 flex 属性，实现不等宽矩形的效果。
-  * [transform.group](./transform/group) - 对离散的 x 和 连续的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
+  * [transform.group](/api/transform/group) - 对离散的 x 和 连续的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.groupColor](./transform/groupColor) - 对离散的 color 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.groupX](./transform/groupX) - 对离散的 x 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.groupY](./transform/groupY) - 对离散的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -51,8 +51,8 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.groupColor](/api/transform/groupcolor) - 对离散的 color 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.groupX](/api/transform/groupx) - 对离散的 x 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.groupY](/api/transform/groupy) - 对离散的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
-  * [transform.jitter](./transform/jitter) - 根据离散的 x 和 离散的 y 比例尺，生成 dy 和 dx 通道，实现在某个区域散开的效果。
-  * [transform.jitterX](./transform/jitterX) - 根据离散的 x 比例尺，生成 dx 通道，实现在某个区域的 x 方向散开的效果。
+  * [transform.jitter](/api/transform/jitter) - 根据离散的 x 和 离散的 y 比例尺，生成 dy 和 dx 通道，实现在某个区域散开的效果。
+  * [transform.jitterX](/api/transform/jitterx) - 根据离散的 x 比例尺，生成 dx 通道，实现在某个区域的 x 方向散开的效果。
   * [transform.normalizeY](./transform/normalizeY) - 对 y 和 y1 通道根据指定的 basis 进行归一化处理。
   * [transform.select](./transform/select) - 按照指定通道进行分组，根据指定通道和 selector 从每组选择出数据。
   * [transform.selectX](./transform/selectX) - 按照指定通道进行分组，根据 x 通道和 selector 从每组选择出数据。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -63,7 +63,7 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.sortY](/api/transform/sorty) - 对离散的 y 比例尺的定义域根据指定通道排序。
   * [transform.stackEnter](/api/transform/stackenter) - 对 enterDuration 和 enterDelay 通道进行堆叠，实现分组动画的效果。
   * [transform.stackY](/api/transform/stacky) - 按照指定通道分组，对每组的 y 和 y1 通道进行堆叠，实现堆叠效果。
-  * [transform.symmetryY](./transform/symmetryY) - 按照指定通道分组，给每组的 y 和 y1 通道添加偏移，实现对称效果。
+  * [transform.symmetryY](./transform/symmetryy) - 按照指定通道分组，给每组的 y 和 y1 通道添加偏移，实现对称效果。
 * Scale - 比例尺相关的介绍
   * [scale.linear](/api/scale/linear) - 针对连续数据，对数据进行连续映射的比例尺。
   * [scale.sqrt](/api/scale/sqrt) - 指数固定为 `0.5` 的 `pow` 比例尺。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -63,7 +63,7 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.sortY](/api/transform/sorty) - 对离散的 y 比例尺的定义域根据指定通道排序。
   * [transform.stackEnter](/api/transform/stackenter) - 对 enterDuration 和 enterDelay 通道进行堆叠，实现分组动画的效果。
   * [transform.stackY](/api/transform/stacky) - 按照指定通道分组，对每组的 y 和 y1 通道进行堆叠，实现堆叠效果。
-  * [transform.symmetryY](./transform/symmetryy) - 按照指定通道分组，给每组的 y 和 y1 通道添加偏移，实现对称效果。
+  * [transform.symmetryY](/api/transform/symmetryy) - 按照指定通道分组，给每组的 y 和 y1 通道添加偏移，实现对称效果。
 * Scale - 比例尺相关的介绍
   * [scale.linear](/api/scale/linear) - 针对连续数据，对数据进行连续映射的比例尺。
   * [scale.sqrt](/api/scale/sqrt) - 指数固定为 `0.5` 的 `pow` 比例尺。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -42,7 +42,7 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [mark.tree](./mark/tree) - 
   * [mark.wordcloud](./mark/wordcloud) - 
 * Transform - 对视觉通道 encode 进行变换。
-  * [transform.bin](./transform/bin) - 对连续的 x 和 连续的 y 通道进行分箱，并且对通道根据指定的 redcuer 进行聚合。
+  * [transform.bin](/api/transform/bin) - 对连续的 x 和 连续的 y 通道进行分箱，并且对通道根据指定的 redcuer 进行聚合。
   * [transform.binX](./transform/binX) - 对 x 通道进行分箱，如果希望对 y 通道进行分箱，使用 binX + transpose 坐标系。
   * [transform.diffY](./transform/diffY) - 对 y 和 y1 通道求差集。
   * [transform.dodgeX](./transform/dodgeX) - 生成 series 通道值为 color 通道的值，根据 series 通道实现分组效果。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -61,8 +61,8 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.sortColor](/api/transform/sortcolor) - 对离散的 color 比例尺的定义域根据指定通道排序。
   * [transform.sortX](/api/transform/sortx) - 对离散的 x 比例尺的定义域根据指定通道排序。
   * [transform.sortY](/api/transform/sorty) - 对离散的 y 比例尺的定义域根据指定通道排序。
-  * [transform.stackEnter](./transform/stackEnter) - 对 enterDuration 和 enterDelay 通道进行堆叠，实现分组动画的效果。
-  * [transform.stackY](./transform/stackY) - 按照指定通道分组，对每组的 y 和 y1 通道进行堆叠，实现堆叠效果。
+  * [transform.stackEnter](/api/transform/stackenter) - 对 enterDuration 和 enterDelay 通道进行堆叠，实现分组动画的效果。
+  * [transform.stackY](/api/transform/stacky) - 按照指定通道分组，对每组的 y 和 y1 通道进行堆叠，实现堆叠效果。
   * [transform.symmetryY](./transform/symmetryY) - 按照指定通道分组，给每组的 y 和 y1 通道添加偏移，实现对称效果。
 * Scale - 比例尺相关的介绍
   * [scale.linear](/api/scale/linear) - 针对连续数据，对数据进行连续映射的比例尺。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -46,7 +46,7 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.binX](/api/transform/binx) - 对 x 通道进行分箱，如果希望对 y 通道进行分箱，使用 binX + transpose 坐标系。
   * [transform.diffY](/api/transform/diffy) - 对 y 和 y1 通道求差集。
   * [transform.dodgeX](/api/transform/dodgex) - 生成 series 通道值为 color 通道的值，根据 series 通道实现分组效果。
-  * [transform.flexX](./transform/flexX) - 根据指定通道设置 x 比例尺的 flex 属性，实现不等宽矩形的效果。
+  * [transform.flexX](/api/transform/flexx) - 根据指定通道设置 x 比例尺的 flex 属性，实现不等宽矩形的效果。
   * [transform.group](./transform/group) - 对离散的 x 和 连续的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.groupColor](./transform/groupColor) - 对离散的 color 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.groupX](./transform/groupX) - 对离散的 x 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -54,9 +54,9 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.jitter](/api/transform/jitter) - 根据离散的 x 和 离散的 y 比例尺，生成 dy 和 dx 通道，实现在某个区域散开的效果。
   * [transform.jitterX](/api/transform/jitterx) - 根据离散的 x 比例尺，生成 dx 通道，实现在某个区域的 x 方向散开的效果。
   * [transform.normalizeY](/api/transform/normalizey) - 对 y 和 y1 通道根据指定的 basis 进行归一化处理。
-  * [transform.select](./transform/select) - 按照指定通道进行分组，根据指定通道和 selector 从每组选择出数据。
-  * [transform.selectX](./transform/selectX) - 按照指定通道进行分组，根据 x 通道和 selector 从每组选择出数据。
-  * [transform.selectY](./transform/selectY) - 按照指定的通道进行分组，根据 y 通道和 selector 从每组选择出数据。
+  * [transform.select](/api/transform/select) - 按照指定通道进行分组，根据指定通道和 selector 从每组选择出数据。
+  * [transform.selectX](/api/transform/selectx) - 按照指定通道进行分组，根据 x 通道和 selector 从每组选择出数据。
+  * [transform.selectY](/api/transform/selecty) - 按照指定的通道进行分组，根据 y 通道和 selector 从每组选择出数据。
   * [transform.pack](./transform/pack) - 生成 transform 和 scale 属性，从而让图形在空间中紧凑排列。
   * [transform.sortColor](./transform/sortColor) - 对离散的 color 比例尺的定义域根据指定通道排序。
   * [transform.sortX](./transform/sortX) - 对离散的 x 比例尺的定义域根据指定通道排序。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -57,7 +57,7 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.select](/api/transform/select) - 按照指定通道进行分组，根据指定通道和 selector 从每组选择出数据。
   * [transform.selectX](/api/transform/selectx) - 按照指定通道进行分组，根据 x 通道和 selector 从每组选择出数据。
   * [transform.selectY](/api/transform/selecty) - 按照指定的通道进行分组，根据 y 通道和 selector 从每组选择出数据。
-  * [transform.pack](./transform/pack) - 生成 transform 和 scale 属性，从而让图形在空间中紧凑排列。
+  * [transform.pack](/api/transform/pack) - 生成 transform 和 scale 属性，从而让图形在空间中紧凑排列。
   * [transform.sortColor](/api/transform/sortcolor) - 对离散的 color 比例尺的定义域根据指定通道排序。
   * [transform.sortX](/api/transform/sortx) - 对离散的 x 比例尺的定义域根据指定通道排序。
   * [transform.sortY](/api/transform/sorty) - 对离散的 y 比例尺的定义域根据指定通道排序。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -48,7 +48,7 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.dodgeX](/api/transform/dodgex) - 生成 series 通道值为 color 通道的值，根据 series 通道实现分组效果。
   * [transform.flexX](/api/transform/flexx) - 根据指定通道设置 x 比例尺的 flex 属性，实现不等宽矩形的效果。
   * [transform.group](/api/transform/group) - 对离散的 x 和 连续的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
-  * [transform.groupColor](./transform/groupColor) - 对离散的 color 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
+  * [transform.groupColor](/api/transform/groupcolor) - 对离散的 color 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.groupX](./transform/groupX) - 对离散的 x 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.groupY](./transform/groupY) - 对离散的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.jitter](./transform/jitter) - 根据离散的 x 和 离散的 y 比例尺，生成 dy 和 dx 通道，实现在某个区域散开的效果。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -45,7 +45,7 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.bin](/api/transform/bin) - 对连续的 x 和 连续的 y 通道进行分箱，并且对通道根据指定的 redcuer 进行聚合。
   * [transform.binX](/api/transform/binx) - 对 x 通道进行分箱，如果希望对 y 通道进行分箱，使用 binX + transpose 坐标系。
   * [transform.diffY](/api/transform/diffy) - 对 y 和 y1 通道求差集。
-  * [transform.dodgeX](./transform/dodgeX) - 生成 series 通道值为 color 通道的值，根据 series 通道实现分组效果。
+  * [transform.dodgeX](/api/transform/dodgex) - 生成 series 通道值为 color 通道的值，根据 series 通道实现分组效果。
   * [transform.flexX](./transform/flexX) - 根据指定通道设置 x 比例尺的 flex 属性，实现不等宽矩形的效果。
   * [transform.group](./transform/group) - 对离散的 x 和 连续的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.groupColor](./transform/groupColor) - 对离散的 color 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -58,9 +58,9 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.selectX](/api/transform/selectx) - 按照指定通道进行分组，根据 x 通道和 selector 从每组选择出数据。
   * [transform.selectY](/api/transform/selecty) - 按照指定的通道进行分组，根据 y 通道和 selector 从每组选择出数据。
   * [transform.pack](./transform/pack) - 生成 transform 和 scale 属性，从而让图形在空间中紧凑排列。
-  * [transform.sortColor](./transform/sortColor) - 对离散的 color 比例尺的定义域根据指定通道排序。
-  * [transform.sortX](./transform/sortX) - 对离散的 x 比例尺的定义域根据指定通道排序。
-  * [transform.sortY](./transform/sortY) - 对离散的 y 比例尺的定义域根据指定通道排序。
+  * [transform.sortColor](/api/transform/sortcolor) - 对离散的 color 比例尺的定义域根据指定通道排序。
+  * [transform.sortX](/api/transform/sortx) - 对离散的 x 比例尺的定义域根据指定通道排序。
+  * [transform.sortY](/api/transform/sorty) - 对离散的 y 比例尺的定义域根据指定通道排序。
   * [transform.stackEnter](./transform/stackEnter) - 对 enterDuration 和 enterDelay 通道进行堆叠，实现分组动画的效果。
   * [transform.stackY](./transform/stackY) - 按照指定通道分组，对每组的 y 和 y1 通道进行堆叠，实现堆叠效果。
   * [transform.symmetryY](./transform/symmetryY) - 按照指定通道分组，给每组的 y 和 y1 通道添加偏移，实现对称效果。

--- a/site/docs/api/overview.zh.md
+++ b/site/docs/api/overview.zh.md
@@ -49,8 +49,8 @@ G2 是一个简洁的、渐进式的可视化语法。文档将按照下面的�
   * [transform.flexX](/api/transform/flexx) - 根据指定通道设置 x 比例尺的 flex 属性，实现不等宽矩形的效果。
   * [transform.group](/api/transform/group) - 对离散的 x 和 连续的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.groupColor](/api/transform/groupcolor) - 对离散的 color 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
-  * [transform.groupX](./transform/groupX) - 对离散的 x 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
-  * [transform.groupY](./transform/groupY) - 对离散的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
+  * [transform.groupX](/api/transform/groupx) - 对离散的 x 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
+  * [transform.groupY](/api/transform/groupy) - 对离散的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
   * [transform.jitter](./transform/jitter) - 根据离散的 x 和 离散的 y 比例尺，生成 dy 和 dx 通道，实现在某个区域散开的效果。
   * [transform.jitterX](./transform/jitterX) - 根据离散的 x 比例尺，生成 dx 通道，实现在某个区域的 x 方向散开的效果。
   * [transform.normalizeY](./transform/normalizeY) - 对 y 和 y1 通道根据指定的 basis 进行归一化处理。

--- a/site/docs/api/plugin/lottie.zh.md
+++ b/site/docs/api/plugin/lottie.zh.md
@@ -42,6 +42,6 @@ import { loadAnimation } from '@antv/g-lottie-player';
 
 效果如下：
 
-<img src="https://gw.alipayobjects.com/zos/raptor/1668509306888/Nov-15-2022%25252018-48-05.gif" alt="lottie animation">
+<img alt="lottie" src="https://gw.alipayobjects.com/zos/raptor/1668509306888/Nov-15-2022%25252018-48-05.gif" alt="lottie animation">
 
 更多动画控制选项可以参考：[Lottie Animation 文档](https://g.antv.antgroup.com/api/animation/lottie#lottieanimation)。

--- a/site/docs/api/plugin/rough.zh.md
+++ b/site/docs/api/plugin/rough.zh.md
@@ -49,11 +49,11 @@ chart.render();
 ```
 
 效果如下，可以看到原本的填充色活泼了起来！
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*cYjCSLzqBVAAAAAAAAAAAAAADmJ7AQ/original" alt="sketchy barchart" width="500">
+<img alt="rough" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*cYjCSLzqBVAAAAAAAAAAAAAADmJ7AQ/original" alt="sketchy barchart" width="500">
 
 当然 `fillStyle` 还有很多填充方式，下图展示了目前支持的所有效果。更多选项详见 [@antv/g-plugin-rough-canvas-renderer 文档](https://g.antv.antgroup.com/plugins/rough-canvas-renderer#fillstyle)：
 
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*vcwuS6mTGBUAAAAAAAAAAAAADmJ7AQ/original" alt="fillStyle in rough.js" width="500">
+<img alt="rough" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*vcwuS6mTGBUAAAAAAAAAAAAADmJ7AQ/original" alt="fillStyle in rough.js" width="500">
 
 最后，选择一款手绘风格的字体能让整体风格趋于统一。在上面的[示例](/examples/plugin/rough/#interval)中我们选择了 `'Gaegu'`，可以参考[如何加载外部字体](https://g.antv.antgroup.com/api/basic/text#%E5%8A%A0%E8%BD%BD%E5%AD%97%E4%BD%93)。
 
@@ -92,4 +92,4 @@ chart
 
 效果如下：
 
-<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*kJuuQ47YUicAAAAAAAAAAAAADmJ7AQ" alt="fillStyle in a11y" width="300">
+<img alt="rough" src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*kJuuQ47YUicAAAAAAAAAAAAADmJ7AQ" alt="fillStyle in a11y" width="300">

--- a/site/docs/api/transform/bin.zh.md
+++ b/site/docs/api/transform/bin.zh.md
@@ -3,4 +3,41 @@ title: bin
 order: 1
 ---
 
-建设中！
+对连续的 x 和 连续的 y 通道进行分箱，并且对通道根据指定的 redcuer 进行聚合。
+## 开始使用
+
+在对应的 mark 中有 transform 方法可以使用 bin 变幻。
+
+```ts
+chart
+  .point()
+  .encode('x', 'x')
+  // ...
+  .transform({
+    type: 'bin',
+    /* options */
+  });
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                 | 默认值                 |
+|-------------------|------------------------------------------------|---------------------|-----------------------|
+| thresholdsX       | 对 x 分箱的数量                                  | `number`            | `d3.thresholdScott`      |  
+| thresholdsY       | 对 y 分箱的数量                                  | `number`            | `d3.thresholdScott`      |
+| [channel]         | 输出到具体 mark 的 channel 数据的聚合方式          | `Reducer`           |                       |
+
+```ts
+type Primitive = number | string | boolean | Date;
+
+type Reducer =
+  | 'mean'
+  | 'max'
+  | 'count'
+  | 'min'
+  | 'median'
+  | 'sum'
+  | 'first'
+  | 'last'
+  | ((I: number[], V: Primitive[]) => Primitive);
+```

--- a/site/docs/api/transform/binX.en.md
+++ b/site/docs/api/transform/binX.en.md
@@ -1,0 +1,6 @@
+---
+title: binX
+order: 1
+---
+
+<embed src="@/docs/api/transform/binX.zh.md"></embed>

--- a/site/docs/api/transform/binX.zh.md
+++ b/site/docs/api/transform/binX.zh.md
@@ -1,13 +1,13 @@
 ---
-title: bin
+title: binX
 order: 1
 ---
 
-对连续的 x 和 连续的 y 通道进行分箱，并且对通道根据指定的 redcuer 进行聚合。
+对 x 通道进行分箱，如果希望对 y 通道进行分箱，使用 binX + transpose 坐标系。
 
 ## 开始使用
 
-在对应的 mark 中有 transform 方法可以使用 bin 变换。
+在对应的 mark 中有 transform 方法可以使用 binX 变换。
 
 ```ts
 chart
@@ -15,7 +15,7 @@ chart
   .encode('x', 'x')
   // ...
   .transform({
-    type: 'bin',
+    type: 'binX',
     /* options */
   });
 ```
@@ -24,8 +24,7 @@ chart
 
 | 属性               | 描述                                           | 类型                 | 默认值                 |
 |-------------------|------------------------------------------------|---------------------|-----------------------|
-| thresholdsX       | 对 x 分箱的数量                                  | `number`            | `d3.thresholdScott`      |  
-| thresholdsY       | 对 y 分箱的数量                                  | `number`            | `d3.thresholdScott`      |
+| thresholds        | 对 x 分箱的数量                                  | `number`            | `d3.thresholdScott`      |  
 | [channel]         | 输出到具体 mark 的 channel 数据的聚合方式          | `Reducer`           |                       |
 
 ```ts

--- a/site/docs/api/transform/diffY.en.md
+++ b/site/docs/api/transform/diffY.en.md
@@ -1,0 +1,6 @@
+---
+title: diffY
+order: 1
+---
+
+<embed src="@/docs/api/transform/diffY.zh.md"></embed>

--- a/site/docs/api/transform/diffY.zh.md
+++ b/site/docs/api/transform/diffY.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*CJn4T4_Rf98AAAAAAAAAAAAADmJ7AQ/original" width="600" />
+<img alt="diffY" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*CJn4T4_Rf98AAAAAAAAAAAAADmJ7AQ/original" width="600" />
 
 在对应的 mark 中有 transform 方法可以使用数据的变换。
 

--- a/site/docs/api/transform/diffY.zh.md
+++ b/site/docs/api/transform/diffY.zh.md
@@ -1,3 +1,17 @@
+---
+title: diffY
+order: 1
+---
+
+对 y 和 y1 通道求差集。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*CJn4T4_Rf98AAAAAAAAAAAAADmJ7AQ/original" width="600" />
+
+在对应的 mark 中有 transform 方法可以使用数据的变换。
+
+```ts
 import { Chart } from '@antv/g2';
 
 const chart = new Chart({
@@ -14,9 +28,9 @@ chart.data({
       callback: (d) => (d) => ({
         ...d,
         date: new Date(d.date),
-      }),
-    },
-  ],
+      })
+    }
+  ]
 });
 
 chart
@@ -45,3 +59,11 @@ chart
   .style('stroke', '#000');
 
 chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                     | 默认值                 |
+|-------------------|------------------------------------------------|-------------------------|-----------------------|
+| groupBy           | 按照哪个通道分组数据                              | `string` \| `string[]`  | `x`                   |  
+| series            | 是否存在分组                                     | `boolean`               | `true`                   |

--- a/site/docs/api/transform/dodgeX.en.md
+++ b/site/docs/api/transform/dodgeX.en.md
@@ -1,0 +1,6 @@
+---
+title: dodgeX
+order: 1
+---
+
+<embed src="@/docs/api/transform/dodgeX.zh.md"></embed>

--- a/site/docs/api/transform/dodgeX.zh.md
+++ b/site/docs/api/transform/dodgeX.zh.md
@@ -1,0 +1,76 @@
+---
+title: dodgeX
+order: 1
+---
+
+生成 series 通道值为 color 通道的值，根据 series 通道实现分组效果。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*FrshQpaS4f0AAAAAAAAAAAAADmJ7AQ/original" width="600" />
+
+在对应的 mark 中有 transform 方法可以使用数据的变换。
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+  paddingLeft: 50,
+});
+
+chart
+  .interval()
+  .data({
+    type: 'fetch',
+    value:
+      'https://gw.alipayobjects.com/os/bmw-prod/f129b517-158d-41a9-83a3-3294d639b39e.csv',
+    format: 'csv',
+  })
+  .transform({ type: 'sortX', by: 'y', reverse: true, slice: 6 })
+  .transform({ type: 'dodgeX' })
+  .encode('x', 'state')
+  .encode('y', 'population')
+  .encode('color', 'age')
+  .axis('y', { tickFormatter: '~s' });
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                     | 默认值                 |
+|-------------------|------------------------------------------------|-------------------------|-----------------------|
+| groupBy           | 按照哪个通道分组数据                              | `string` \| `string[]`  | `x`                   |  
+| reverse           | 是否逆序                                        | `boolean`               | `false`               |
+| orderBy           | 排序方式                                        | `TransformOrder`        | `() => null`          |
+| padding           | 分组数据之间的间距（0 ~ 1）                       | `number`                | `0`                |
+
+```ts
+type Primitive = number | string | boolean | Date;
+
+type TransformOrder =
+  | 'value'
+  | 'sum'
+  | 'series'
+  | 'maxIndex'
+  | string[]
+  | null
+  | ((data: Record<string, Primitive>) => Primitive);
+```
+
+## FAQ
+
+- 怎么设置分组柱形图，柱子之间的间距？
+
+使用 `dodgeX` 的 paddig 配置。
+
+```ts
+chart
+  .interval()
+  .transform({ type: 'dodgeX', padding: 0.5 }) // <----
+  .encode('x', 'state')
+  .encode('y', 'population')
+  .encode('color', 'age');
+```

--- a/site/docs/api/transform/dodgeX.zh.md
+++ b/site/docs/api/transform/dodgeX.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*FrshQpaS4f0AAAAAAAAAAAAADmJ7AQ/original" width="600" />
+<img alt="dodgeX" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*FrshQpaS4f0AAAAAAAAAAAAADmJ7AQ/original" width="600" />
 
 在对应的 mark 中有 transform 方法可以使用数据的变换。
 

--- a/site/docs/api/transform/flexX.en.md
+++ b/site/docs/api/transform/flexX.en.md
@@ -1,0 +1,6 @@
+---
+title: flexX
+order: 1
+---
+
+<embed src="@/docs/api/transform/flexX.zh.md"></embed>

--- a/site/docs/api/transform/flexX.zh.md
+++ b/site/docs/api/transform/flexX.zh.md
@@ -1,0 +1,51 @@
+---
+title: flexX
+order: 1
+---
+
+根据指定通道设置 x 比例尺的 flex 属性，实现不等宽矩形的效果。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*NfBaTZtrUhoAAAAAAAAAAAAADmJ7AQ/original" width="600" />
+
+在对应的 mark 中有 transform 方法可以使用数据的变换。
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  width: 1000,
+  paddingBottom: 100,
+});
+
+chart
+  .interval()
+  .data({
+    type: 'fetch',
+    value:
+      'https://gw.alipayobjects.com/os/bmw-prod/90873879-09d7-4842-a493-03fb560267bc.csv',
+  })
+  .transform({ type: 'flexX', field: 'gdp' })
+  .encode('x', 'country')
+  .encode('y', 'value')
+  .encode('color', 'country')
+  .axis('y', { tickFormatter: '~s' });
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                     | 默认值                 |
+|-------------------|------------------------------------------------|-------------------------|-----------------------|
+| field             | 指定生成权重数组的字段，优先级比 channel 高          | `string` \| `(d: any) => Primitive[]`  |        |  
+| channel           | 指定生成权重数组的通道                             | `string`               | `y`                    |
+| reducer           | 聚合每一组权重的函数                               | `Reducer`              | `sum`                  |
+
+```ts
+type Primitive = number | string | boolean | Date;
+
+type Reducer = 'sum' | ((I: number[], V: Primitive[]) => Primitive);
+```

--- a/site/docs/api/transform/flexX.zh.md
+++ b/site/docs/api/transform/flexX.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*NfBaTZtrUhoAAAAAAAAAAAAADmJ7AQ/original" width="600" />
+<img alt="flexX" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*NfBaTZtrUhoAAAAAAAAAAAAADmJ7AQ/original" width="600" />
 
 在对应的 mark 中有 transform 方法可以使用数据的变换。
 

--- a/site/docs/api/transform/group.en.md
+++ b/site/docs/api/transform/group.en.md
@@ -1,0 +1,6 @@
+---
+title: group
+order: 1
+---
+
+<embed src="@/docs/api/transform/group.zh.md"></embed>

--- a/site/docs/api/transform/group.zh.md
+++ b/site/docs/api/transform/group.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*Wk4zR40uQesAAAAAAAAAAAAADmJ7AQ" width="500" />
+<img alt="group" src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*Wk4zR40uQesAAAAAAAAAAAAADmJ7AQ" width="500" />
 
 在对应的 mark 中有 transform 方法可以使用数据的变换。
 

--- a/site/docs/api/transform/group.zh.md
+++ b/site/docs/api/transform/group.zh.md
@@ -1,0 +1,61 @@
+---
+title: group
+order: 1
+---
+
+对离散的 x 和 连续的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*Wk4zR40uQesAAAAAAAAAAAAADmJ7AQ" width="500" />
+
+在对应的 mark 中有 transform 方法可以使用数据的变换。
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  height: 300,
+});
+
+chart
+  .cell()
+  .data({
+    type: 'fetch',
+    value: 'https://assets.antv.antgroup.com/g2/seattle-weather.json',
+  })
+  .transform({ type: 'group', color: 'max' })
+  .encode('x', (d) => new Date(d.date).getUTCDate())
+  .encode('y', (d) => new Date(d.date).getUTCMonth())
+  .encode('color', 'temp_max')
+  .style('inset', 0.5)
+  .scale('color', {
+    type: 'sequential',
+    palette: 'gnBu',
+  });
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                     | 默认值                 |
+|-------------------|------------------------------------------------|-------------------------|-----------------------|
+| channels          | 针对哪些通道做数据分组聚合                         | `string` \| `string[]`  | `['x', 'y']`           |  
+| [channel]         | 输出到具体 mark 的 channel 数据的聚合方式          | `Reducer`               |                       |
+
+```ts
+type Primitive = number | string | boolean | Date;
+
+type Reducer =
+  | 'mean'
+  | 'max'
+  | 'count'
+  | 'min'
+  | 'median'
+  | 'sum'
+  | 'first'
+  | 'last'
+  | ((I: number[], V: Primitive[]) => Primitive);
+```

--- a/site/docs/api/transform/groupColor.en.md
+++ b/site/docs/api/transform/groupColor.en.md
@@ -1,0 +1,6 @@
+---
+title: groupColor
+order: 1
+---
+
+<embed src="@/docs/api/transform/groupColor.zh.md"></embed>

--- a/site/docs/api/transform/groupColor.zh.md
+++ b/site/docs/api/transform/groupColor.zh.md
@@ -1,0 +1,59 @@
+---
+title: groupColor
+order: 1
+---
+
+对离散的 color 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*6CbxQ6P9bFcAAAAAAAAAAAAADmJ7AQ" width="500" />
+
+在对应的 mark 中有 transform 方法可以使用数据的变换。
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  height: 120,
+});
+
+chart.coordinate({ type: 'transpose' });
+
+chart
+  .interval()
+  .data({
+    type: 'fetch',
+    value: 'https://assets.antv.antgroup.com/g2/penguins.json',
+  })
+  .transform({ type: 'groupColor', y: 'count' })
+  .transform({ type: 'stackY' })
+  .transform({ type: 'normalizeY' })
+  .axis('y', { tickFormatter: '.0%' })
+  .encode('color', 'sex')
+  .label({ text: 'sex', position: 'inside' });
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                     | 默认值                 |
+|-------------------|------------------------------------------------|-------------------------|-----------------------|
+| [channel]         | 输出到具体 mark 的 channel 数据的聚合方式          | `Reducer`               |                       |
+
+```ts
+type Primitive = number | string | boolean | Date;
+
+type Reducer =
+  | 'mean'
+  | 'max'
+  | 'count'
+  | 'min'
+  | 'median'
+  | 'sum'
+  | 'first'
+  | 'last'
+  | ((I: number[], V: Primitive[]) => Primitive);
+```

--- a/site/docs/api/transform/groupColor.zh.md
+++ b/site/docs/api/transform/groupColor.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*6CbxQ6P9bFcAAAAAAAAAAAAADmJ7AQ" width="500" />
+<img alt="groupColor" src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*6CbxQ6P9bFcAAAAAAAAAAAAADmJ7AQ" width="500" />
 
 在对应的 mark 中有 transform 方法可以使用数据的变换。
 

--- a/site/docs/api/transform/groupX.en.md
+++ b/site/docs/api/transform/groupX.en.md
@@ -1,0 +1,6 @@
+---
+title: groupX
+order: 1
+---
+
+<embed src="@/docs/api/transform/groupX.zh.md"></embed>

--- a/site/docs/api/transform/groupX.zh.md
+++ b/site/docs/api/transform/groupX.zh.md
@@ -1,0 +1,69 @@
+---
+title: groupX
+order: 1
+---
+
+对离散的 x 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。等效于 `chanels = ['x']` 的 [group](/api/transform/group)。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*RtalTb-DPdkAAAAAAAAAAAAADmJ7AQ" width="400" />
+
+在对应的 mark 中有 transform 方法可以使用数据的变换。
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  width: 800,
+  height: 1200,
+});
+
+chart.coordinate({ type: 'transpose' });
+
+chart.data({
+  type: 'fetch',
+  value:
+    'https://gw.alipayobjects.com/os/bmw-prod/b6f2ff26-b232-447d-a613-0df5e30104a0.csv',
+});
+
+chart
+  .link()
+  .scale('y', { formatter: '.0%' })
+  .transform({ type: 'groupX', y: 'min', y1: 'max' })
+  .encode('x', 'state')
+  .encode('y', 'population')
+  .style('stroke', '#000');
+
+chart
+  .point()
+  .scale('color', { palette: 'spectral' })
+  .encode('x', 'state')
+  .encode('y', 'population')
+  .encode('shape', 'point')
+  .encode('color', 'age');
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                     | 默认值                 |
+|-------------------|------------------------------------------------|-------------------------|-----------------------|
+| [channel]         | 输出到具体 mark 的 channel 数据的聚合方式          | `Reducer`               |                       |
+
+```ts
+type Primitive = number | string | boolean | Date;
+
+type Reducer =
+  | 'mean'
+  | 'max'
+  | 'count'
+  | 'min'
+  | 'median'
+  | 'sum'
+  | 'first'
+  | 'last'
+  | ((I: number[], V: Primitive[]) => Primitive);
+```

--- a/site/docs/api/transform/groupX.zh.md
+++ b/site/docs/api/transform/groupX.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*RtalTb-DPdkAAAAAAAAAAAAADmJ7AQ" width="400" />
+<img alt="groupX" src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*RtalTb-DPdkAAAAAAAAAAAAADmJ7AQ" width="400" />
 
 在对应的 mark 中有 transform 方法可以使用数据的变换。
 

--- a/site/docs/api/transform/groupY.en.md
+++ b/site/docs/api/transform/groupY.en.md
@@ -1,0 +1,6 @@
+---
+title: groupY
+order: 1
+---
+
+<embed src="@/docs/api/transform/groupY.zh.md"></embed>

--- a/site/docs/api/transform/groupY.zh.md
+++ b/site/docs/api/transform/groupY.zh.md
@@ -1,0 +1,78 @@
+---
+title: groupY
+order: 1
+---
+
+对离散的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。等效于 `chanels = ['y']` 的 [group](/api/transform/group)。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*rWBUQ6_kf8kAAAAAAAAAAAAADmJ7AQ" width="500" />
+
+在对应的 mark 中有 transform 方法可以使用数据的变换。
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  paddingLeft: 80,
+  height: 180,
+});
+
+chart.data({
+  type: 'fetch',
+  value: 'https://assets.antv.antgroup.com/g2/penguins.json',
+  transform: [
+    {
+      type: 'map',
+      callback: (d) => ({ ...d, body_mass_g: +d.body_mass_g }),
+    },
+  ],
+});
+
+chart
+  .point()
+  .encode('x', 'body_mass_g')
+  .encode('y', 'species')
+  .style('stroke', '#000');
+
+chart
+  .link()
+  .transform({ type: 'groupY', x: 'min', x1: 'max' })
+  .encode('x', 'body_mass_g')
+  .encode('y', 'species')
+  .style('stroke', '#000');
+
+chart
+  .point()
+  .transform({ type: 'groupY', x: 'median' })
+  .encode('y', 'species')
+  .encode('x', 'body_mass_g')
+  .encode('shape', 'line')
+  .encode('size', 12)
+  .style('stroke', 'red');
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                     | 默认值                 |
+|-------------------|------------------------------------------------|-------------------------|-----------------------|
+| [channel]         | 输出到具体 mark 的 channel 数据的聚合方式          | `Reducer`               |                       |
+
+```ts
+type Primitive = number | string | boolean | Date;
+
+type Reducer =
+  | 'mean'
+  | 'max'
+  | 'count'
+  | 'min'
+  | 'median'
+  | 'sum'
+  | 'first'
+  | 'last'
+  | ((I: number[], V: Primitive[]) => Primitive);
+```

--- a/site/docs/api/transform/groupY.zh.md
+++ b/site/docs/api/transform/groupY.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*rWBUQ6_kf8kAAAAAAAAAAAAADmJ7AQ" width="500" />
+<img alt="groupY" src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*rWBUQ6_kf8kAAAAAAAAAAAAADmJ7AQ" width="500" />
 
 在对应的 mark 中有 transform 方法可以使用数据的变换。
 

--- a/site/docs/api/transform/jitter.en.md
+++ b/site/docs/api/transform/jitter.en.md
@@ -1,0 +1,6 @@
+---
+title: jitter
+order: 1
+---
+
+<embed src="@/docs/api/transform/jitter.zh.md"></embed>

--- a/site/docs/api/transform/jitter.zh.md
+++ b/site/docs/api/transform/jitter.zh.md
@@ -1,0 +1,42 @@
+---
+title: jitter
+order: 1
+---
+
+根据离散的 x 和 离散的 y 比例尺，生成 dy 和 dx 通道，实现在某个区域散开的效果。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*eJQYQZQ_HZQAAAAAAAAAAAAADmJ7AQ" width="500" />
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+});
+
+chart.coordinate({ type: 'polar' });
+
+chart
+  .point()
+  .data({
+    type: 'fetch',
+    value: 'https://gw.alipayobjects.com/os/antvdemo/assets/data/diamond.json',
+  })
+  .transform({ type: 'jitter' })
+  .scale('color', { guide: null })
+  .encode('x', 'clarity')
+  .encode('color', 'clarity');
+
+chart.render();
+```
+
+## 选项
+| 属性               | 描述                                           | 类型                 | 默认值                 |
+|-------------------|------------------------------------------------|---------------------|-----------------------|
+| padding           | 分组在 x,y 方向上的间距 [0 ~ 1]                   | `number`            | `0`                   |
+| paddingX          | 分组在 x 方向的间距 [0 ~ 1]                       | `number`            | `0`                   |
+| paddingY          | 分组在 y 方向的间距 [0 ~ 1]                       | `number`            | `0`                   |
+| random            | 随机函数，返回值为 [0, 1)                         | `() => number`      | `Math.random`         |

--- a/site/docs/api/transform/jitter.zh.md
+++ b/site/docs/api/transform/jitter.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*eJQYQZQ_HZQAAAAAAAAAAAAADmJ7AQ" width="500" />
+<img alt="jitter" src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*eJQYQZQ_HZQAAAAAAAAAAAAADmJ7AQ" width="500" />
 
 ```ts
 import { Chart } from '@antv/g2';

--- a/site/docs/api/transform/jitterX.en.md
+++ b/site/docs/api/transform/jitterX.en.md
@@ -1,0 +1,6 @@
+---
+title: jitterX
+order: 1
+---
+
+<embed src="@/docs/api/transform/jitterX.zh.md"></embed>

--- a/site/docs/api/transform/jitterX.zh.md
+++ b/site/docs/api/transform/jitterX.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*0BaMRpu8tN8AAAAAAAAAAAAADmJ7AQ" width="500" />
+<img alt="jitterX" src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*0BaMRpu8tN8AAAAAAAAAAAAADmJ7AQ" width="500" />
 
 ```ts
 import { Chart } from '@antv/g2';

--- a/site/docs/api/transform/jitterX.zh.md
+++ b/site/docs/api/transform/jitterX.zh.md
@@ -1,0 +1,44 @@
+---
+title: jitterX
+order: 1
+---
+
+根据离散的 x 比例尺，生成 dx 通道，实现在某个区域的 x 方向散开的效果。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*0BaMRpu8tN8AAAAAAAAAAAAADmJ7AQ" width="500" />
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+});
+
+chart
+  .point()
+  .data({
+    type: 'fetch',
+    value:
+      'https://gw.alipayobjects.com/os/bmw-prod/2c813e2d-2276-40b9-a9af-cf0a0fb7e942.csv',
+  })
+  .transform({ type: 'sortX', channel: 'x' })
+  .transform({ type: 'jitterX' })
+  .encode('y', 'Horsepower')
+  .encode('x', 'Cylinders')
+  .encode('shape', 'hollow')
+  .encode('color', 'Cylinders')
+  .scale('x', { type: 'point' })
+  .scale('color', { type: 'ordinal' });
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                 | 默认值                 |
+|-------------------|------------------------------------------------|---------------------|-----------------------|
+| padding           | 每个分组之间的间距 [0 ~ 1]                        | `number`            | `0`                   |  
+| random            | 随机函数，返回值为 [0, 1)                         | `() => number`      | `Math.random`         |

--- a/site/docs/api/transform/normalizeY.en.md
+++ b/site/docs/api/transform/normalizeY.en.md
@@ -1,0 +1,6 @@
+---
+title: normalizeY
+order: 1
+---
+
+<embed src="@/docs/api/transform/normalizeY.zh.md"></embed>

--- a/site/docs/api/transform/normalizeY.zh.md
+++ b/site/docs/api/transform/normalizeY.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*1oZjT4cKSh8AAAAAAAAAAAAADmJ7AQ/original" width="600" />
+<img alt="normalizeY" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*1oZjT4cKSh8AAAAAAAAAAAAADmJ7AQ/original" width="600" />
 
 ```ts
 import { Chart } from '@antv/g2';

--- a/site/docs/api/transform/normalizeY.zh.md
+++ b/site/docs/api/transform/normalizeY.zh.md
@@ -1,0 +1,65 @@
+---
+title: normalizeY
+order: 1
+---
+
+对 y 和 y1 通道根据指定的 basis 进行归一化处理。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*1oZjT4cKSh8AAAAAAAAAAAAADmJ7AQ/original" width="600" />
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+});
+
+chart.coordinate({ type: 'transpose' });
+
+chart
+  .interval()
+  .data({
+    type: 'fetch',
+    value:
+      'https://gw.alipayobjects.com/os/bmw-prod/87b2ff47-2a33-4509-869c-dae4cdd81163.csv',
+    transform: [
+      {
+        type: 'filterBy',
+        fields: [['year', (d) => d === 2000]],
+      },
+    ],
+  })
+  .transform({ type: 'stackY' })
+  .transform({ type: 'normalizeY' })
+  .encode('x', 'age')
+  .encode('y', 'people')
+  .encode('color', 'sex')
+  .scale('color', { type: 'ordinal', range: ['#ca8861', '#675193'] })
+  .axis('y', { tickFormatter: '.0%' })
+  .label({ text: 'people', position: 'inside', fill: 'white' });
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                     | 默认值                 |
+|-------------------|------------------------------------------------|-------------------------|-----------------------|
+| groupBy           | 按照哪个通道分组数据                              | `string` \| `string[]`   | `x`                   |  
+| basis             | 使用某一个聚合数据进行归一化计算                    | `Basis`                  | `max`                 |
+
+```ts
+type Basis =
+  | 'deviation'
+  | 'first'
+  | 'last'
+  | 'max'
+  | 'mean'
+  | 'median'
+  | 'min'
+  | 'sum'
+  | (I, Y) => number;
+```

--- a/site/docs/api/transform/pack.en.md
+++ b/site/docs/api/transform/pack.en.md
@@ -1,0 +1,6 @@
+---
+title: pack
+order: 1
+---
+
+<embed src="@/docs/api/transform/pack.zh.md"></embed>

--- a/site/docs/api/transform/pack.zh.md
+++ b/site/docs/api/transform/pack.zh.md
@@ -1,0 +1,6 @@
+---
+title: pack
+order: 1
+---
+
+生成 transform 和 scale 属性，从而让图形在空间中紧凑排列。

--- a/site/docs/api/transform/select.en.md
+++ b/site/docs/api/transform/select.en.md
@@ -1,0 +1,6 @@
+---
+title: select
+order: 1
+---
+
+<embed src="@/docs/api/transform/select.zh.md"></embed>

--- a/site/docs/api/transform/select.zh.md
+++ b/site/docs/api/transform/select.zh.md
@@ -1,0 +1,64 @@
+---
+title: select
+order: 1
+---
+
+按照指定通道进行分组，根据指定通道和 selector 从每组选择出数据。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*q8F1S4YXwtsAAAAAAAAAAAAADmJ7AQ/original" width="500" />
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  width: 800,
+  paddingLeft: 50,
+  paddingRight: 100,
+});
+
+chart
+  .data({
+    type: 'fetch',
+    value: 'https://assets.antv.antgroup.com/g2/indices.json',
+  });
+
+chart
+  .line()
+  .encode('x', (d) => new Date(d.Date))
+  .encode('y', 'Close')
+  .encode('color', 'Symbol')
+  .axis('y', { title: '↑ Change in price (%)' })
+
+chart
+  .text()
+  .encode('x', (d) => new Date(d.Date))
+  .encode('y', 'Close')
+  .encode('series', 'Symbol')
+  .encode('color', 'Symbol')
+  .encode('text', 'Symbol')
+  .transform({ type: 'select', series: 'last' })
+  .style('dx', 12)
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                     | 默认值                 |
+|-------------------|------------------------------------------------|-------------------------|-----------------------|
+| groupBy           | 针对指定的通道进行分组                             | `string` \| `string[]`  | `series`              |  
+| [channel]         | 针对每个分组，使用指定的通道进行指定的数据抽取，输出到对应的通道 | `Selector`       |                       |
+
+```ts
+type Selector =
+  | 'min'
+  | 'max'
+  | 'first'
+  | 'last'
+  | 'mean'
+  | 'median'
+  | ((I: number[], V: number[]) => number[]);
+```

--- a/site/docs/api/transform/select.zh.md
+++ b/site/docs/api/transform/select.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*q8F1S4YXwtsAAAAAAAAAAAAADmJ7AQ/original" width="500" />
+<img alt="select" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*q8F1S4YXwtsAAAAAAAAAAAAADmJ7AQ/original" width="500" />
 
 ```ts
 import { Chart } from '@antv/g2';

--- a/site/docs/api/transform/selectX.en.md
+++ b/site/docs/api/transform/selectX.en.md
@@ -1,0 +1,6 @@
+---
+title: selectX
+order: 1
+---
+
+<embed src="@/docs/api/transform/selectX.zh.md"></embed>

--- a/site/docs/api/transform/selectX.zh.md
+++ b/site/docs/api/transform/selectX.zh.md
@@ -1,0 +1,39 @@
+---
+title: selectX
+order: 1
+---
+
+按照指定通道进行分组，根据 x 通道和 selector 从每组选择出数据。
+
+## 开始使用
+
+具体案例可以参考 [select](/api/transform/select)，下面伪代码示意一下。
+
+```ts
+chart
+  .point()
+  // ...
+  .transform({
+    type: 'selectX',
+    selector: 'mean',
+    /* options */
+  });
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                     | 默认值                 |
+|-------------------|------------------------------------------------|-------------------------|-----------------------|
+| groupBy           | 针对指定的通道进行分组                             | `string` \| `string[]`  | `series`              |  
+| selector          | 针对每个分组，使用指定的通道进行指定的数据抽取，输出到 x 通道 | `Selector`         |  `first`              |
+
+```ts
+type Selector =
+  | 'min'
+  | 'max'
+  | 'first'
+  | 'last'
+  | 'mean'
+  | 'median'
+  | ((I: number[], V: number[]) => number[]);
+```

--- a/site/docs/api/transform/selectY.en.md
+++ b/site/docs/api/transform/selectY.en.md
@@ -1,0 +1,6 @@
+---
+title: selectX
+order: 1
+---
+
+<embed src="@/docs/api/transform/selectX.zh.md"></embed>

--- a/site/docs/api/transform/selectY.zh.md
+++ b/site/docs/api/transform/selectY.zh.md
@@ -1,0 +1,39 @@
+---
+title: selectY
+order: 1
+---
+
+按照指定的通道进行分组，根据 y 通道和 selector 从每组选择出数据。
+
+## 开始使用
+
+具体案例可以参考 [select](/api/transform/select)，下面伪代码示意一下。
+
+```ts
+chart
+  .point()
+  // ...
+  .transform({
+    type: 'selectY',
+    selector: 'mean',
+    /* options */
+  });
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                     | 默认值                 |
+|-------------------|------------------------------------------------|-------------------------|-----------------------|
+| groupBy           | 针对指定的通道进行分组                             | `string` \| `string[]`  | `series`              |  
+| selector          | 针对每个分组，使用指定的通道进行指定的数据抽取，输出到 y 通道 | `Selector`         | `first`               |
+
+```ts
+type Selector =
+  | 'min'
+  | 'max'
+  | 'first'
+  | 'last'
+  | 'mean'
+  | 'median'
+  | ((I: number[], V: number[]) => number[]);
+```

--- a/site/docs/api/transform/sortColor.en.md
+++ b/site/docs/api/transform/sortColor.en.md
@@ -1,0 +1,6 @@
+---
+title: sortColor
+order: 1
+---
+
+<embed src="@/docs/api/transform/sortColor.zh.md"></embed>

--- a/site/docs/api/transform/sortColor.zh.md
+++ b/site/docs/api/transform/sortColor.zh.md
@@ -1,0 +1,43 @@
+---
+title: sortColor
+order: 1
+---
+
+对离散的 color 比例尺的定义域根据指定通道排序。
+
+## 开始使用
+
+案例可以参考 [sortX](/api/transform/sortX)，下面是伪代码示意。
+
+```ts
+chart
+  .interval()
+  // ...
+  .transform({
+    type: 'sortColor',
+    /* options */
+  });
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                               | 默认值                 |
+|-------------------|------------------------------------------------|-----------------------------------|-----------------------|
+| reverse           | 是否逆序                                        | `boolean`                        | `false`               |  
+| by                | 指定排序的通道                                   | `string`                          | `y`                   |
+| slice             | 选择一个分片范围                                  | `number \| [number, number]`      | `y`                   |
+| reducer           | 分组聚合，用于比较大小                             | `Reducer`                         | `max`                 |
+
+```ts
+type Primitive = number | string | boolean | Date;
+
+type Reducer =
+  | 'max'
+  | 'min'
+  | 'sum'
+  | 'first'
+  | 'last'
+  | 'mean'
+  | 'median'
+  | ((I: number[], V: Primitive[]) => Primitive);
+```

--- a/site/docs/api/transform/sortX.en.md
+++ b/site/docs/api/transform/sortX.en.md
@@ -1,0 +1,6 @@
+---
+title: sortX
+order: 1
+---
+
+<embed src="@/docs/api/transform/sortX.zh.md"></embed>

--- a/site/docs/api/transform/sortX.zh.md
+++ b/site/docs/api/transform/sortX.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*TehBRbDnoIkAAAAAAAAAAAAADmJ7AQ/original" width="500" />
+<img alt="sortX" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*TehBRbDnoIkAAAAAAAAAAAAADmJ7AQ/original" width="500" />
 
 ```ts
 import { Chart } from '@antv/g2';

--- a/site/docs/api/transform/sortX.zh.md
+++ b/site/docs/api/transform/sortX.zh.md
@@ -1,0 +1,87 @@
+---
+title: sortX
+order: 1
+---
+
+对离散的 x 比例尺的定义域根据指定通道排序。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*TehBRbDnoIkAAAAAAAAAAAAADmJ7AQ/original" width="500" />
+
+```ts
+import { Chart } from '@antv/g2';
+
+const tickFormatter = (d) => Math.abs(d) + (d < 0 ? 'BC' : d > 0 ? 'AC' : '');
+const left = (d) => d.end > -1500 && d.start > -3000;
+
+const chart = new Chart({
+  container: 'container',
+  width: 900,
+  height: 1000,
+  paddingRight: 80,
+});
+
+chart.coordinate({ type: 'transpose' });
+
+chart
+  .interval()
+  .data({
+    type: 'fetch',
+    value: 'https://assets.antv.antgroup.com/g2/world-history.json',
+  })
+  .transform({ type: 'sortX', by: 'y' })
+  .transform({ type: 'sortColor', by: 'y', reducer: 'min' })
+  .axis('y', [
+    {
+      tickCount: 5,
+      tickFormatter,
+      grid: null,
+      title: null,
+      labelTextAlign: 'start',
+    },
+    {
+      position: 'top',
+      tickFormatter,
+      title: null,
+      labelTextAlign: 'start',
+    },
+  ])
+  .axis('x', false)
+  .encode('x', 'civilization')
+  .encode('y', ['start', 'end'])
+  .encode('color', 'region')
+  .scale('color', { palette: 'set2' })
+  .label({
+    text: 'civilization',
+    position: (d) => (left(d) ? 'left' : 'right'),
+    textAlign: (d) => (left(d) ? 'end' : 'start'),
+    dx: (d) => (left(d) ? -5 : 5),
+    fontSize: 10,
+  });
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                               | 默认值                 |
+|-------------------|------------------------------------------------|-----------------------------------|-----------------------|
+| reverse           | 是否逆序                                        | `boolean`                        | `false`               |  
+| by                | 指定排序的通道                                   | `string`                          | `y`                   |
+| slice             | 选择一个分片范围                                  | `number \| [number, number]`      | `y`                   |
+| reducer           | 分组聚合，用于比较大小                             | `Reducer`                         | `max`                 |
+
+```ts
+type Primitive = number | string | boolean | Date;
+
+type Reducer =
+  | 'max'
+  | 'min'
+  | 'sum'
+  | 'first'
+  | 'last'
+  | 'mean'
+  | 'median'
+  | ((I: number[], V: Primitive[]) => Primitive);
+```

--- a/site/docs/api/transform/sortY.en.md
+++ b/site/docs/api/transform/sortY.en.md
@@ -1,0 +1,6 @@
+---
+title: sortY
+order: 1
+---
+
+<embed src="@/docs/api/transform/sortY.zh.md"></embed>

--- a/site/docs/api/transform/sortY.zh.md
+++ b/site/docs/api/transform/sortY.zh.md
@@ -1,0 +1,41 @@
+---
+title: sortY
+order: 1
+---
+
+对离散的 y 比例尺的定义域根据指定通道排序。
+
+## 开始使用
+
+```ts
+chart
+  .interval()
+  // ...
+  .transform({
+    type: 'sortY',
+    /* options */
+  });
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                               | 默认值                 |
+|-------------------|------------------------------------------------|-----------------------------------|-----------------------|
+| reverse           | 是否逆序                                        | `boolean`                        | `false`               |  
+| by                | 指定排序的通道                                   | `string`                          | `y`                   |
+| slice             | 选择一个分片范围                                  | `number \| [number, number]`      | `y`                   |
+| reducer           | 分组聚合，用于比较大小                             | `Reducer`                         | `max`                 |
+
+```ts
+type Primitive = number | string | boolean | Date;
+
+type Reducer =
+  | 'max'
+  | 'min'
+  | 'sum'
+  | 'first'
+  | 'last'
+  | 'mean'
+  | 'median'
+  | ((I: number[], V: Primitive[]) => Primitive);
+```

--- a/site/docs/api/transform/stackEnter.en.md
+++ b/site/docs/api/transform/stackEnter.en.md
@@ -1,0 +1,6 @@
+---
+title: stackEnter
+order: 1
+---
+
+<embed src="@/docs/api/transform/stackEnter.zh.md"></embed>

--- a/site/docs/api/transform/stackEnter.zh.md
+++ b/site/docs/api/transform/stackEnter.zh.md
@@ -1,0 +1,48 @@
+---
+title: stackEnter
+order: 1
+---
+
+对 enterDuration 和 enterDelay 通道进行堆叠，实现分组动画的效果。
+
+## 开始使用
+
+<img src="https://gw.alipayobjects.com/zos/raptor/1668659773138/stackenter.gif" width="600" />
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+});
+
+chart
+  .interval()
+  .data([
+    { type: 'Apple', year: '2001', value: 260 },
+    { type: 'Orange', year: '2001', value: 100 },
+    { type: 'Banana', year: '2001', value: 90 },
+    { type: 'Apple', year: '2002', value: 210 },
+    { type: 'Orange', year: '2002', value: 150 },
+    { type: 'Banana', year: '2002', value: 30 },
+  ])
+  .transform({ type: 'stackEnter', groupBy: 'x' })
+  .encode('x', 'year')
+  .encode('y', 'value')
+  .encode('color', 'type')
+  .encode('series', 'type')
+  .encode('enterDuration', 1000);
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                               | 默认值                 |
+|-------------------|------------------------------------------------|-----------------------------------|-----------------------|
+| groupBy           | 选择一个分组通道                                  | `string \| string[]`              | `x`                   |
+| orderBy           | 排序的通道                                       | `string`                          | `null`                |  
+| reverse           | 是否逆序                                         | `boolean`                         | `y`                   |
+| duration          | 动画间隔                                         | `number`                          | `3000`                |
+| reducer           | 分组取值方式                                     | `(I: number[], V: any[]) => any`   | `(I, V) => V[I[0]]`   |

--- a/site/docs/api/transform/stackEnter.zh.md
+++ b/site/docs/api/transform/stackEnter.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://gw.alipayobjects.com/zos/raptor/1668659773138/stackenter.gif" width="600" />
+<img alt="stackEnter" src="https://gw.alipayobjects.com/zos/raptor/1668659773138/stackenter.gif" width="600" />
 
 ```ts
 import { Chart } from '@antv/g2';

--- a/site/docs/api/transform/stackY.en.md
+++ b/site/docs/api/transform/stackY.en.md
@@ -1,0 +1,6 @@
+---
+title: stackY
+order: 1
+---
+
+<embed src="@/docs/api/transform/stackY.zh.md"></embed>

--- a/site/docs/api/transform/stackY.zh.md
+++ b/site/docs/api/transform/stackY.zh.md
@@ -1,0 +1,60 @@
+---
+title: stackY
+order: 1
+---
+
+按照指定通道分组，对每组的 y 和 y1 通道进行堆叠，实现堆叠效果。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*GwDUQbVt9XYAAAAAAAAAAAAADmJ7AQ/original" width="600" />
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+});
+
+chart
+  .interval()
+  .data({
+    type: 'fetch',
+    value:
+      'https://gw.alipayobjects.com/os/bmw-prod/f129b517-158d-41a9-83a3-3294d639b39e.csv',
+    format: 'csv',
+  })
+  .transform({ type: 'stackY' })
+  .transform({ type: 'sortX', by: 'y', reverse: true })
+  .encode('x', 'state')
+  .encode('y', 'population')
+  .encode('color', 'age')
+  .axis('y', { tickFormatter: '~s' });
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                               | 默认值                 |
+|-------------------|------------------------------------------------|-----------------------------------|-----------------------|
+| groupBy           | 指定分组通道                                     | `string \| string[]`              | `x`                   |
+| orderBy           | 指定排序的数据                                   | `TransformOrder`                   | `null`                |
+| y                 | y 通道选择的数据通道来源                           | `'y'\ | 'y1'`                     | `y`                   |
+| y1                | y1 通道选择的数据通道来源                          | `'y'\ | 'y1'`                     | `y1`                   |
+| reverse           | 是否逆序                                        | `boolean`                          | `false`               |
+| series            | 是否有分组字段                                   | `boolean`                         | `true`                 |
+
+```ts
+type Primitive = number | string | boolean | Date;
+
+type TransformOrder =
+  | 'value'
+  | 'sum'
+  | 'series'
+  | 'maxIndex'
+  | string[]
+  | null
+  | ((data: Record<string, Primitive>) => Primitive);
+```

--- a/site/docs/api/transform/stackY.zh.md
+++ b/site/docs/api/transform/stackY.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*GwDUQbVt9XYAAAAAAAAAAAAADmJ7AQ/original" width="600" />
+<img alt="stackY" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*GwDUQbVt9XYAAAAAAAAAAAAADmJ7AQ/original" width="600" />
 
 ```ts
 import { Chart } from '@antv/g2';

--- a/site/docs/api/transform/symmetryY.en.md
+++ b/site/docs/api/transform/symmetryY.en.md
@@ -1,0 +1,6 @@
+---
+title: symmetryY
+order: 1
+---
+
+<embed src="@/docs/api/transform/symmetryY.zh.md"></embed>

--- a/site/docs/api/transform/symmetryY.zh.md
+++ b/site/docs/api/transform/symmetryY.zh.md
@@ -7,7 +7,7 @@ order: 1
 
 ## 开始使用
 
-<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*Vf-FQZH-5FMAAAAAAAAAAAAADmJ7AQ/original" width="600" />
+<img alt="symmetryY" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*Vf-FQZH-5FMAAAAAAAAAAAAADmJ7AQ/original" width="600" />
 
 ```ts
 import { Chart } from '@antv/g2';

--- a/site/docs/api/transform/symmetryY.zh.md
+++ b/site/docs/api/transform/symmetryY.zh.md
@@ -1,0 +1,83 @@
+---
+title: symmetryY
+order: 1
+---
+
+按照指定通道分组，给每组的 y 和 y1 通道添加偏移，实现对称效果。
+
+## 开始使用
+
+<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*Vf-FQZH-5FMAAAAAAAAAAAAADmJ7AQ/original" width="600" />
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+});
+
+chart.data({
+  type: 'fetch',
+  value: 'https://assets.antv.antgroup.com/g2/unemployment-by-industry.json',
+  transform: [{
+    type: 'map',
+    callback: (d) => ({
+      ...d,
+      date: new Date(d.date),
+    })
+  }],
+});
+
+chart
+  .area()
+  .transform({ type: 'stackY' })
+  .transform({ type: 'symmetryY' })
+  .encode('x', 'date')
+  .encode('y', 'unemployed')
+  .encode('color', 'industry');
+
+chart.render();
+```
+
+## 选项
+
+| 属性               | 描述                                           | 类型                               | 默认值                 |
+|-------------------|------------------------------------------------|-----------------------------------|-----------------------|
+| groupBy           | 指定分组通道                                     | `string \| string[]`              | `x`                   |
+
+## FAQ
+
+- 怎么绘制一个对称的条形图？
+
+同样的，使用这个 transform 即可，如下：
+
+```ts
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  width: 800,
+  height: 300,
+});
+
+chart.coordinate({ type: 'transpose' });
+
+chart
+  .interval()
+  .data([
+    { x: 'A', y: 100 },
+    { x: 'B', y: 200 },
+    { x: 'C', y: 300 },
+    { x: 'D', y: 250 },
+  ])
+  .transform({ type: 'stackY' })
+  .transform({ type: 'symmetryY' })
+  .encode('x', 'x')
+  .encode('y', 'y')
+  .encode('color', 'x')
+  .scale('x', { padding: 0.5 })
+  .legend(false);
+
+chart.render();
+```

--- a/site/examples/animation/general/demo/meta.json
+++ b/site/examples/animation/general/demo/meta.json
@@ -51,6 +51,14 @@
         "en": "ZoomIn"
       },
       "screenshot": "https://gw.alipayobjects.com/zos/raptor/1667976930984/zoomIn.gif"
+    },
+    {
+      "filename": "stack-enter.ts",
+      "title": {
+        "zh": "StackEnter",
+        "en": "StackEnter"
+      },
+      "screenshot": "https://gw.alipayobjects.com/zos/raptor/1668659773138/stackenter.gif"
     }
   ]
 }

--- a/site/examples/animation/general/demo/stack-enter.ts
+++ b/site/examples/animation/general/demo/stack-enter.ts
@@ -1,0 +1,25 @@
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+});
+
+chart
+  .interval()
+  .data([
+    { type: 'Apple', year: '2001', value: 260 },
+    { type: 'Orange', year: '2001', value: 100 },
+    { type: 'Banana', year: '2001', value: 90 },
+    { type: 'Apple', year: '2002', value: 210 },
+    { type: 'Orange', year: '2002', value: 150 },
+    { type: 'Banana', year: '2002', value: 30 },
+  ])
+  .transform({ type: 'stackEnter', groupBy: 'x' })
+  .encode('x', 'year')
+  .encode('y', 'value')
+  .encode('color', 'type')
+  .encode('series', 'type')
+  .encode('enterDuration', 1000);
+
+chart.render();

--- a/site/examples/general/area/demo/streamgraph.ts
+++ b/site/examples/general/area/demo/streamgraph.ts
@@ -1,27 +1,30 @@
 import { Chart } from '@antv/g2';
 
-fetch('https://assets.antv.antgroup.com/g2/unemployment-by-industry.json')
-  .then((res) => res.json())
-  .then((data) =>
-    data.map((d) => ({
-      ...d,
-      date: new Date(d.date),
-    })),
-  )
-  .then((data) => {
-    const chart = new Chart({
-      container: 'container',
-      autoFit: true,
-    });
+const chart = new Chart({
+  container: 'container',
+  autoFit: true,
+});
 
-    chart.data(data);
+chart.data({
+  type: 'fetch',
+  value: 'https://assets.antv.antgroup.com/g2/unemployment-by-industry.json',
+  transform: [
+    {
+      type: 'map',
+      callback: (d) => ({
+        ...d,
+        date: new Date(d.date),
+      }),
+    },
+  ],
+});
 
-    chart
-      .area()
-      .transform([{ type: 'stackY' }, { type: 'symmetryY' }])
-      .encode('x', 'date')
-      .encode('y', 'unemployed')
-      .encode('color', 'industry');
+chart
+  .area()
+  .transform({ type: 'stackY' })
+  .transform({ type: 'symmetryY' })
+  .encode('x', 'date')
+  .encode('y', 'unemployed')
+  .encode('color', 'industry');
 
-    chart.render();
-  });
+chart.render();


### PR DESCRIPTION
* Transform - 对视觉通道 encode 进行变换。
  * [transform.bin](/api/transform/bin) - 对连续的 x 和 连续的 y 通道进行分箱，并且对通道根据指定的 redcuer 进行聚合。
  * [transform.binX](/api/transform/binx) - 对 x 通道进行分箱，如果希望对 y 通道进行分箱，使用 binX + transpose 坐标系。
  * [transform.diffY](/api/transform/diffy) - 对 y 和 y1 通道求差集。
  * [transform.dodgeX](/api/transform/dodgex) - 生成 series 通道值为 color 通道的值，根据 series 通道实现分组效果。
  * [transform.flexX](/api/transform/flexx) - 根据指定通道设置 x 比例尺的 flex 属性，实现不等宽矩形的效果。
  * [transform.group](/api/transform/group) - 对离散的 x 和 连续的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
  * [transform.groupColor](/api/transform/groupcolor) - 对离散的 color 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
  * [transform.groupX](/api/transform/groupx) - 对离散的 x 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
  * [transform.groupY](/api/transform/groupy) - 对离散的 y 通道进行分组，并且对通道根据指定的 Redcuer 进行聚合。
  * [transform.jitter](/api/transform/jitter) - 根据离散的 x 和 离散的 y 比例尺，生成 dy 和 dx 通道，实现在某个区域散开的效果。
  * [transform.jitterX](/api/transform/jitterx) - 根据离散的 x 比例尺，生成 dx 通道，实现在某个区域的 x 方向散开的效果。
  * [transform.normalizeY](./transform/normalizeY) - 对 y 和 y1 通道根据指定的 basis 进行归一化处理。
  * [transform.select](./transform/select) - 按照指定通道进行分组，根据指定通道和 selector 从每组选择出数据。
  * [transform.selectX](./transform/selectX) - 按照指定通道进行分组，根据 x 通道和 selector 从每组选择出数据。
  * [transform.selectY](./transform/selectY) - 按照指定的通道进行分组，根据 y 通道和 selector 从每组选择出数据。
  * [transform.pack](./transform/pack) - 生成 transform 和 scale 属性，从而让图形在空间中紧凑排列。
  * [transform.sortColor](./transform/sortColor) - 对离散的 color 比例尺的定义域根据指定通道排序。
  * [transform.sortX](./transform/sortX) - 对离散的 x 比例尺的定义域根据指定通道排序。
  * [transform.sortY](./transform/sortY) - 对离散的 y 比例尺的定义域根据指定通道排序。
  * [transform.stackEnter](./transform/stackEnter) - 对 enterDuration 和 enterDelay 通道进行堆叠，实现分组动画的效果。
  * [transform.stackY](./transform/stackY) - 按照指定通道分组，对每组的 y 和 y1 通道进行堆叠，实现堆叠效果。
  * [transform.symmetryY](./transform/symmetryY) - 按照指定通道分组，给每组的 y 和 y1 通道添加偏移，实现对称效果。