### PR TITLE
docs: add chart api

### DIFF
--- a/site/docs/api/chart.zh.md
+++ b/site/docs/api/chart.zh.md
@@ -3,4 +3,114 @@ title: Chart
 order: 2
 ---
 
-建设中！
+G2 的 Node 是图形容器的概念，Chart 以及 Mark（Interval、Area、Line 等）都继承自 Node。每一个 Node 拥有自己独立的数据源、坐标系、几何标记、Tooltip 以及图例，可以理解 Node 是整个 G2 体系中，用来组装 Data、Mark、Component 的容器。 一个 Node 可以包含有多个子 Node，通过这种嵌套关系，可以将一个画布按照不同的布局划分多个不同区域，也可以将不同数据源的多个 Node 叠加到一起，形成一个多数据源，多图层的图表。
+
+而 Chart 用于提供创建 canvas、自适应图表大小等能力，便于开发者使用的类。
+
+下面会介绍如何创建 Chart 对象，以及 Chart 对象提供一些 API，包括通用 API、生命周期 API 以及 Node 管理 API 等。
+
+## 创建 Chart 对象
+
+```js
+const chart = new Chart({
+  container: 'container',
+  width: 400,
+  height: 600,
+});
+```
+
+### 选项
+
+| API       | 描述                                                                                                                                                                                          | 类型                    | 默认值 |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------ |
+| container | 指定 chart 绘制的 DOM，可以传入 DOM id，也可以直接传入 dom 实例                                                                                                                               | `string \| HTMLElement` |        |
+| width     | 图表宽度                                                                                                                                                                                      | `number`                | 640    |
+| height    | 图表高度                                                                                                                                                                                      | `number`                | 480    |
+| renderer  | 指定渲染引擎，默认使用 canvas。                                                                                                                                                               |                         |        |
+| plugins   | 指定渲染时使用的插件                                                                                                                                                                          | `any[]`                 |        |
+| autoFit   | 图表是否自适应容器宽高，默认为 `false`，用户需要手动设置 `width` 和 `height`。<br/>当 `autoFit: true` 时，会自动取图表容器的宽高，如果用户设置了 `height`，那么会以用户设置的 `height` 为准。 | `boolean`               | false  |
+| padding   | 图表内边距                                                                                                                                                                                    | `number`                | 30     |
+
+## Chart API
+
+| API                                               | 描述                         | 示例               |
+| ------------------------------------------------- | ---------------------------- | ------------------ |
+| chart.[`mark`] ()                                 | 为 Chart 添加图形标记        | `chart.interval()` |
+| chart.render()                                    | 调用图表的渲染方法           |                    |
+| chart.options()                                   | 获取图表的配置项             |                    |
+| chart.node()                                      | 获取图表的 HTML 容器         |                    |
+| chart.forceFit()                                  | 自动根据容器大小 resize 画布 |                    |
+| chart.destroy()                                   | 销毁图表容器和 Canvas 画布   |                    |
+| chart.changeSize(_width: number, height: number_) | 改变图表大小，同时重新渲染。 |                    |
+
+## Node API
+
+| API                                          | 描述                                                                                                                           | 示例               |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
+| node.[**attribute**] (_...params?_)          | 修改或者返回节点对应的属性。<br/>如果该函数没有参数，那么返回节点对应的属性值；<br/>如果函数有参数，那么会去设置对应属性的值。 | `node.data([...])` |
+| node.remove()                                | 从当前 node 的父节点上移除该节点                                                                                               | -                  |
+| node.getNodesByType(_type: string_):_Node[]_ | 通过 type 查找所有的 node 子节点                                                                                               | -                  |
+| node.getNodeByKey(_key: string_):_Node_      | 通过 key 查找当前 node 的子节点                                                                                                | -                  |
+| node.changeSize(data: _Datum[]_)             | 改变 Node 数据并重新渲染图表                                                                                                   | -                  |
+| node.append(Ctor: _Node_)                    | 创建一个新的 Node 并添加在 node 的子节点上                                                                                     | -                  |
+
+**配置 node 的属性有：**
+
+- `node.data()`： 配置当前 Node 的数据源。
+- `node.encode()`： 配置当前 Node 的每个通道的字段名称。
+- `node.scale()`： 配置当前 Node 的每个通道的比例尺。
+- `node.coordinate()`： 配置当前 Node 的坐标变换。
+- `node.legend()`： 配置当前 Node 图形的图例。
+- `node.axis()`： 配置当前 Node 图形的坐标轴。
+- `node.tooltip()`： 配置当前 Node 图形的 Tooltip。
+- `node.label()`： 配置当前 Node 图形的标签样式。
+- `node.style()`： 配置当前 Node 图形的样式。
+- `node.theme()`： 配置当前 Node 图形的主题样式。
+
+上述属性支持链式调用，例如：
+
+```js
+const chart = new Chart({
+  container: 'container',
+  width: 640,
+  height: 480,
+});
+
+chart
+  .interval()
+  .data([
+    { genre: 'Sports', sold: 275 },
+    { genre: 'Strategy', sold: 115 },
+    { genre: 'Action', sold: 120 },
+    { genre: 'Shooter', sold: 350 },
+    { genre: 'Other', sold: 150 },
+  ])
+  .encode('x', 'genre')
+  .encode('y', 'sold')
+  .encode('color', 'genre');
+
+chart.render();
+```
+
+## Chart 生命周期 API
+
+图表渲染的生命周期有：
+
+- `beforerender`
+- `afterrender`
+- `beforepaint`
+- `afterpaint`
+- `beforechangedata`
+- `afterchangedata`
+- `beforechangesize`
+- `afterchangesize`
+- `beforedestroy`
+- `afterdestroy`
+
+通过 `chart.on()` 来申明生命周期事件。例如：
+
+```js
+chart.on('afterrender', (e) => {
+  // callback
+});
+```

--- a/site/docs/api/chart.zh.md
+++ b/site/docs/api/chart.zh.md
@@ -3,71 +3,13 @@ title: Chart
 order: 2
 ---
 
-G2 的 Node 是图形容器的概念，Chart 以及 Mark（Interval、Area、Line 等）都继承自 Node。每一个 Node 拥有自己独立的数据源、坐标系、几何标记、Tooltip 以及图例，可以理解 Node 是整个 G2 体系中，用来组装 Data、Mark、Component 的容器。 一个 Node 可以包含有多个子 Node，通过这种嵌套关系，可以将一个画布按照不同的布局划分多个不同区域，也可以将不同数据源的多个 Node 叠加到一起，形成一个多数据源，多图层的图表。
+G2 的 Node 是图形容器的概念，Chart 以及 Mark（Interval、Area、Line 等）都继承自 Node 类。每一个 Node 拥有自己独立的数据源、坐标系、几何标记、Tooltip 以及图例，可以理解 Node 是整个 G2 体系中，用来组装 Data、Mark、Component 的容器。 一个 Node 可以包含有多个子 Node，通过这种嵌套关系，可以将一个画布按照不同的布局划分多个不同区域，也可以将不同数据源的多个 Node 叠加到一起，形成一个多数据源，多图层的图表。
 
-而 Chart 用于提供创建 canvas、自适应图表大小等能力，便于开发者使用的类。
+而 Chart 用于提供创建 canvas、自适应图表大小等能力。
 
-下面会介绍如何创建 Chart 对象，以及 Chart 对象提供一些 API，包括通用 API、生命周期 API 以及 Node 管理 API 等。
+下面会介绍如何创建 Chart 对象，以及 Chart 对象提供一些 API，包括通用 API、生命周期 API 以及 Node API 等。
 
-## 创建 Chart 对象
-
-```js
-const chart = new Chart({
-  container: 'container',
-  width: 400,
-  height: 600,
-});
-```
-
-### 选项
-
-| API       | 描述                                                                                                                                                                                          | 类型                    | 默认值 |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------ |
-| container | 指定 chart 绘制的 DOM，可以传入 DOM id，也可以直接传入 dom 实例                                                                                                                               | `string \| HTMLElement` |        |
-| width     | 图表宽度                                                                                                                                                                                      | `number`                | 640    |
-| height    | 图表高度                                                                                                                                                                                      | `number`                | 480    |
-| renderer  | 指定渲染引擎，默认使用 canvas。                                                                                                                                                               |                         |        |
-| plugins   | 指定渲染时使用的插件                                                                                                                                                                          | `any[]`                 |        |
-| autoFit   | 图表是否自适应容器宽高，默认为 `false`，用户需要手动设置 `width` 和 `height`。<br/>当 `autoFit: true` 时，会自动取图表容器的宽高，如果用户设置了 `height`，那么会以用户设置的 `height` 为准。 | `boolean`               | false  |
-| padding   | 图表内边距                                                                                                                                                                                    | `number`                | 30     |
-
-## Chart API
-
-| API                                               | 描述                         | 示例               |
-| ------------------------------------------------- | ---------------------------- | ------------------ |
-| chart.[`mark`] ()                                 | 为 Chart 添加图形标记        | `chart.interval()` |
-| chart.render()                                    | 调用图表的渲染方法           |                    |
-| chart.options()                                   | 获取图表的配置项             |                    |
-| chart.node()                                      | 获取图表的 HTML 容器         |                    |
-| chart.forceFit()                                  | 自动根据容器大小 resize 画布 |                    |
-| chart.destroy()                                   | 销毁图表容器和 Canvas 画布   |                    |
-| chart.changeSize(_width: number, height: number_) | 改变图表大小，同时重新渲染。 |                    |
-
-## Node API
-
-| API                                          | 描述                                                                                                                           | 示例               |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
-| node.[**attribute**] (_...params?_)          | 修改或者返回节点对应的属性。<br/>如果该函数没有参数，那么返回节点对应的属性值；<br/>如果函数有参数，那么会去设置对应属性的值。 | `node.data([...])` |
-| node.remove()                                | 从当前 node 的父节点上移除该节点                                                                                               | -                  |
-| node.getNodesByType(_type: string_):_Node[]_ | 通过 type 查找所有的 node 子节点                                                                                               | -                  |
-| node.getNodeByKey(_key: string_):_Node_      | 通过 key 查找当前 node 的子节点                                                                                                | -                  |
-| node.changeSize(data: _Datum[]_)             | 改变 Node 数据并重新渲染图表                                                                                                   | -                  |
-| node.append(Ctor: _Node_)                    | 创建一个新的 Node 并添加在 node 的子节点上                                                                                     | -                  |
-
-**配置 node 的属性有：**
-
-- `node.data()`： 配置当前 Node 的数据源。
-- `node.encode()`： 配置当前 Node 的每个通道的字段名称。
-- `node.scale()`： 配置当前 Node 的每个通道的比例尺。
-- `node.coordinate()`： 配置当前 Node 的坐标变换。
-- `node.legend()`： 配置当前 Node 图形的图例。
-- `node.axis()`： 配置当前 Node 图形的坐标轴。
-- `node.tooltip()`： 配置当前 Node 图形的 Tooltip。
-- `node.label()`： 配置当前 Node 图形的标签样式。
-- `node.style()`： 配置当前 Node 图形的样式。
-- `node.theme()`： 配置当前 Node 图形的主题样式。
-
-上述属性支持链式调用，例如：
+## 开始使用
 
 ```js
 const chart = new Chart({
@@ -92,7 +34,119 @@ chart
 chart.render();
 ```
 
-## Chart 生命周期 API
+## 配置
+
+| API       | 描述                                                                                                                                                                                          | 类型                    | 默认值 |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------ |
+| container | 指定 chart 绘制的 DOM，可以传入 DOM id，也可以直接传入 dom 实例                                                                                                                               | `string \| HTMLElement` |        |
+| width     | 图表宽度                                                                                                                                                                                      | `number`                | 640    |
+| height    | 图表高度                                                                                                                                                                                      | `number`                | 480    |
+| renderer  | 指定渲染引擎，默认使用 canvas。                                                                                                                                                               |                         |        |
+| plugins   | 指定渲染时使用的插件 ，具体见 [plugin](/api/plugin/rough)                                                                                                                                     | `any[]`                 |        |
+| autoFit   | 图表是否自适应容器宽高，默认为 `false`，用户需要手动设置 `width` 和 `height`。<br/>当 `autoFit: true` 时，会自动取图表容器的宽高，如果用户设置了 `height`，那么会以用户设置的 `height` 为准。 | `boolean`               | false  |
+| padding   | 图表内边距                                                                                                                                                                                    | `number`                | 30     |
+
+## Chart API
+
+### `chart.[mark]()`
+
+设置图表的 Mark 标记，具体见 [mark](/api/mark)。
+
+### `chart.render()`
+
+调用图表的渲染方法。
+
+### `chart.options()`
+
+获取图表的配置项。
+
+### `chart.node()`
+
+获取图表的 HTML 容器。
+
+### `chart.forceFit()`
+
+自动根据外部 DOM 容器大小调整画布并重新渲染。
+
+### `chart.changeSize(width: number, height: number)`
+
+改变图表的宽高，并重新渲染。
+
+### `chart.destroy()`
+
+销毁图表容器和 Canvas 画布。
+
+## Node API
+
+Mark 以及 Chart 共享的 API
+
+### `node.data()`
+
+设置图形的数据，支持多种数据来源和数据变换，具体见 [data](/api/data/overview)。
+
+### `node.encode()`
+
+设置图形每个通道的字段名称，具体见 [encode](/api/encode/overview)。
+
+### `node.scale()`
+
+设置图形每个通道的比例尺，具体见 [scale](/api/scale/overview)。
+
+### `node.coordinate()`
+
+设置图形的坐标变换，具体见 [coordinate](/api/coordinate/overview)。
+
+### `node.legend()`
+
+设置图形的图例，具体见 [legend](/api/component/legend/overview)。
+
+### `node.tooltip()`
+
+设置图形的 Tooltip，具体见 [tooltip](/api/component/tooltip/overview)。
+
+### `node.axis()`
+
+设置图形的坐标轴，具体见 [axis](/api/component/axis/overview)。
+
+### `node.label()`
+
+设置图形的标签，具体见 [label](/api/label/overview)。
+
+### `node.style()`
+
+设置图形的样式，具体见 [style](/api/style/overview)。
+
+### `node.theme()`
+
+设置图形的主题，具体见 [style](/api/theme/overview)。
+
+### `node.changeData(data:Datum[])`
+
+更改图形的数据来源并重新渲染整个图表。
+
+### `node.getNodesByType(type: string): Node[]`
+
+通过 type 查找所有的 node 子节点。
+
+### `node.getNodeByKey(key: string): Node`
+
+通过 key 找到当前 node 的子节点。
+
+### `node.changeData(data: Datum[])`
+
+更新当前图形的数据并重新渲染图表。
+
+### `node.append(node:Node)`
+
+创建一个新的 Node 并添加在 node 的子节点上。
+
+### `node.remove()`
+
+从当前 node 的父节点上移除该节点。
+
+## 事件
+
+### 生命周期事件
 
 图表渲染的生命周期有：
 
@@ -111,6 +165,37 @@ chart.render();
 
 ```js
 chart.on('afterrender', (e) => {
-  // callback
+  console.log('Chart has been rendered!');
 });
+```
+
+### UI 事件
+
+## FAQ
+
+- 如何使用 svg 进行图表渲染？
+
+```js
+import { Renderer as GRenderer } from '@antv/g-svg';
+const chart = new Chart({
+  container: 'container',
+  width: 640,
+  height: 480,
+  renderer: GRenderer,
+});
+
+chart
+  .interval()
+  .data([
+    { genre: 'Sports', sold: 275 },
+    { genre: 'Strategy', sold: 115 },
+    { genre: 'Action', sold: 120 },
+    { genre: 'Shooter', sold: 350 },
+    { genre: 'Other', sold: 150 },
+  ])
+  .encode('x', 'genre')
+  .encode('y', 'sold')
+  .encode('color', 'genre');
+
+chart.render();
 ```

--- a/site/docs/api/chart.zh.md
+++ b/site/docs/api/chart.zh.md
@@ -148,18 +148,18 @@ Mark 以及 Chart 共享的 API
 
 ### 生命周期事件
 
-图表渲染的生命周期有：
-
-- `beforerender`
-- `afterrender`
-- `beforepaint`
-- `afterpaint`
-- `beforechangedata`
-- `afterchangedata`
-- `beforechangesize`
-- `afterchangesize`
-- `beforedestroy`
-- `afterdestroy`
+| 事件               | 描述                             |
+| ------------------ | -------------------------------- |
+| `beforerender`     | 图表渲染前执行该事件             |
+| `afterrender`      | 图表渲染后执行该事件             |
+| `beforepaint`      | 图表布局计算后，绘制前执行该事件 |
+| `afterpaint`       | 图表绘制后执行该事件             |
+| `beforechangedata` | 图表更新数据前执行该事件         |
+| `afterchangedata`  | 图表更新数据后执行该事件         |
+| `beforechangesize` | 图表更新尺寸前执行该事件         |
+| `afterchangesize`  | 图表更新尺寸后执行该事件         |
+| `beforedestroy`    | 图表销毁前执行该事件             |
+| `afterdestroy`     | 图表销毁后执行该事件             |
 
 通过 `chart.on()` 来申明生命周期事件。例如：
 

--- a/site/examples/general/text/demo/wordCloud-mask.ts
+++ b/site/examples/general/text/demo/wordCloud-mask.ts
@@ -16,14 +16,12 @@ chart
       'https://gw.alipayobjects.com/os/antvdemo/assets/data/antv-keywords.json',
   })
   .layout({
-    padding: 0,
     imageMask:
       'https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*LKU4TYEiB-4AAAAAAAAAAAAADmJ7AQ/original',
     fontSize: 10,
   })
   .encode('color', 'name')
   .encode('text', 'name')
-  .axis(false)
-  .legend(false);
+  .axis(false);
 
 chart.render();

--- a/site/examples/general/text/demo/wordCloud.ts
+++ b/site/examples/general/text/demo/wordCloud.ts
@@ -13,11 +13,9 @@ chart
     value: 'https://assets.antv.antgroup.com/g2/philosophy-word.json',
   })
   .layout({
-    padding: 3,
     spiral: 'rectangular',
   })
   .encode('color', 'text')
-  .axis(false)
-  .legend(false);
+  .axis(false);
 
 chart.render();

--- a/site/examples/graph/hierarchy/demo/treemap.ts
+++ b/site/examples/graph/hierarchy/demo/treemap.ts
@@ -19,9 +19,7 @@ chart
   })
   .encode('value', 'size')
   .encode('color', (d) => d.parent.data.name.split('.')[1])
-  .encode('legend', (d) => d.parent.data.name.split('.')[1])
   .scale('color', { range: schemeTableau10 })
-  .axis(false)
   .style(
     'labelText',
     (d) =>

--- a/src/mark/treemap.ts
+++ b/src/mark/treemap.ts
@@ -136,7 +136,6 @@ export const Treemap: CC<TreemapOptions> = (options) => {
     const DEFAULT_OPTIONS = {
       type: 'rect',
       axis: false,
-      legend: false,
       encode: {
         x: 'x',
         y: 'y',

--- a/src/mark/wordCloud.ts
+++ b/src/mark/wordCloud.ts
@@ -9,6 +9,15 @@ import {
 
 export type WordCloudOptions = Omit<WordCloudMark, 'type'>;
 
+function initializeData(data, encode) {
+  const { text = 'text', value = 'value' } = encode;
+  return data.map((d) => ({
+    ...d,
+    text: d[text],
+    value: data[value],
+  }));
+}
+
 export const WordCloud: CC<WordCloudOptions> = (options) => {
   return async (viewOptions) => {
     const { width, height } = getBBoxSize(viewOptions);
@@ -22,11 +31,9 @@ export const WordCloud: CC<WordCloudOptions> = (options) => {
     } = options;
     const DEFAULT_LAYOUT_OPTIONS: WordCloudTransformOptions = {
       size: [width, height],
-      padding: 2,
     };
     const DEFAULT_OPTIONS = {
       axis: false,
-      legend: false,
       type: 'text',
       encode: {
         x: 'x',
@@ -45,10 +52,11 @@ export const WordCloud: CC<WordCloudOptions> = (options) => {
         textAlign: 'center',
       },
     };
+    const initializedData = initializeData(data, encode);
     const transformData = await WordCloudTransform({
       ...DEFAULT_LAYOUT_OPTIONS,
       ...layout,
-    })(data);
+    })(initializedData);
 
     return [
       deepMix({}, DEFAULT_OPTIONS, {

--- a/src/runtime/render.ts
+++ b/src/runtime/render.ts
@@ -134,7 +134,7 @@ export function destroy<T extends G2ViewTree = G2ViewTree>(
   }
 
   // Unbind chart events.
-  bindAutoFit(options, context);
+  unbindAutoFit(options, context);
   offEvent(on);
 }
 


### PR DESCRIPTION

G2 的 Node 是图形容器的概念，Chart 以及 Mark（Interval、Area、Line 等）都继承自 Node 类。每一个 Node 拥有自己独立的数据源、坐标系、几何标记、Tooltip 以及图例，可以理解 Node 是整个 G2 体系中，用来组装 Data、Mark、Component 的容器。 一个 Node 可以包含有多个子 Node，通过这种嵌套关系，可以将一个画布按照不同的布局划分多个不同区域，也可以将不同数据源的多个 Node 叠加到一起，形成一个多数据源，多图层的图表。

而 Chart 用于提供创建 canvas、自适应图表大小等能力。

下面会介绍如何创建 Chart 对象，以及 Chart 对象提供一些 API，包括通用 API、生命周期 API 以及 Node API 等。

## 开始使用

```js
const chart = new Chart({
  container: 'container',
  width: 640,
  height: 480,
});

chart
  .interval()
  .data([
    { genre: 'Sports', sold: 275 },
    { genre: 'Strategy', sold: 115 },
    { genre: 'Action', sold: 120 },
    { genre: 'Shooter', sold: 350 },
    { genre: 'Other', sold: 150 },
  ])
  .encode('x', 'genre')
  .encode('y', 'sold')
  .encode('color', 'genre');

chart.render();
```

## 配置

| API       | 描述                                                                                                                                                                                          | 类型                    | 默认值 |
| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------ |
| container | 指定 chart 绘制的 DOM，可以传入 DOM id，也可以直接传入 dom 实例                                                                                                                               | `string \| HTMLElement` |        |
| width     | 图表宽度                                                                                                                                                                                      | `number`                | 640    |
| height    | 图表高度                                                                                                                                                                                      | `number`                | 480    |
| renderer  | 指定渲染引擎，默认使用 canvas。                                                                                                                                                               |                         |        |
| plugins   | 指定渲染时使用的插件 ，具体见 [plugin](/api/plugin/rough)                                                                                                                                     | `any[]`                 |        |
| autoFit   | 图表是否自适应容器宽高，默认为 `false`，用户需要手动设置 `width` 和 `height`。<br/>当 `autoFit: true` 时，会自动取图表容器的宽高，如果用户设置了 `height`，那么会以用户设置的 `height` 为准。 | `boolean`               | false  |
| padding   | 图表内边距                                                                                                                                                                                    | `number`                | 30     |

## Chart API

### `chart.[mark]()`

设置图表的 Mark 标记，具体见 [mark](/api/mark)。

### `chart.render()`

调用图表的渲染方法。

### `chart.options()`

获取图表的配置项。

### `chart.node()`

获取图表的 HTML 容器。

### `chart.forceFit()`

自动根据外部 DOM 容器大小调整画布并重新渲染。

### `chart.changeSize(width: number, height: number)`

改变图表的宽高，并重新渲染。

### `chart.destroy()`

销毁图表容器和 Canvas 画布。

## Node API

Mark 以及 Chart 共享的 API

### `node.data()`

设置图形的数据，支持多种数据来源和数据变换，具体见 [data](/api/data/overview)。

### `node.encode()`

设置图形每个通道的字段名称，具体见 [encode](/api/encode/overview)。

### `node.scale()`

设置图形每个通道的比例尺，具体见 [scale](/api/scale/overview)。

### `node.coordinate()`

设置图形的坐标变换，具体见 [coordinate](/api/coordinate/overview)。

### `node.legend()`

设置图形的图例，具体见 [legend](/api/component/legend/overview)。

### `node.tooltip()`

设置图形的 Tooltip，具体见 [tooltip](/api/component/tooltip/overview)。

### `node.axis()`

设置图形的坐标轴，具体见 [axis](/api/component/axis/overview)。

### `node.label()`

设置图形的标签，具体见 [label](/api/label/overview)。

### `node.style()`

设置图形的样式，具体见 [style](/api/style/overview)。

### `node.theme()`

设置图形的主题，具体见 [style](/api/theme/overview)。

### `node.changeData(data:Datum[])`

更改图形的数据来源并重新渲染整个图表。

### `node.getNodesByType(type: string): Node[]`

通过 type 查找所有的 node 子节点。

### `node.getNodeByKey(key: string): Node`

通过 key 找到当前 node 的子节点。

### `node.changeData(data: Datum[])`

更新当前图形的数据并重新渲染图表。

### `node.append(node:Node)`

创建一个新的 Node 并添加在 node 的子节点上。

### `node.remove()`

从当前 node 的父节点上移除该节点。

## 事件

### 生命周期事件

图表渲染的生命周期有：

- `beforerender`
- `afterrender`
- `beforepaint`
- `afterpaint`
- `beforechangedata`
- `afterchangedata`
- `beforechangesize`
- `afterchangesize`
- `beforedestroy`
- `afterdestroy`

通过 `chart.on()` 来申明生命周期事件。例如：

```js
chart.on('afterrender', (e) => {
  console.log('Chart has been rendered!');
});
```

### UI 事件

## FAQ

- 如何使用 svg 进行图表渲染？

```js
import { Renderer as GRenderer } from '@antv/g-svg';
const chart = new Chart({
  container: 'container',
  width: 640,
  height: 480,
  renderer: GRenderer,
});

chart
  .interval()
  .data([
    { genre: 'Sports', sold: 275 },
    { genre: 'Strategy', sold: 115 },
    { genre: 'Action', sold: 120 },
    { genre: 'Shooter', sold: 350 },
    { genre: 'Other', sold: 150 },
  ])
  .encode('x', 'genre')
  .encode('y', 'sold')
  .encode('color', 'genre');

chart.render();
```
