### PR TITLE
fix: fix site direct and auto-deploy when push to v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ name: Deploy
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+     - v5
 
 jobs:
   deploy-site:

--- a/site/.dumi/global.ts
+++ b/site/.dumi/global.ts
@@ -27,8 +27,8 @@ if (window) {
 }
 
 if (
-  location.origin === 'g2.antv.vision' ||
-  location.origin === 'antv-g2.gitee.io'
+  location.host === 'g2.antv.vision' ||
+  location.host === 'antv-g2.gitee.io'
 ) {
   (window as any).location.href = location.href.replace(
     location.origin,


### PR DESCRIPTION
- 修复  g2.antv.vision 以及 antv-g2.gitee.io 跳转问题
- push 到 v5 自动 deploy 构建产物到 gh-pages 分支上