### PR TITLE
fix(test): write diff png when mismatch greater than maxError

### DIFF
--- a/__tests__/integration/canvas.ts
+++ b/__tests__/integration/canvas.ts
@@ -31,6 +31,7 @@ export function diff(
   src: string,
   target: string,
   diff: string,
+  maxError = 0,
   showMismatchedPixels = true,
 ) {
   const img1 = PNG.sync.read(fs.readFileSync(src));
@@ -49,7 +50,7 @@ export function diff(
     threshold: 0.1,
   });
 
-  if (showMismatchedPixels && mismatch && diffPNG) {
+  if (showMismatchedPixels && mismatch > maxError && diffPNG) {
     fs.writeFileSync(diff, PNG.sync.write(diffPNG));
   }
 

--- a/__tests__/integration/snapshot-animation.spec.ts
+++ b/__tests__/integration/snapshot-animation.spec.ts
@@ -52,7 +52,7 @@ describe('integration', () => {
               //@ts-ignore
               const maxError = generateOptions.maxError || 0;
               expect(
-                diff(actualPath, expectedPath, diffPath),
+                diff(actualPath, expectedPath, diffPath, maxError),
               ).toBeLessThanOrEqual(maxError);
 
               // Persevere the diff image if do not pass the test.

--- a/__tests__/integration/snapshot-interaction.spec.ts
+++ b/__tests__/integration/snapshot-interaction.spec.ts
@@ -81,7 +81,7 @@ describe('integration', () => {
                 //@ts-ignore
                 const maxError = generateOptions.maxError || 0;
                 expect(
-                  diff(actualPath, expectedPath, diffPath),
+                  diff(actualPath, expectedPath, diffPath, maxError),
                 ).toBeLessThanOrEqual(maxError);
                 // Persevere the diff image if do not pass the test.
                 fs.unlinkSync(actualPath);

--- a/__tests__/integration/snapshot.spec.ts
+++ b/__tests__/integration/snapshot.spec.ts
@@ -36,7 +36,7 @@ describe('integration', () => {
             //@ts-ignore
             const maxError = generateOptions.maxError || 0;
             expect(
-              diff(actualPath, expectedPath, diffPath),
+              diff(actualPath, expectedPath, diffPath, maxError),
             ).toBeLessThanOrEqual(maxError);
 
             // Persevere the diff image if do not pass the test.


### PR DESCRIPTION
之前图片有不匹配，就是生成 diff 图片，但是期望是不匹配的像素点大于 maxError 的时候才生成 diff 图片。