### PR TITLE
feat(interaction): add facet tooltip

### DIFF
--- a/__tests__/integration/interactions/index.ts
+++ b/__tests__/integration/interactions/index.ts
@@ -23,3 +23,4 @@ export { temperaturesLineTooltipDiscrete } from './temperatures-line-tooltip-dis
 export { morleyBoxTooltip } from './morley-box-tooltip';
 export { temperaturesLineLegendFilterOrdinal } from './temperatures-line-legend-filter-ordinal';
 export { profitIntervalLegendFilterOrdinal } from './profit-interval-legend-filter-ordinal';
+export { indicesLineChartFacetTooltip } from './indices-line-chart-facet-tooltip';

--- a/__tests__/integration/interactions/indices-line-chart-facet-tooltip.ts
+++ b/__tests__/integration/interactions/indices-line-chart-facet-tooltip.ts
@@ -1,0 +1,38 @@
+import { csv } from 'd3-fetch';
+import { autoType } from 'd3-dsv';
+import { G2Spec } from '../../../src';
+
+export async function indicesLineChartFacetTooltip(): Promise<G2Spec> {
+  const data = await csv('data/indices.csv', autoType);
+  return {
+    type: 'facetRect',
+    height: 600,
+    width: 700,
+    paddingRight: 80,
+    paddingBottom: 50,
+    paddingLeft: 60,
+    encode: { y: 'Symbol' },
+    scale: { y: { paddingInner: 0.2 } },
+    data,
+    children: [
+      {
+        type: 'line',
+        frame: false,
+        scale: { y: { nice: true, facet: false } },
+        axis: { y: { labelAutoRotate: false } },
+        encode: {
+          x: 'Date',
+          y: 'Close',
+          color: 'Symbol',
+          key: 'Symbol',
+          title: (d) => new Date(d.Date).toLocaleDateString(),
+        },
+      },
+    ],
+    interactions: [
+      { type: 'tooltip', series: true, facet: true, crosshairs: true },
+    ],
+  };
+}
+
+indicesLineChartFacetTooltip.skip = true;

--- a/__tests__/integration/interactions/temperatures-line-tooltip-discrete.ts
+++ b/__tests__/integration/interactions/temperatures-line-tooltip-discrete.ts
@@ -10,7 +10,7 @@ export function temperaturesLineTooltipDiscrete(): G2Spec {
       y: 'temperature',
       color: 'city',
     },
-    interactions: [{ type: 'tooltip', showCrosshairs: false }],
+    interactions: [{ type: 'tooltip', crosshairs: false }],
   };
 }
 

--- a/src/composition/facetRect.ts
+++ b/src/composition/facetRect.ts
@@ -174,6 +174,7 @@ export const setChildren = useOverrideAdaptor<G2ViewTree>(
       x: originX = 0,
       y: originY = 0,
       shareData = false,
+      key: viewKey,
     } = options;
     const { value: data } = dataValue;
     // Only support field encode now.
@@ -256,6 +257,7 @@ export const setChildren = useOverrideAdaptor<G2ViewTree>(
               data: newData,
               x: left + paddingLeft + originX,
               y: top + paddingTop + originY,
+              parentKey: viewKey,
               width,
               height,
               paddingLeft: 0,

--- a/src/composition/mark.ts
+++ b/src/composition/mark.ts
@@ -35,6 +35,7 @@ export const Mark: CC<MarkOptions> = () => {
       frame,
       title,
       labelTransform,
+      parentKey,
       ...mark
     } = options;
 
@@ -68,6 +69,7 @@ export const Mark: CC<MarkOptions> = () => {
         marginBottom,
         marginTop,
         marginRight,
+        parentKey,
         marks: [{ ...mark, key: `${key}-0`, data }],
       },
     ];

--- a/src/composition/repeatMatrix.ts
+++ b/src/composition/repeatMatrix.ts
@@ -25,7 +25,13 @@ const setScale = useDefaultAdaptor<G2ViewTree>((options) => {
 });
 
 const setChildren = useOverrideAdaptor<G2ViewTree>((options) => {
-  const { data, children, x: originX = 0, y: originY = 0 } = options;
+  const {
+    data,
+    children,
+    x: originX = 0,
+    y: originY = 0,
+    key: viewKey,
+  } = options;
   const createChildren = (visualData, scale, layout) => {
     const { x: scaleX, y: scaleY } = scale;
     const { paddingLeft, paddingTop } = layout;
@@ -76,6 +82,7 @@ const setChildren = useOverrideAdaptor<G2ViewTree>((options) => {
         };
         return {
           data,
+          parentKey: viewKey,
           key: `${key}-${i}`,
           x: left + paddingLeft + originX,
           y: top + paddingTop + originY,

--- a/src/mark/area.ts
+++ b/src/mark/area.ts
@@ -84,6 +84,6 @@ Area.props = {
   interaction: {
     shareTooltip: true,
     seriesTooltip: true,
-    showCrosshairs: true,
+    crosshairs: true,
   },
 };

--- a/src/mark/line.ts
+++ b/src/mark/line.ts
@@ -101,6 +101,6 @@ Line.props = {
   interaction: {
     shareTooltip: true,
     seriesTooltip: true,
-    showCrosshairs: true,
+    crosshairs: true,
   },
 };

--- a/src/runtime/types/mark.ts
+++ b/src/runtime/types/mark.ts
@@ -23,7 +23,7 @@ export type MarkProps = {
   interaction?: {
     shareTooltip?: boolean;
     seriesTooltip?: boolean;
-    showCrosshairs?: boolean;
+    crosshairs?: boolean;
   };
 };
 

--- a/src/spec/interaction.ts
+++ b/src/spec/interaction.ts
@@ -125,6 +125,7 @@ export type TooltipInteraction = Omit<TooltipAction, 'type'> & {
   type?: 'tooltip';
   shared?: boolean;
   series?: boolean;
+  facet?: boolean;
   // @todo
   item?: any;
 };


### PR DESCRIPTION
# facet tooltip

添加分面的 tooltip，但是现在只能用于折线图和面积图这种 series Mark。


## 案例

![facet-tooltip](https://user-images.githubusercontent.com/49330279/206228133-aef11e71-dca5-4536-9b89-4fbec0f80da6.gif)

```ts
export async function indicesLineChartFacetTooltip(): Promise<G2Spec> {
  const data = await csv('data/indices.csv', autoType);
  return {
    type: 'facetRect',
    height: 600,
    width: 700,
    paddingRight: 80,
    paddingBottom: 50,
    paddingLeft: 60,
    encode: { y: 'Symbol' },
    scale: { y: { paddingInner: 0.2 } },
    data,
    children: [
      {
        type: 'line',
        frame: false,
        scale: { y: { nice: true, facet: false } },
        axis: { y: { labelAutoRotate: false } },
        encode: {
          x: 'Date',
          y: 'Close',
          color: 'Symbol',
          key: 'Symbol',
          title: (d) => new Date(d.Date).toLocaleDateString(),
        },
      },
    ],
    interactions: [
      { type: 'tooltip', series: true, facet: true, crosshairs: true },
    ],
  };
}
```