### PR TITLE
docs: change chart to container in getting-started

### DIFF
--- a/site/docs/manual/getting-started.zh.md
+++ b/site/docs/manual/getting-started.zh.md
@@ -25,7 +25,7 @@ yarn add @antv/g2@beta
 安装成功之后给 G2 提供一个容器:
 
 ```html
-<div id="chart"></div>
+<div id="container"></div>
 ```
 
 然后输入如下代码：


### PR DESCRIPTION
* **G2 版本**：v5
* **代码笔链接**：

```
<div id="container"></div>
```

```js
    // 准备数据
    const data = [
      { genre: "Sports", sold: 275 },
      { genre: "Strategy", sold: 115 },
      { genre: "Action", sold: 120 },
      { genre: "Shooter", sold: 350 },
      { genre: "Other", sold: 150 },
    ];

    // 初始化图表实例
    const chart = new Chart({
      container: "container",
    });

    // 声明可视化
    chart
      .interval() // 创建一个 Interval 标记
      .data(data) // 绑定数据
      .encode("x", "genre") // 编码 x 通道
      .encode("y", "sold"); // 编码 y 通道

    // 渲染可视化
    chart.render();
```
-----------------------------------------------------------------------------------------------------------------------------------------

修改文档 
在 https://g2.antv.antgroup.com/manual/getting-started --快速上手部分--包管理器章节，在安装成功之后给 G2 提供一个容器：该容器id为chart，而下面初始化图表实例中container值是container，container与容器id不对应，无法生成图表
经过vue测试，如果按照原来的文档，无法生成图表实例，而将初始化图表实例中容器值与容器id对应，可以正常生成图表实例

**问题出现原因：g2实例化图表是通过new Chart()中的container属性实现的，container值应该与容器id一致**

附图： 原错误文档： ![图像](https://user-images.githubusercontent.com/40731243/206336861-5b78a0b4-a0ca-4fe3-9b5b-64d455445db0.png)

复现：[CodeSandBox](https://codesandbox.io/s/friendly-taussig-siscsv?file=/src/components/HelloWorld.vue)

修正后的： 复现链接：[CodeSandBox](https://codesandbox.io/s/holy-mountain-eq2u9f?file=/src/components/HelloWorld.vue)

-----------------------------------------------------------------------------------------------------------------------------------------

复现链接与原链接区别在于将
```html
<div id="chart"></div>
```
修改为
```html
<div id="container"></div>
```