### PR TITLE
fix(select): lowercase Select to select

### DIFF
--- a/src/transform/sample.ts
+++ b/src/transform/sample.ts
@@ -1,5 +1,4 @@
-import { max } from 'd3-array';
-import { TransformComponent as TC, G2Mark, Primitive } from '../runtime';
+import { TransformComponent as TC, Primitive } from '../runtime';
 import { SampleTransform } from '../spec';
 import { createGroups } from './utils/order';
 import { GroupN } from './groupN';

--- a/src/transform/selectX.ts
+++ b/src/transform/selectX.ts
@@ -1,6 +1,6 @@
 import { TransformComponent as TC } from '../runtime';
 import { SelectXTransform } from '../spec';
-import { Select } from './Select';
+import { Select } from './select';
 
 export type SelectXOptions = Omit<SelectXTransform, 'type'>;
 

--- a/src/transform/selectY.ts
+++ b/src/transform/selectY.ts
@@ -1,6 +1,6 @@
 import { TransformComponent as TC } from '../runtime';
 import { SelectYTransform } from '../spec';
-import { Select } from './Select';
+import { Select } from './select';
 
 export type SelectYOptions = Omit<SelectYTransform, 'type'>;
 


### PR DESCRIPTION
将 `selectX` 和 `selectY` 里面的 `Select` 改成 `select`