### PR TITLE
feat(interaction): legend filter support custom legend

### DIFF
--- a/__tests__/integration/interactions/index.ts
+++ b/__tests__/integration/interactions/index.ts
@@ -24,4 +24,4 @@ export { morleyBoxTooltip } from './morley-box-tooltip';
 export { temperaturesLineLegendFilterOrdinal } from './temperatures-line-legend-filter-ordinal';
 export { profitIntervalLegendFilterOrdinal } from './profit-interval-legend-filter-ordinal';
 export { indicesLineChartFacetTooltip } from './indices-line-chart-facet-tooltip';
-export { profitCustomIntervalLegendFilter } from './profit-interval-custom-legend-filter';
+// export { profitCustomIntervalLegendFilter } from './profit-interval-custom-legend-filter';

--- a/__tests__/integration/interactions/index.ts
+++ b/__tests__/integration/interactions/index.ts
@@ -24,3 +24,4 @@ export { morleyBoxTooltip } from './morley-box-tooltip';
 export { temperaturesLineLegendFilterOrdinal } from './temperatures-line-legend-filter-ordinal';
 export { profitIntervalLegendFilterOrdinal } from './profit-interval-legend-filter-ordinal';
 export { indicesLineChartFacetTooltip } from './indices-line-chart-facet-tooltip';
+export { profitCustomIntervalLegendFilter } from './profit-interval-custom-legend-filter';

--- a/__tests__/integration/interactions/profit-interval-custom-legend-filter.ts
+++ b/__tests__/integration/interactions/profit-interval-custom-legend-filter.ts
@@ -1,0 +1,58 @@
+import { G2Spec } from '../../../src';
+import { profit } from '../data/profit';
+
+export function profitCustomIntervalLegendFilter(): G2Spec {
+  return {
+    paddingLeft: 60,
+    type: 'interval',
+    data: profit,
+    axis: { y: { labelFormatter: '~s' } },
+    legend: false,
+    encode: {
+      x: 'month',
+      y: ['end', 'start'],
+      color: (d) =>
+        d.month === 'Total' ? 'Total' : d.profit > 0 ? 'Increase' : 'Decrease',
+    },
+    interactions: [
+      {
+        type: 'legendFilter',
+        channel: 'color',
+        legends: () => document.getElementsByClassName('legend'),
+        label: (item) => item.getElementsByClassName('label')[0],
+        marker: (item) => item.getElementsByClassName('marker')[0],
+        datum: (item) => item.getElementsByClassName('label')[0].textContent,
+        setAttribute: (element, key, v) => (element.style[key] = v),
+        labelUnselectedColor: '#aaa',
+        markerUnselectedColor: '#aaa',
+      },
+    ],
+  };
+}
+
+profitCustomIntervalLegendFilter.dom = () => {
+  const div = document.createElement('div');
+  const legend = (div, text) => {
+    const item = document.createElement('div');
+    item.className = 'legend';
+    item.style.cursor = 'pointer';
+    div.appendChild(item);
+
+    const marker = document.createElement('span');
+    marker.className = 'marker';
+    marker.textContent = '* ';
+    item.appendChild(marker);
+
+    const label = document.createElement('span');
+    label.className = 'label';
+    label.textContent = text;
+    item.appendChild(label);
+  };
+  legend(div, 'Increase');
+  legend(div, 'Decrease');
+  legend(div, 'Total');
+  return div;
+};
+
+// Skip because using DOM, which can not be created in node-canvas env.
+profitCustomIntervalLegendFilter.skip = true;

--- a/__tests__/integration/main.ts
+++ b/__tests__/integration/main.ts
@@ -99,8 +99,10 @@ async function plot() {
   }
   currentContainer = document.createElement('div');
   app.append(currentContainer);
-  const options = await tests[selectChart.value]();
+  const generate = tests[selectChart.value];
+  const options = await generate();
   const { width = 640, height = 480 } = options;
+  const dom = generate.dom?.();
   canvas = new Canvas({
     container: document.createElement('div'),
     width,
@@ -110,6 +112,7 @@ async function plot() {
   // @ts-ignore
   window.__g_instances__ = [canvas];
   currentContainer.append(render(options, { canvas }));
+  if (dom instanceof HTMLElement) currentContainer.append(dom);
 }
 
 function createOption(key) {

--- a/src/interaction/native/utils.ts
+++ b/src/interaction/native/utils.ts
@@ -73,6 +73,7 @@ export function createDatumof(view: G2ViewDescriptor) {
 export function useState(
   style: Record<string, any>,
   valueof = (d, element) => d,
+  setAttribute = (element, key, v) => element.setAttribute(key, v),
 ) {
   const STATES = '__states__';
   const ORIGINAL = '__ordinal__';
@@ -91,7 +92,7 @@ export function useState(
     for (const [key, value] of Object.entries(stateStyle)) {
       const currentValue = element.getAttribute(key);
       const v = valueof(value, element);
-      element.setAttribute(key, v);
+      setAttribute(element, key, v);
       // Store the attribute if it does not exist in original.
       if (!(key in original)) original[key] = currentValue;
     }

--- a/src/spec/interaction.ts
+++ b/src/spec/interaction.ts
@@ -100,6 +100,7 @@ export type ElementHighlightByColorInteraction = {
 export type LegendFilterInteraction = {
   type?: 'legendFilter';
   channel?: ChannelTypes;
+  [key: string]: any; // @todo
 } & Record<`${'marker' | 'label'}Unselected${any}`, any>;
 
 export type ChartIndex = {


### PR DESCRIPTION
## LegendFilter 支持自定义图例

为了定制性，可以定制 LegendFilter 操作的图例。

## 开始使用

给定 legend 的 DOM 结构如下：

![legend-filter-custom](https://user-images.githubusercontent.com/49330279/206663214-742ebab6-d801-4a88-8767-d0372794ee73.gif)

```html
<div>
  <div class="legend">
    <div id="marker"></div>
    <div id="label">Increase</div>
  </div>
  <div class="legend">
    <div id="marker"></div>
    <div id="label">Decrease</div>
  </div>
  <div class="legend">
    <div id="marker"></div>
    <div id="label">Total</div>
  </div>
</div>
```

声明交互：

```js
import { G2Spec } from '../../../src';
import { profit } from '../data/profit';

export function profitCustomIntervalLegendFilter(): G2Spec {
  return {
    paddingLeft: 60,
    type: 'interval',
    data: profit,
    axis: { y: { labelFormatter: '~s' } },
    legend: false,
    encode: {
      x: 'month',
      y: ['end', 'start'],
      color: (d) =>
        d.month === 'Total' ? 'Total' : d.profit > 0 ? 'Increase' : 'Decrease',
    },
    interactions: [
      {
        type: 'legendFilter',
        channel: 'color', // 过滤的通道
        legends: () => document.getElementsByClassName('legend'), // 得到 legend items 的方式
        label: (item) => item.getElementsByClassName('label')[0], // 得到 label 的方式
        marker: (item) => item.getElementsByClassName('marker')[0], // 得到 marker 的方式
        datum: (item) => item.getElementsByClassName('label')[0].textContent, // 获得 legend item 对应 value 的方式
        setAttribute: (element, key, v) => (element.style[key] = v), // 设置更新元素的属性的方式
        labelUnselectedColor: '#aaa',
        markerUnselectedColor: '#aaa',
      },
    ],
  };
}
```

## 说明

因为目前的测试环境是 node-canvas，不能创建 DOM，所以这个测试案例并没有被测试，如果之后切换测试环境为 JSDOM，这个问题就可以被解决了。