### PR TITLE
fix(types): type errors

### DIFF
--- a/src/interaction/index.ts
+++ b/src/interaction/index.ts
@@ -32,19 +32,19 @@ export { LEGEND_ITEMS_CLASS_NAME } from './native/legendFilter';
 // export { ActiveRegion } from './builtin/activeRegion';
 // export { EllipsisText } from './builtin/ellipsisText';
 
-// export type {
-//   InteractionContext,
-//   ActionComponent,
-//   InteractionDescriptor,
-//   InteractionStep,
-//   InteractorOptions,
-//   ActionOptions,
-//   Action,
-//   InteractorAction,
-//   Interactor,
-//   G2Event,
-//   InteractionNamespaces,
-//   InteractorComponent,
-//   InteractionOptions,
-//   InteractionValue,
-// } from './types';
+export type {
+  InteractionContext,
+  ActionComponent,
+  InteractionDescriptor,
+  InteractionStep,
+  InteractorOptions,
+  ActionOptions,
+  Action,
+  InteractorAction,
+  Interactor,
+  G2Event,
+  InteractionNamespaces,
+  InteractorComponent,
+  InteractionOptions,
+  InteractionValue,
+} from './types';

--- a/src/spec/action.ts
+++ b/src/spec/action.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { ActionComponent } from '../interaction';
 import { FisheyeCoordinate } from './coordinate';
 

--- a/src/spec/interaction.ts
+++ b/src/spec/interaction.ts
@@ -1,5 +1,5 @@
-import { ChannelTypes } from 'spec';
 import { InteractionComponent } from '../runtime';
+import { ChannelTypes } from './geometry';
 import { ActiveRegionAction, PoptipAction, TooltipAction } from './action';
 import { FisheyeCoordinate } from './coordinate';
 


### PR DESCRIPTION
修复 G2 打包时候遇见的一些类型问题，详见 issue：https://github.com/antvis/G2/issues/4508 

![image](https://user-images.githubusercontent.com/49330279/209136039-860221e8-bb64-4cba-aa50-0823f109ccd4.png)

之前实现的交互相关的 types 暂时先保留，当新的交互实现完了之后再删除。
