### PR TITLE
docs: remove g from dependencies in site & use document creating elem…

### DIFF
--- a/site/.dumi/global.ts
+++ b/site/.dumi/global.ts
@@ -13,7 +13,6 @@ if (window) {
   (window as any).d3GeoProjection = require('d3-geo-projection');
   (window as any).d3Random = require('d3-random');
   (window as any).topojson = require('topojson');
-  (window as any).g = require('@antv/g');
   (window as any).gLottiePlayer = require('@antv/g-lottie-player');
   (window as any).gPattern = require('@antv/g-pattern');
   (window as any).webfontloader = require('webfontloader');

--- a/site/docs/api/mark/shape.zh.md
+++ b/site/docs/api/mark/shape.zh.md
@@ -9,15 +9,19 @@ order: 1
 
 <img alt="shape" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*aIpTRZ-_b9wAAAAAAAAAAAAADmJ7AQ/original" width="600" />
 
-上图中的「数据保密」的徽章图案就是使用 `shape` 绘制。
+上图中的「数据保密」的徽章图案就是使用 `shape` 绘制。在绘制图形时，可以从图表上下文中获取 [document](https://g.antv.antgroup.com/api/builtin-objects/document) 对象，随后使用 [document.createElement](https://g.antv.antgroup.com/api/builtin-objects/document#createelement) 创建基础图形。在下面的示例中我们创建了一个 [Circle](https://g.antv.antgroup.com/api/basic/circle)。
 
 ```ts
-import { Circle } from '@antv/g';
 import { Chart } from '@antv/g2';
 
 function point(style) {
   const { x, y, fill } = style;
-  return new Circle({
+
+  const {
+    canvas: { document },
+  } = chart.context();
+
+  return document.createElement('circle', {
     style: {
       cx: x,
       cy: y,
@@ -26,14 +30,12 @@ function point(style) {
   });
 }
 
-chart
-  .shape()
-  .style({
-    x: '50%',
-    y: '50%',
-    fill: 'red',
-    render: point,
-  })
+chart.shape().style({
+  x: '50%',
+  y: '50%',
+  fill: 'red',
+  render: point,
+});
 
 chart.render();
 ```
@@ -42,9 +44,9 @@ chart.render();
 
 ## 选项
 
-| 属性               | 描述                                           | 类型                 | 默认值      |
-|-------------------|------------------------------------------------|---------------------|------------|
-| x            | 设置图形的位置 x，支持百分比（`'50%'`）和像素值（`200`）    | `number` | `string` | -         |
-| x            | 设置图形的位置 y，支持百分比（`'50%'`）和像素值（`200`）    | `number` | `string` | -         |
-| render            | 对应的自定义渲染函数，函数需要返回 G 的 DisplayObject  | `(style: object) => DisplayObject` | -  |
-| { ...rest }       | 自定义图形的额外参数，都会作为 `render` 函数的参数      | `object`                           | -  |
+| 属性        | 描述                                                     | 类型                               | 默认值   |
+| ----------- | -------------------------------------------------------- | ---------------------------------- | -------- | --- |
+| x           | 设置图形的位置 x，支持百分比（`'50%'`）和像素值（`200`） | `number`                           | `string` | -   |
+| x           | 设置图形的位置 y，支持百分比（`'50%'`）和像素值（`200`） | `number`                           | `string` | -   |
+| render      | 对应的自定义渲染函数，函数需要返回 G 的 DisplayObject    | `(style: object) => DisplayObject` | -        |
+| { ...rest } | 自定义图形的额外参数，都会作为 `render` 函数的参数       | `object`                           | -        |

--- a/site/examples/annotation/annotation/demo/watermark.ts
+++ b/site/examples/annotation/annotation/demo/watermark.ts
@@ -1,4 +1,3 @@
-import { Group, Circle, Text, Path } from '@antv/g';
 import { Chart } from '@antv/g2';
 
 const chart = new Chart({
@@ -36,8 +35,12 @@ chart.shape().style('x', '80%').style('y', '70%').style('render', watermark);
 chart.render();
 
 function watermark({ x, y }) {
-  const g = new Group();
-  const c1 = new Circle({
+  const {
+    canvas: { document },
+  } = chart.context();
+
+  const g = document.createElement('g', {});
+  const c1 = document.createElement('circle', {
     style: {
       cx: x,
       cy: y,
@@ -47,7 +50,7 @@ function watermark({ x, y }) {
       opacity: 0.3,
     },
   });
-  const c2 = new Circle({
+  const c2 = document.createElement('circle', {
     style: {
       cx: x,
       cy: y,
@@ -58,7 +61,7 @@ function watermark({ x, y }) {
     },
   });
 
-  const text = new Text({
+  const text = document.createElement('text', {
     style: {
       x,
       y,

--- a/site/package.json
+++ b/site/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@antv/dumi-theme-antv": "^0.3.0",
-    "@antv/g": "^5.15.1",
     "@antv/g-lottie-player": "^0.0.13",
     "@antv/g-pattern": "^0.0.3",
     "@antv/g-plugin-a11y": "^0.4.27",


### PR DESCRIPTION
关于 UMD 下正确的使用方式讨论，是否应该将 G 作为 G2 的 peerDependencies 而非直接依赖：
https://github.com/antvis/G/issues/1255

修改了下例子中创建图形的方式，使用上下文中的 `document.createElement('circle')` 代替 `new Circle()`。