### PR TITLE
fix(interaction): legend fitler transform should in first

### DIFF
--- a/src/interaction/native/legendFilter.ts
+++ b/src/interaction/native/legendFilter.ts
@@ -159,8 +159,10 @@ export function LegendFilter({ channel: selectedChannel, ...rest }) {
         // which will skip for mark without color channel.
         const newMarks = marks.map((mark) => {
           const { transform = [] } = mark;
-          const newTransform = [...transform];
-          newTransform.push({ type: 'filter', [channel]: value });
+          const newTransform = [
+            { type: 'filter', [channel]: value },
+            ...transform,
+          ];
           return deepMix({}, mark, {
             transform: newTransform,
             // Set domain of scale to preserve legends.


### PR DESCRIPTION
- 图例筛选 filter tranform 需要在第一位。如：饼图场景，合理：`transform: [{ type: 'fitler' }, { type: 'stackY' } ]`

饼图动画关闭动画之后，筛选有点问题，暂时不写单测