### PR TITLE
refactor(tests): .diff -> .actual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,13 +26,8 @@ coverage
 stats.html
 
 # Snapshots error images
-__tests__/integration/snapshots/*-diff.png
-__tests__/integration/snapshots/*-diff.svg
-__tests__/integration/snapshots/**/*-diff.png
-
-# Show mismatched pixels
-__tests__/integration/snapshots/*.diff.png
-__tests__/integration/snapshots/**/*.diff.png
+__tests__/integration/snapshots/**/*-actual.*
+__tests__/integration/snapshots/**/*-diff.*
 
 # Website cache byb dumi
 site/.dumi/tmp

--- a/__tests__/integration/canvas.ts
+++ b/__tests__/integration/canvas.ts
@@ -27,7 +27,12 @@ export async function renderCanvas(
 /**
  * diff between PNGs
  */
-export function diff(src: string, target: string, showMismatchedPixels = true) {
+export function diff(
+  src: string,
+  target: string,
+  diff: string,
+  showMismatchedPixels = true,
+) {
   const img1 = PNG.sync.read(fs.readFileSync(src));
   const img2 = PNG.sync.read(fs.readFileSync(target));
   const { width, height } = img1;
@@ -45,7 +50,7 @@ export function diff(src: string, target: string, showMismatchedPixels = true) {
   });
 
   if (showMismatchedPixels && mismatch && diffPNG) {
-    fs.writeFileSync(`${target}.diff.png`, PNG.sync.write(diffPNG));
+    fs.writeFileSync(diff, PNG.sync.write(diffPNG));
   }
 
   return mismatch;

--- a/__tests__/integration/snapshot-animation.spec.ts
+++ b/__tests__/integration/snapshot-animation.spec.ts
@@ -40,8 +40,9 @@ describe('integration', () => {
 
           // Asset interval
           const asset = async (i) => {
-            const actualPath = `${dir}/interval${i}-diff.png`;
+            const actualPath = `${dir}/interval${i}-actual.png`;
             const expectedPath = `${dir}/interval${i}.png`;
+            const diffPath = `${dir}/interval${i}-diff.png`;
             if (!fs.existsSync(expectedPath)) {
               console.warn(`! generate ${name}-${i}`);
               await writePNG(nodeCanvas, expectedPath);
@@ -50,9 +51,9 @@ describe('integration', () => {
 
               //@ts-ignore
               const maxError = generateOptions.maxError || 0;
-              expect(diff(actualPath, expectedPath)).toBeLessThanOrEqual(
-                maxError,
-              );
+              expect(
+                diff(actualPath, expectedPath, diffPath),
+              ).toBeLessThanOrEqual(maxError);
 
               // Persevere the diff image if do not pass the test.
               fs.unlinkSync(actualPath);

--- a/__tests__/integration/snapshot-interaction.spec.ts
+++ b/__tests__/integration/snapshot-interaction.spec.ts
@@ -70,8 +70,9 @@ describe('integration', () => {
 
             // If do not skip this state, asset it after dispatch the event.
             if (!skip) {
-              const actualPath = `${dir}/step${i}-diff.png`;
+              const actualPath = `${dir}/step${i}-actual.png`;
               const expectedPath = `${dir}/step${i}.png`;
+              const diffPath = `${dir}/step${i}-diff.png`;
               if (!fs.existsSync(expectedPath)) {
                 console.warn(`! generate ${name}-${i}`);
                 await writePNG(nodeCanvas, expectedPath);
@@ -79,9 +80,9 @@ describe('integration', () => {
                 await writePNG(nodeCanvas, actualPath);
                 //@ts-ignore
                 const maxError = generateOptions.maxError || 0;
-                expect(diff(actualPath, expectedPath)).toBeLessThanOrEqual(
-                  maxError,
-                );
+                expect(
+                  diff(actualPath, expectedPath, diffPath),
+                ).toBeLessThanOrEqual(maxError);
                 // Persevere the diff image if do not pass the test.
                 fs.unlinkSync(actualPath);
               }

--- a/__tests__/integration/snapshot.spec.ts
+++ b/__tests__/integration/snapshot.spec.ts
@@ -22,8 +22,9 @@ describe('integration', () => {
       it(`[Canvas]: ${name}`, async () => {
         let canvas;
         try {
-          const actualPath = `${__dirname}/snapshots/${name}-diff.png`;
+          const actualPath = `${__dirname}/snapshots/${name}-actual.png`;
           const expectedPath = `${__dirname}/snapshots/${name}.png`;
+          const diffPath = `${__dirname}/snapshots/${name}-diff.png`;
           const options = await generateOptions();
 
           // Generate golden png if not exists.
@@ -34,9 +35,9 @@ describe('integration', () => {
             canvas = await renderCanvas(options, actualPath);
             //@ts-ignore
             const maxError = generateOptions.maxError || 0;
-            expect(diff(actualPath, expectedPath)).toBeLessThanOrEqual(
-              maxError,
-            );
+            expect(
+              diff(actualPath, expectedPath, diffPath),
+            ).toBeLessThanOrEqual(maxError);
 
             // Persevere the diff image if do not pass the test.
             fs.unlinkSync(actualPath);
@@ -75,7 +76,7 @@ describe('integration', () => {
         } catch (error) {
           // Generate error svg to compare.
           console.warn(`! generate ${name}`);
-          const diffPath = `${__dirname}/snapshots/${name}-diff.svg`;
+          const diffPath = `${__dirname}/snapshots/${name}-actual.svg`;
           fs.writeFileSync(diffPath, actual);
           throw error;
         } finally {


### PR DESCRIPTION
修改了集成测试输出文件的名字格式：

- `[filename]-actual`: 当前代码生成的截图
- `[filename]-diff`：expected 和 actual 文件之间的 diff