### PR TITLE
docs: add details of axis gridLength option

### DIFF
--- a/site/docs/api/component/axis.zh.md
+++ b/site/docs/api/component/axis.zh.md
@@ -155,7 +155,7 @@ export interface HideOverlapCfg extends Overlap {
 | ----------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ------ |
 | grid              | 是否显示网格线                                                                                                      | `boolean`                                                | false  |
 | gridFilter        | 网格线过滤                                                                                                          | `(datum, index, data)=> boolean`                         | -      |
-| gridLength        | 网格线长度                                                                                                          | `number` \| `(datum, index, data)=> number`              | 0      |
+| gridLength        | 网格线长度。一般情况下，不需要用户配置。                                                                                                          | `number` \| `(datum, index, data)=> number`              | 0      |
 | gridAreaFill      | 网格线区域颜色                                                                                                      | `string` \| `string[]`\| `(datum, index, data)=> string` | -      |
 | gridLineWidth     | 网格线宽度                                                                                                          | `number`                                                 | -      |
 | gridLineDash      | 网格线描边的虚线配置，第一个值为虚线每个分段的长度，第二个值为分段间隔的距离。lineDash 设为[0, 0]的效果为没有描边。 | `[number,number]`                                        | -      |

--- a/site/docs/api/component/category.zh.md
+++ b/site/docs/api/component/category.zh.md
@@ -3,8 +3,6 @@ title: category
 order: 1
 ---
 
-`Category`
-
 ## 开始使用
 
 使用离散数据绘制视图时采用的图例类型。

--- a/site/docs/api/component/continuous.zh.md
+++ b/site/docs/api/component/continuous.zh.md
@@ -3,8 +3,6 @@ title: continuous
 order: 1
 ---
 
-`Continuous`
-
 ## 开始使用
 
 使用离散数据绘制视图时采用的图例类型。


### PR DESCRIPTION
- `gridLength` 会在内部根据 coordinate 推断计算，不需要用户配置。增加文档说明，避免用户误传。

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/15646325/210163907-c0579b7a-89db-4174-9463-93d283f10ee8.png">

```ts
import { Chart } from '@antv/g2';

const chart = new Chart({
  container: 'container',
  height: 320
});

chart
  .line()
  .data({
    type: 'fetch',
    value:
      'https://gw.alipayobjects.com/os/bmw-prod/551d80c6-a6be-4f3c-a82a-abd739e12977.csv',
  })
  .encode('x', 'date')
  .encode('y', 'close')
  .axis('x', {
    line: true,
 //   gridLength: 100,
    gridAreaFill: ['rgba(0,0,0,0.05)', 'rgba(0,0,0,0.02)']
  })
  .axis('y', {
    line: true,
    gridAreaFill: ['rgba(0,0,0,0.05)', 'rgba(0,0,0,0.02)']
  })

chart.render();
```
