### PR TITLE
fix(api): remove interaction and coordinate for mark (close: #4438)

### DIFF
--- a/__tests__/unit/api/mark.spec.ts
+++ b/__tests__/unit/api/mark.spec.ts
@@ -36,8 +36,6 @@ function setOptions(node) {
     .attr('facet', true)
     .attr('key', 'mark')
     .attr('class', 'mark')
-    .coordinate({ type: 'polar' })
-    .interaction({ type: 'elementHighlight' })
     .attr('padding', 0)
     .attr('paddingBottom', 10)
     .attr('paddingLeft', 20)
@@ -80,8 +78,6 @@ function getOptions() {
     facet: true,
     key: 'mark',
     class: 'mark',
-    coordinates: [{ type: 'polar' }],
-    interactions: [{ type: 'elementHighlight' }],
     padding: 0,
     paddingBottom: 10,
     paddingLeft: 20,

--- a/site/docs/api/chart.zh.md
+++ b/site/docs/api/chart.zh.md
@@ -92,10 +92,6 @@ Mark 以及 Chart 共享的 API
 
 设置图形每个通道的比例尺，具体见 [scale](/api/scale/overview)。
 
-### `node.coordinate()`
-
-设置图形的坐标变换，具体见 [coordinate](/api/coordinate/overview)。
-
 ### `node.legend()`
 
 设置图形的图例，具体见 [legend](/api/component/legend)。

--- a/src/api/mark/mark.ts
+++ b/src/api/mark/mark.ts
@@ -140,8 +140,6 @@ export const props: NodePropertyDescriptor[] = [
   { name: 'transform', type: 'array' },
   { name: 'style', type: 'object' },
   { name: 'animate', type: 'object' },
-  { name: 'coordinate', type: 'array', key: 'coordinates' },
-  { name: 'interaction', type: 'array', key: 'interactions' },
   { name: 'label', type: 'array', key: 'labels' },
   { name: 'axis', type: 'object' },
   { name: 'legend', type: 'object' },

--- a/src/api/mark/types.ts
+++ b/src/api/mark/types.ts
@@ -12,7 +12,5 @@ export type API<Props extends Geometry, Mark> = {
   axis: ObjectAttribute<Props['axis'], Mark>;
   slider: ObjectAttribute<Props['slider'], Mark>;
   legend: ObjectAttribute<Props['legend'], Mark>;
-  coordinate: ArrayAttribute<Props['coordinates'], Mark>;
-  interaction: ArrayAttribute<Props['interactions'], Mark>;
   layout: ValueAttribute<Props['layout'], Mark>;
 };


### PR DESCRIPTION
# 移除 Mark 没有用的 API

目前以下两种写法无效，是因为 interaction 和 coordinate 都应该配置到 chart 对象上。issue: https://github.com/antvis/G2/issues/4438

```js
chart.line().interaction(); // 无效
chart.line().coordinate();  // 无效
```
```js
chart.interaction();// 有效
chart.coordinate(); // 有效
```

所以移除这两个没有用的 API。
