### PR TITLE
Feat/multi mask actions

### DIFF
--- a/docs/api/general/interaction.zh.md
+++ b/docs/api/general/interaction.zh.md
@@ -1027,6 +1027,39 @@ registerInteraction('element-brush', {
 - hide() 隐藏遮罩层
 - end() 结束框选
 
+#### rect-multi-mask
+
+在画布上进行框选，支持反复框选，出现多个矩形的遮罩：
+
+- start() 开始框选
+- show() 显示遮罩层
+- resize() 改变大小
+- hide() 隐藏遮罩层
+- end() 结束框选
+- clear() 清除框选
+
+#### circle-multi-mask
+
+在画布上进行框选，支持反复框选，出现多个圆形的遮罩：
+
+- start() 开始框选
+- show() 显示遮罩层
+- resize() 改变大小
+- hide() 隐藏遮罩层
+- end() 结束框选
+- clear() 清除框选
+
+#### path-multi-mask
+
+在画布上进行框选，在多个点上形成 path，支持反复框选，出现多个 path 遮罩：
+
+- start() 开始框选
+- show() 显示遮罩层
+- addPoint() 添加一个点
+- hide() 隐藏遮罩层
+- end() 结束框选
+- clear() 清除框选
+
 #### reset-button
 
 在画布右上角出现一个恢复按钮，按钮图形上有 name: 'reset-button'，仅有两个方法：

--- a/examples/interaction/brush/demo/meta.json
+++ b/examples/interaction/brush/demo/meta.json
@@ -67,6 +67,14 @@
         "en": "Multiple view brush highlight"
       },
       "screenshot": "https://gw.alipayobjects.com/mdn/rms_f5c722/afts/img/A*dXxcQJo8c7sAAAAAAAAAAABkARQnAQ"
+    },
+    {
+      "filename": "range-multi-highlight.ts",
+      "title": {
+        "zh": "多框选高亮",
+        "en": "Brush multiple highlight"
+      },
+      "screenshot": "https://img.alicdn.com/imgextra/i2/O1CN01PVHFdF1x5aSdxkVLS_!!6000000006392-1-tps-694-476.gif"
     }
   ]
 }

--- a/examples/interaction/brush/demo/range-multi-highlight.ts
+++ b/examples/interaction/brush/demo/range-multi-highlight.ts
@@ -1,0 +1,40 @@
+import DataSet from '@antv/data-set';
+import { Chart } from '@antv/g2';
+
+fetch('https://gw.alipayobjects.com/os/antvdemo/assets/data/top2000.json')
+  .then(res => res.json())
+  .then(data => {
+    const ds = new DataSet();
+    const dv = ds.createView('test')
+      .source(data)
+      .transform({
+        as: ['count'],
+        groupBy: ['release'],
+        operations: ['count'],
+        type: 'aggregate'
+      });
+
+    const chart = new Chart({
+      container: 'container',
+      autoFit: true,
+      height: 500
+    });
+    chart.data(dv.rows);
+    chart.scale({
+      count: {
+        alias: 'top2000 唱片总量',
+        nice: true
+      },
+      release: {
+        tickInterval: 5,
+        alias: '唱片发行年份'
+      }
+    });
+    chart
+      .interval()
+      .position('release*count')
+      .tooltip(false);
+
+    chart.interaction('element-x-multi-range-highlight');
+    chart.render();
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,12 @@ import PathMask from './interaction/action/mask/path';
 import RectMask from './interaction/action/mask/rect';
 import SmoothPathMask from './interaction/action/mask/smooth-path';
 
+import RectMultiMask from './interaction/action/mask/multiple/rect';
+import DimRectMultiMask from './interaction/action/mask/multiple/dim-rect';
+import CircleMultiMask from './interaction/action/mask/multiple/circle';
+import PathMultiMask from './interaction/action/mask/multiple/path';
+import SmoothPathMultiMask from './interaction/action/mask/multiple/smooth-path';
+
 import CursorAction from './interaction/action/cursor';
 import DataFilter from './interaction/action/data/filter';
 import DataRangeFilter, { BRUSH_FILTER_EVENTS } from './interaction/action/data/range-filter';
@@ -270,6 +276,13 @@ registerAction('circle-mask', CircleMask);
 registerAction('path-mask', PathMask);
 registerAction('smooth-path-mask', SmoothPathMask);
 
+registerAction('rect-multi-mask', RectMultiMask);
+registerAction('x-rect-multi-mask', DimRectMultiMask, { dim: 'x' });
+registerAction('y-rect-multi-mask', DimRectMultiMask, { dim: 'y' });
+registerAction('circle-multi-mask', CircleMultiMask);
+registerAction('path-multi-mask', PathMultiMask);
+registerAction('smooth-path-multi-mask', SmoothPathMultiMask);
+
 registerAction('cursor', CursorAction);
 registerAction('data-filter', DataFilter);
 
@@ -298,6 +311,7 @@ registerAction('mousewheel-scroll', MousewheelScroll);
 
 // 注册默认的 Interaction 交互行为
 import { registerInteraction } from './core';
+import { isMultipleMask } from './interaction/action/util';
 
 function isPointInView(context: IInteractionContext) {
   return context.isInPlot();
@@ -557,6 +571,62 @@ registerInteraction('element-path-highlight', {
   processing: [{ trigger: 'mousemove', action: 'path-mask:addPoint' }],
   end: [{ trigger: 'mouseup', action: 'path-mask:end' }],
   rollback: [{ trigger: 'dblclick', action: 'path-mask:hide' }],
+});
+
+registerInteraction('element-x-multi-range-highlight', {
+  showEnable: [
+    { trigger: 'plot:mouseenter', action: 'cursor:crosshair' },
+    { trigger: 'mask:mouseenter', action: 'cursor:move' },
+    { trigger: 'plot:mouseleave', action: 'cursor:default' },
+    { trigger: 'mask:mouseleave', action: 'cursor:crosshair' },
+  ],
+  start: [
+    {
+      trigger: 'mousedown',
+      isEnable: isPointInView,
+      action: ['x-rect-multi-mask:start', 'x-rect-multi-mask:show'],
+    },
+    {
+      trigger: 'mask:dragstart',
+      action: ['x-rect-multi-mask:moveStart'],
+    },
+  ],
+  processing: [
+    {
+      trigger: 'mousemove',
+      isEnable: (context) => !isMultipleMask(context),
+      action: ['x-rect-multi-mask:resize'],
+    },
+    {
+      trigger: 'multi-mask:change',
+      action: 'element-range-highlight:highlight',
+    },
+    {
+      trigger: 'mask:drag',
+      action: ['x-rect-multi-mask:move'],
+    },
+  ],
+  end: [
+    {
+      trigger: 'mouseup',
+      action: ['x-rect-multi-mask:end'],
+    },
+    { trigger: 'mask:dragend', action: ['x-rect-multi-mask:moveEnd'] },
+  ],
+  rollback: [
+    {
+      trigger: 'dblclick',
+      action: ['x-rect-multi-mask:clear', 'cursor:crosshair'],
+    },
+    {
+      trigger: 'multi-mask:clearAll',
+      action: ['element-range-highlight:clear'],
+    },
+    {
+      trigger: 'multi-mask:clearSingle',
+      action: ['element-range-highlight:highlight'],
+    },
+  ],
 });
 
 // 点击选中，允许取消

--- a/src/interaction/action/mask/circle.ts
+++ b/src/interaction/action/mask/circle.ts
@@ -8,9 +8,9 @@ import MaskBase from './base';
  */
 class CircleMask extends MaskBase {
   protected shapeType = 'circle';
-  protected getMaskAttrs() {
-    const points = this.points;
-    const currentPoint = last(this.points);
+  public getMaskAttrs(_points?: number[]) {
+    const points = _points ?? this.points;
+    const currentPoint = last(points);
     let r = 0;
     let x = 0;
     let y = 0;

--- a/src/interaction/action/mask/dim-rect.ts
+++ b/src/interaction/action/mask/dim-rect.ts
@@ -13,10 +13,10 @@ function clampPoint(point) {
 class DimRect extends RectMask {
   protected dim = 'x';
   protected inPlot = true;
-  protected getRegion(): Region {
+  public getRegion(_points?: number[]): Region {
     let start = null;
     let end = null;
-    const points = this.points;
+    const points = _points ?? this.points;
     const dim = this.dim;
     const coord = this.context.view.getCoordinate();
     const normalStart = coord.invert(head(points));

--- a/src/interaction/action/mask/multiple/base.ts
+++ b/src/interaction/action/mask/multiple/base.ts
@@ -1,0 +1,314 @@
+import { deepMix } from '@antv/util';
+import Action from '../../base';
+import { LooseObject } from '../../../../interface';
+
+/**
+ * @ignore
+ * 辅助框 Action 的基类
+ */
+abstract class MultipleMaskBase extends Action {
+  // mask 图形
+  protected maskShapes = [];
+  // 开始 mask 的标记
+  protected starting = false;
+  // 开始移动的标记
+  protected moving = false;
+  // 记录 mask 节点
+  protected recordPoints = null;
+  protected preMovePoint = null;
+  protected shapeType = 'path';
+  protected maskType = 'multi-mask';
+
+  /**
+   * 获取当前的位置
+   */
+  protected getCurrentPoint() {
+    const event = this.context.event;
+    return {
+      x: event.x,
+      y: event.y,
+    };
+  }
+
+  /**
+   * 触发 mask 的事件
+   * @param type
+   */
+  protected emitEvent(type) {
+    const eventName = `${this.maskType}:${type}`;
+    const view = this.context.view;
+    const event = this.context.event;
+    const target = {
+      type: this.shapeType,
+      name: this.maskType,
+      get: (key: string) => (target.hasOwnProperty(key) ? target[key] : undefined),
+    };
+    view.emit(eventName, {
+      target,
+      maskShapes: this.maskShapes,
+      multiPoints: this.recordPoints,
+      x: event.x,
+      y: event.y,
+    });
+  }
+
+  /**
+   * 创建 mask
+   * @param index
+   */
+  private createMask(index: number) {
+    const view = this.context.view;
+    const points = this.recordPoints[index];
+    const maskAttrs = this.getMaskAttrs(points);
+    const maskShape = view.foregroundGroup.addShape({
+      type: this.shapeType,
+      name: 'mask',
+      draggable: true,
+      attrs: {
+        fill: '#C5D4EB',
+        opacity: 0.3,
+        ...maskAttrs,
+      },
+    });
+    this.maskShapes.push(maskShape);
+  }
+
+  /**
+   * 获取 mask shape attributes
+   * @param points
+   */
+  protected abstract getMaskAttrs(points: number[]): LooseObject;
+
+  /**
+   * 生成 mask 的路径
+   */
+  protected getMaskPath() {
+    return [];
+  }
+
+  /**
+   * 显示
+   */
+  public show() {
+    if (this.maskShapes.length > 0) {
+      this.maskShapes.forEach((maskShape) => maskShape.show());
+      this.emitEvent('show');
+    }
+  }
+
+  /**
+   * 开始
+   */
+  public start(arg?: { maskStyle: LooseObject }) {
+    this.recordPointStart();
+
+    this.starting = true;
+    // 开始时，保证移动结束
+    this.moving = false;
+    // 开始第 index 个 mask
+    const index = this.recordPoints.length - 1;
+    this.createMask(index);
+    // 开始时设置 capture: false，可以避免创建、resize 时触发事件
+    this.updateShapesCapture(false);
+    this.updateMask(arg?.maskStyle);
+    this.emitEvent('start');
+  }
+
+  /**
+   * 开始移动
+   */
+  public moveStart() {
+    this.moving = true;
+    this.preMovePoint = this.getCurrentPoint();
+    this.updateShapesCapture(false);
+  }
+
+  /**
+   * 移动 mask
+   */
+  public move() {
+    if (!this.moving || this.maskShapes.length === 0) {
+      return;
+    }
+    const currentPoint = this.getCurrentPoint();
+    const preMovePoint = this.preMovePoint;
+    const dx = currentPoint.x - preMovePoint.x;
+    const dy = currentPoint.y - preMovePoint.y;
+
+    // 只移动当前 event (x, y) 所在的某个 mask
+    const index = this.getCurMaskShapeIndex();
+    if (index > -1) {
+      this.recordPoints[index].forEach((point) => {
+        point.x += dx;
+        point.y += dy;
+      });
+      this.updateMask();
+      this.emitEvent('change');
+      this.preMovePoint = currentPoint;
+    }
+  }
+
+  /**
+   * 更新
+   * @param maskStyle
+   */
+  protected updateMask(maskStyle?: LooseObject) {
+    this.recordPoints.forEach((points, index) => {
+      const attrs = deepMix({}, this.getMaskAttrs(points), maskStyle);
+      this.maskShapes[index].attr(attrs);
+    });
+  }
+
+  /**
+   * 大小变化
+   */
+  public resize() {
+    if (this.starting && this.maskShapes.length > 0) {
+      this.recordPointContinue();
+
+      this.updateMask();
+      this.emitEvent('change');
+    }
+  }
+
+  /**
+   * 结束移动
+   */
+  public moveEnd() {
+    this.moving = false;
+    this.preMovePoint = null;
+    this.updateShapesCapture(true);
+  }
+
+  /**
+   * 结束
+   */
+  public end() {
+    this.starting = false;
+    this.emitEvent('end');
+    this.updateShapesCapture(true);
+  }
+
+  /**
+   * 隐藏
+   */
+  public hide() {
+    if (this.maskShapes.length > 0) {
+      this.maskShapes.forEach((maskShape) => maskShape.hide());
+      this.emitEvent('hide');
+    }
+  }
+
+  /**
+   * 清除某个 mask
+   */
+  public remove() {
+    const index = this.getCurMaskShapeIndex();
+    if (index > -1) {
+      // event (x, y) 在的某个 mask 区域内时，清除该 mask
+      this.recordPoints.splice(index, 1);
+      this.maskShapes[index].remove();
+      this.maskShapes.splice(index, 1);
+      this.preMovePoint = null;
+      this.updateShapesCapture(true);
+      this.emitEvent('change');
+    }
+  }
+
+  /**
+   * 清除全部 mask
+   */
+  public clearAll() {
+    this.recordPointClear();
+    this.maskShapes.forEach((maskShape) => maskShape.remove());
+    this.maskShapes = [];
+    this.preMovePoint = null;
+  }
+
+  /**
+   * 清除
+   */
+  public clear() {
+    const index = this.getCurMaskShapeIndex();
+    if (index === -1) {
+      this.recordPointClear();
+      this.maskShapes.forEach((maskShape) => maskShape.remove());
+      this.maskShapes = [];
+      this.emitEvent('clearAll');
+    } else {
+      this.recordPoints.splice(index, 1);
+      this.maskShapes[index].remove();
+      this.maskShapes.splice(index, 1);
+      this.preMovePoint = null;
+      this.emitEvent('clearSingle');
+    }
+    this.preMovePoint = null;
+  }
+
+  /**
+   * 销毁
+   */
+  public destroy() {
+    this.clear();
+    super.destroy();
+  }
+
+  /**
+   * 获取 mask 节点记录
+   */
+  protected getRecordPoints() {
+    return [...(this.recordPoints ?? [])];
+  }
+
+  /**
+   * 创建 mask 节点记录
+   */
+  protected recordPointStart() {
+    const recordPoints = this.getRecordPoints();
+    const currentPoint = this.getCurrentPoint();
+    this.recordPoints = [...recordPoints, [currentPoint]];
+  }
+
+  /**
+   * 持续记录 mask 节点
+   */
+  protected recordPointContinue() {
+    const recordPoints = this.getRecordPoints();
+    const currentPoint = this.getCurrentPoint();
+    const lastPoints = recordPoints.splice(-1, 1)[0] || [];
+    lastPoints.push(currentPoint);
+    this.recordPoints = [...recordPoints, lastPoints];
+  }
+
+  /**
+   * 清除 mask 节点 记录
+   */
+  protected recordPointClear() {
+    this.recordPoints = [];
+  }
+
+  /**
+   * 设置 capture
+   * false: 避免创建、resize 时触发事件
+   * true: 正常触发其它事件
+   * @param isCapture
+   */
+  protected updateShapesCapture(isCapture: boolean) {
+    this.maskShapes.forEach((maskShape) => maskShape.set('capture', isCapture));
+  }
+
+  /**
+   * 
+   * @returns 获取当前 event (x, y) 所在 maskShape 的 index
+   */
+  protected getCurMaskShapeIndex() {
+    const currentPoint = this.getCurrentPoint();
+    return this.maskShapes.findIndex((maskShape) => {
+      const { width, height, r } = maskShape.attrs
+      const isEmpty = width === 0 || height === 0 || r === 0
+      return !isEmpty && maskShape.isHit(currentPoint.x, currentPoint.y)
+    });
+  }
+}
+
+export default MultipleMaskBase;

--- a/src/interaction/action/mask/multiple/circle.ts
+++ b/src/interaction/action/mask/multiple/circle.ts
@@ -1,0 +1,13 @@
+import MultipleMaskBase from './base';
+import CircleMask from '../circle';
+
+/**
+ * @ignore
+ * 圆形辅助框 Action
+ */
+class CircleMultiMask extends MultipleMaskBase {
+  protected shapeType = 'circle';
+  protected getMaskAttrs = CircleMask.prototype.getMaskAttrs;
+}
+
+export default CircleMultiMask;

--- a/src/interaction/action/mask/multiple/dim-rect.ts
+++ b/src/interaction/action/mask/multiple/dim-rect.ts
@@ -1,0 +1,13 @@
+import MultipleRectMask from './rect';
+import DimRect from '../dim-rect';
+
+/**
+ * @ignore
+ */
+class DimRectMultiMask extends MultipleRectMask {
+  protected dim = 'x';
+  protected inPlot = true;
+  protected getRegion = DimRect.prototype.getRegion;
+}
+
+export default DimRectMultiMask;

--- a/src/interaction/action/mask/multiple/path.ts
+++ b/src/interaction/action/mask/multiple/path.ts
@@ -1,0 +1,14 @@
+import MultipleMaskBase from './base';
+import PathMask from '../path';
+
+/**
+ * @ignore
+ * 多个点构成的 Path 辅助框 Action
+ */
+class PathMultiMask extends MultipleMaskBase {
+  protected getMaskAttrs = PathMask.prototype.getMaskAttrs;
+  protected getMaskPath = PathMask.prototype.getMaskPath;
+  public addPoint = PathMask.prototype.addPoint;
+}
+
+export default PathMultiMask;

--- a/src/interaction/action/mask/multiple/rect.ts
+++ b/src/interaction/action/mask/multiple/rect.ts
@@ -1,0 +1,14 @@
+import MultipleMaskBase from './base';
+import RectMask from '../rect';
+
+/**
+ * @ignore
+ * 矩形的辅助框 Action
+ */
+class RectMultiMask extends MultipleMaskBase {
+  protected shapeType = 'rect';
+  protected getRegion = RectMask.prototype.getRegion;
+  protected getMaskAttrs = RectMask.prototype.getMaskAttrs;
+}
+
+export default RectMultiMask;

--- a/src/interaction/action/mask/multiple/smooth-path.ts
+++ b/src/interaction/action/mask/multiple/smooth-path.ts
@@ -1,0 +1,13 @@
+import MultiplePathMask from './path';
+import SmoothPathMask from '../smooth-path';
+
+/**
+ * Smooth path mask
+ * @ignore
+ */
+class SmoothPathMultiMask extends MultiplePathMask {
+  // 生成 mask 的路径属性
+  protected getMaskPath = SmoothPathMask.prototype.getMaskPath;
+}
+
+export default SmoothPathMultiMask;

--- a/src/interaction/action/mask/path.ts
+++ b/src/interaction/action/mask/path.ts
@@ -7,8 +7,8 @@ import MaskBase from './base';
  */
 class PathMask extends MaskBase {
   // 生成 mask 的路径
-  protected getMaskPath() {
-    const points = this.points;
+  public getMaskPath(_points?: number[]) {
+    const points = _points ?? this.points;
     const path = [];
     if (points.length) {
       each(points, (point, index) => {
@@ -23,9 +23,9 @@ class PathMask extends MaskBase {
     return path;
   }
 
-  protected getMaskAttrs() {
+  public getMaskAttrs(_points?: number[]) {
     return {
-      path: this.getMaskPath(),
+      path: this.getMaskPath(_points),
     };
   }
 

--- a/src/interaction/action/mask/rect.ts
+++ b/src/interaction/action/mask/rect.ts
@@ -8,16 +8,16 @@ import MaskBase from './base';
  */
 class RectMask extends MaskBase {
   protected shapeType = 'rect';
-  protected getRegion(): Region {
-    const points = this.points;
+  public getRegion(_points?: number[]): Region {
+    const points = _points ?? this.points;
     return {
       start: head(points),
       end: last(points),
     };
   }
   // 添加图形
-  protected getMaskAttrs() {
-    const { start, end } = this.getRegion();
+  public getMaskAttrs(_points?: number[]) {
+    const { start, end } = this.getRegion(_points);
     const x = Math.min(start.x, end.x);
     const y = Math.min(start.y, end.y);
     const width = Math.abs(end.x - start.x);

--- a/src/interaction/action/mask/smooth-path.ts
+++ b/src/interaction/action/mask/smooth-path.ts
@@ -7,8 +7,8 @@ import PathMask from './path';
  */
 class SmoothPathMask extends PathMask {
   // 生成 mask 的路径
-  protected getMaskPath() {
-    const points = this.points;
+  public getMaskPath(_points?: number[]) {
+    const points = _points ?? this.points;
     return getSpline(points, true);
   }
 }

--- a/src/interaction/action/util.ts
+++ b/src/interaction/action/util.ts
@@ -11,23 +11,65 @@ import { ComponentOption, IInteractionContext, LooseObject } from '../../interfa
 function getMaskBBox(context: IInteractionContext, tolerance: number) {
   const event = context.event;
   const maskShape = event.target;
+  return getMaskBBoxByShape(maskShape, tolerance);
+}
+
+/**
+ * 如果 mask BBox 过小则不返回
+ */
+function isValidMaskBBox(maskShape, tolerance: number) {
   const maskBBox = maskShape.getCanvasBBox();
-  // 如果 bbox 过小则不返回
-  if (!(maskBBox.width >= tolerance || maskBBox.height >= tolerance)) {
-    return null;
-  }
-  return maskBBox;
+  const { width, height } = maskBBox;
+  return width > 0 && height > 0 && (width >= tolerance || height >= tolerance);
+}
+
+/**
+ * 通过 maskShape 获取 mask 的 canvasBBox
+ * @param maskShape
+ * @param tolerance
+ * @returns
+ */
+function getMaskBBoxByShape(maskShape, tolerance: number) {
+  const maskBBox = maskShape.getCanvasBBox();
+  return isValidMaskBBox(maskShape, tolerance) ? maskBBox : null;
+}
+
+/**
+ * 获取 multiple 模式下 mask 的 canvasBBox 数组
+ * @param context 上下文
+ * @param tolerance box 宽高小于则不返回
+ * @returns
+ */
+function getMultiMaskBBoxList(context: IInteractionContext, tolerance: number) {
+  const { maskShapes } = context.event;
+  return maskShapes.map((maskShape) => getMaskBBoxByShape(maskShape, tolerance)).filter((bBox) => !!bBox);
 }
 
 function getMaskPath(context: IInteractionContext, tolerance: number) {
   const event = context.event;
   const maskShape = event.target;
-  const maskBBox = maskShape.getCanvasBBox();
-  // 如果 bbox 过小则不返回
-  if (!(maskBBox.width >= tolerance || maskBBox.height >= tolerance)) {
-    return null;
-  }
-  return maskShape.attr('path');
+  return getMaskPathByMaskShape(maskShape, tolerance);
+}
+
+/**
+ * 通过 maskShape 获取 mask path
+ * @param maskShape
+ * @param tolerance box 宽高小于则不返回
+ * @returns
+ */
+export function getMaskPathByMaskShape(maskShape, tolerance: number) {
+  return isValidMaskBBox(maskShape, tolerance) ? maskShape.attr('path') : null;
+}
+
+/**
+ * 获取 multiple 模式下 mask path 数组
+ * @param context 上下文
+ * @param tolerance box 宽高小于则不返回
+ * @returns
+ */
+function getMultiMaskPathList(context: IInteractionContext, tolerance: number) {
+  const { maskShapes } = context.event;
+  return maskShapes.map((maskShape) => getMaskPathByMaskShape(maskShape, tolerance));
 }
 
 /**
@@ -95,7 +137,16 @@ export function isSlider(delegateObject: LooseObject): boolean {
 export function isMask(context: IInteractionContext): boolean {
   const event = context.event;
   const target = event.target;
-  return target && target.get('name') === 'mask';
+  return (target && target?.get('name') === 'mask') || isMultipleMask(context);
+}
+
+/**
+ * 是否由 multiple mask 触发
+ * @param context
+ * @returns
+ */
+export function isMultipleMask(context: IInteractionContext): boolean {
+  return context.event.target?.get('name') === 'multi-mask';
 }
 
 /**
@@ -105,6 +156,13 @@ export function isMask(context: IInteractionContext): boolean {
  */
 export function getMaskedElements(context: IInteractionContext, tolerance: number): Element[] {
   const target = context.event.target;
+
+  // multiple 模式下
+  if (isMultipleMask(context)) {
+    return getMultiMaskedElements(context, tolerance);
+  }
+
+  // 正常模式下
   if (target.get('type') === 'path') {
     const maskPath = getMaskPath(context, tolerance);
     if (!maskPath) {
@@ -121,14 +179,52 @@ export function getMaskedElements(context: IInteractionContext, tolerance: numbe
 }
 
 /**
+ * 获取 multiple 模式下被 mask 遮挡的 elements
+ * @param context 上下文
+ * @returns
+ */
+function getMultiMaskedElements(context: IInteractionContext, tolerance: number): Element[] {
+  const { target } = context.event;
+  if (target.get('type') === 'path') {
+    const maskPathList = getMultiMaskPathList(context, tolerance);
+    if (maskPathList.length > 0) {
+      return maskPathList.map((maskPath) => getElementsByPath(context.view, maskPath)).flat();
+    }
+    return null;
+  }
+  const maskBBoxList = getMultiMaskBBoxList(context, tolerance);
+  if (maskBBoxList.length > 0) {
+    return maskBBoxList.map((maskBBox) => getIntersectElements(context.view, maskBBox)).flat();
+  }
+  return null;
+}
+
+/**
  * @ignore
  */
 export function getSiblingMaskElements(context: IInteractionContext, sibling: View, tolerance: number) {
+  // multiple 模式下
+  if (isMultipleMask(context)) {
+    return getSiblingMultiMaskedElements(context, sibling, tolerance);
+  }
+
+  // 正常模式下
   const maskBBox = getMaskBBox(context, tolerance);
   // 如果 bbox 过小则不返回
   if (!maskBBox) {
     return null;
   }
+  return getSiblingMaskElementsByBBox(maskBBox, context, sibling);
+}
+
+/**
+ * 通过 mashBBox 获取 sibling 模式下被 mask 遮挡的 elements
+ * @param maskBBox
+ * @param context 上下文
+ * @param sibling sibling view
+ * @returns
+ */
+function getSiblingMaskElementsByBBox(maskBBox, context: IInteractionContext, sibling: View) {
   const view = context.view;
   const start = getSiblingPoint(view, sibling, { x: maskBBox.x, y: maskBBox.y });
   const end = getSiblingPoint(view, sibling, { x: maskBBox.maxX, y: maskBBox.maxY });
@@ -139,6 +235,21 @@ export function getSiblingMaskElements(context: IInteractionContext, sibling: Vi
     maxY: end.y,
   };
   return getIntersectElements(sibling, box);
+}
+
+/**
+ * 获取 sibling 模式下被 multiple mask 遮挡的 elements
+ * @param context 上下文
+ * @param sibling sibling view
+ * @param tolerance box 宽高小于则不返回
+ * @returns
+ */
+function getSiblingMultiMaskedElements(context: IInteractionContext, sibling: View, tolerance: number): Element[] {
+  const maskBBoxList = getMultiMaskBBoxList(context, tolerance);
+  if (maskBBoxList.length > 0) {
+    return maskBBoxList.map((maskBBox) => getSiblingMaskElementsByBBox(maskBBox, context, sibling)).flat();
+  }
+  return null;
 }
 
 /**

--- a/tests/unit/interaction/action/multi-mask-spec.ts
+++ b/tests/unit/interaction/action/multi-mask-spec.ts
@@ -1,0 +1,773 @@
+import { Chart } from '../../../../src/index';
+import RectMultiMask from '../../../../src/interaction/action/mask/multiple/rect';
+import DimRectMultiMask from '../../../../src/interaction/action/mask/multiple/dim-rect';
+import CircleMultiMask from '../../../../src/interaction/action/mask/multiple/circle';
+import PathMultiMask from '../../../../src/interaction/action/mask/multiple/path';
+import SmoothPathMultiMask from '../../../../src/interaction/action/mask/multiple/smooth-path';
+
+import Context from '../../../../src/interaction/context';
+import { createDiv } from '../../../util/dom';
+import { IShape } from '../../../../src/dependents';
+
+describe('test multiple mask', () => {
+  const chart = new Chart({
+    container: createDiv(),
+    width: 800,
+    height: 800,
+    autoFit: false,
+  });
+  chart.data([
+    { year: '1991', value: 13 },
+    { year: '1992', value: 34 },
+    { year: '1993', value: 5 },
+    { year: '1994', value: 34 },
+  ]);
+  chart.animate(false);
+  chart.tooltip(false);
+  chart.interval().position('year*value').color('year');
+  chart.render();
+
+  const context = new Context(chart);
+  describe('test multiple rect mask', () => {
+    const maskAction = new RectMultiMask(context);
+    let recordPoints;
+    let maskShapes
+    it('start and show', () => {
+      context.event = {
+        x: 100,
+        y: 100,
+      };
+
+      maskAction.start();
+      // @ts-ignore
+      maskShapes = maskAction.maskShapes;
+      // @ts-ignore
+      recordPoints = maskAction.recordPoints;
+      expect(recordPoints).not.toBe(null);
+      expect(recordPoints.length).toEqual(1);
+      expect(maskShapes.length).toEqual(1);
+      let showed = false;
+      chart.on('multi-mask:show', () => {
+        showed = true;
+      });
+      maskAction.show();
+      expect(showed).toBe(true);
+    });
+
+    it('resize', () => {
+      context.event = {
+        x: 200,
+        y: 200,
+      };
+      maskAction.resize();
+      expect(maskShapes[0].attr('x')).toBe(100);
+      expect(maskShapes[0].attr('y')).toBe(100);
+      expect(maskShapes[0].attr('width')).toBe(100);
+      expect(maskShapes[0].attr('height')).toBe(100);
+
+      context.event = {
+        x: 300,
+        y: 300,
+      };
+      maskAction.resize();
+      expect(maskShapes[0].attr('width')).toBe(200);
+      expect(maskShapes[0].attr('height')).toBe(200);
+    });
+
+    it('end', () => {
+      let ended = false;
+      chart.on('multi-mask:end', () => {
+        ended = true;
+      });
+      maskAction.end();
+      expect(ended).toBe(true);
+    });
+
+    it('move', () => {
+      context.event = {
+        x: 150,
+        y: 150,
+      };
+      maskAction.moveStart();
+      context.event = {
+        x: 160,
+        y: 160,
+      };
+      maskAction.move();
+      expect(maskShapes[0].attr('x')).toBe(110);
+      expect(maskShapes[0].attr('y')).toBe(110);
+      expect(maskShapes[0].attr('width')).toBe(200);
+      expect(maskShapes[0].attr('height')).toBe(200);
+
+      context.event = {
+        x: 170,
+        y: 170,
+      };
+      maskAction.move();
+
+      expect(maskShapes[0].attr('x')).toBe(120);
+      expect(maskShapes[0].attr('y')).toBe(120);
+      expect(maskShapes[0].attr('width')).toBe(200);
+      expect(maskShapes[0].attr('height')).toBe(200);
+
+      maskAction.moveEnd();
+
+      // move again
+      context.event = {
+        x: 150,
+        y: 150,
+      };
+      maskAction.moveStart();
+      context.event = {
+        x: 160,
+        y: 160,
+      };
+      maskAction.move();
+      expect(maskShapes[0].attr('x')).toBe(130);
+      expect(maskShapes[0].attr('y')).toBe(130);
+
+      context.event = {
+        x: 170,
+        y: 170,
+      };
+      maskAction.move();
+      expect(maskShapes[0].attr('x')).toBe(140);
+      expect(maskShapes[0].attr('y')).toBe(140);
+
+      context.event = {
+        x: 140,
+        y: 140,
+      };
+      maskAction.move();
+      expect(maskShapes[0].attr('x')).toBe(110);
+      expect(maskShapes[0].attr('y')).toBe(110);
+
+      context.event = {
+        x: 130,
+        y: 130,
+      };
+      maskAction.move();
+      expect(maskShapes[0].attr('x')).toBe(100);
+      expect(maskShapes[0].attr('y')).toBe(100);
+
+      maskAction.moveEnd();
+    });
+
+    it('add multiple mask', () => {
+      context.event = {
+        x: 400,
+        y: 400,
+      };
+      maskAction.start();
+      maskAction.show();
+      context.event = {
+        x: 420,
+        y: 420,
+      };
+      maskAction.resize();
+      context.event = {
+        x: 440,
+        y: 440,
+      };
+      maskAction.resize();
+      maskAction.end();
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(2);
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(2);
+
+      context.event = {
+        x: 450,
+        y: 450,
+      };
+      maskAction.start();
+      maskAction.show();
+      context.event = {
+        x: 460,
+        y: 460,
+      };
+      maskAction.resize();
+      context.event = {
+        x: 480,
+        y: 480,
+      };
+      maskAction.resize();
+      maskAction.end();
+
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(3);
+      // @ts-ignore
+      maskShapes = maskAction.maskShapes
+      expect(maskShapes.length).toEqual(3);
+      expect(maskShapes[0].attr('x')).toBe(100);
+      expect(maskShapes[0].attr('y')).toBe(100);
+      expect(maskShapes[0].attr('width')).toBe(200);
+      expect(maskShapes[0].attr('height')).toBe(200);
+      expect(maskShapes[1].attr('x')).toBe(400);
+      expect(maskShapes[1].attr('y')).toBe(400);
+      expect(maskShapes[1].attr('width')).toBe(40);
+      expect(maskShapes[1].attr('height')).toBe(40);
+      expect(maskShapes[2].attr('x')).toBe(450);
+      expect(maskShapes[2].attr('y')).toBe(450);
+      expect(maskShapes[2].attr('width')).toBe(30);
+      expect(maskShapes[2].attr('height')).toBe(30);
+    })
+
+    it('hide', () => {
+      maskAction.hide();
+      // @ts-ignore
+      expect(maskAction.maskShapes.every(maskShape => maskShape.get('visible'))).toBe(false);
+    });
+
+    it('clear', () => {
+      maskAction.show();
+
+      // cursor on first mask, only clear this mask
+      context.event = {
+        x: 150,
+        y: 150,
+      };
+      maskAction.clear();
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(2);
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(2);
+
+      // cursor not on any mask, clear all
+      context.event = {
+        x: 150,
+        y: 150,
+      };
+      maskAction.clear();
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(0);
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(0);
+    })
+
+    it('destroy', () => {
+      maskAction.destroy();
+      // @ts-ignore
+      expect(maskAction.maskShapes.every((maskShape: IShape) => maskShape.destroyed)).toEqual(true);
+    });
+  });
+
+  describe('test dim rect mask', () => {
+    let maskAction;
+    const coord = chart.getCoordinate();
+    const { start, end } = coord;
+    let recordPoints;
+    let maskShapes;
+
+    it('start, resize and end vertical', () => {
+      maskAction = new DimRectMultiMask(context);
+      maskAction.init();
+      context.event = {
+        x: 100,
+        y: 100,
+      };
+
+      maskAction.start();
+      // @ts-ignore
+      maskShapes = maskAction.maskShapes;
+      // @ts-ignore
+      recordPoints = maskAction.recordPoints;
+      expect(recordPoints).not.toBe(null);
+      expect(recordPoints.length).toEqual(1);
+      expect(maskShapes.length).toEqual(1);
+
+      context.event = {
+        x: 200,
+        y: 200,
+      };
+      maskAction.resize();
+      expect(maskShapes[0].attr('x')).toBe(100);
+      expect(maskShapes[0].attr('width')).toBe(100);
+
+      maskAction.end();
+    });
+
+    it('move', () => {
+      context.event = {
+        x: 150,
+        y: 150,
+      };
+      maskAction.moveStart();
+      context.event = {
+        x: 160,
+        y: 160,
+      };
+      maskAction.move();
+
+      expect(maskAction.maskShapes[0].attr('x')).toBe(110);
+      expect(maskAction.maskShapes[0].attr('width')).toBe(100);
+      maskAction.moveEnd();
+    });
+
+    it('add multiple mask', () => {
+      context.event = {
+        x: 220,
+        y: 100,
+      };
+      maskAction.start();
+      context.event = {
+        x: 260,
+        y: 200,
+      };
+      maskAction.resize();
+      maskAction.end();
+
+      context.event = {
+        x: 280,
+        y: 100,
+      };
+      maskAction.start();
+      context.event = {
+        x: 300,
+        y: 200,
+      };
+      maskAction.resize();
+      maskAction.end();
+
+      // @ts-ignore
+      maskShapes = maskAction.maskShapes;
+      expect(maskShapes.length).toEqual(3);
+      expect(maskShapes[0].attr('x')).toBe(110);
+      expect(maskShapes[0].attr('width')).toBe(100);
+      expect(maskShapes[1].attr('x')).toBe(220);
+      expect(maskShapes[1].attr('width')).toBe(40);
+      expect(maskShapes[2].attr('x')).toBe(280);
+      expect(maskShapes[2].attr('width')).toBe(20);
+      expect(maskAction.recordPoints.length).toEqual(3);
+    })
+
+    it('hide', () => {
+      maskAction.hide();
+      // @ts-ignore
+      expect(maskAction.maskShapes.every(maskShape => maskShape.get('visible'))).toBe(false);
+    });
+
+    it('clear', () => {
+      maskAction.show();
+
+      // cursor on first mask, only clear this mask
+      context.event = {
+        x: 120,
+        y: 120,
+      };
+      maskAction.clear();
+      expect(maskAction.maskShapes.length).toEqual(2);
+      expect(maskAction.recordPoints.length).toEqual(2);
+
+      // cursor not on any mask, clear all
+      context.event = {
+        x: 120,
+        y: 120,
+      };
+      maskAction.clear();
+      expect(maskAction.maskShapes.length).toEqual(0);
+      expect(maskAction.recordPoints.length).toEqual(0);
+    })
+
+    it('destroy', () => {
+      maskAction.destroy();
+      // @ts-ignore
+      expect(maskAction.maskShapes.every((maskShape: IShape) => maskShape.destroyed)).toEqual(true);
+    });
+
+
+    it('horizontal', () => {
+      maskAction = new DimRectMultiMask(context, { dim: 'y' });
+      maskAction.init();
+      context.event = {
+        x: 100,
+        y: 100,
+      };
+      maskAction.start();
+      context.event = {
+        x: 200,
+        y: 200,
+      };
+      maskAction.resize();
+      maskAction.end();
+
+      // @ts-ignore
+      maskShapes = maskAction.maskShapes;
+      expect(maskShapes[0].attr('x')).toBe(start.x);
+      expect(maskShapes[0].attr('width')).toBe(end.x - start.x);
+    });
+  });
+
+  describe('test circle mask', () => {
+    const maskAction = new CircleMultiMask(context);
+    let recordPoints
+    let maskShapes
+    it('start, resize and end', () => {
+      // @ts-ignore
+      expect(maskAction.recordPoints).toBe(null);
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(0);
+      context.event = {
+        x: 200,
+        y: 200,
+      };
+      maskAction.start();
+      maskAction.show();
+      context.event = {
+        x: 200,
+        y: 220,
+      };
+      maskAction.resize();
+      // @ts-ignore
+      expect(maskAction.maskShapes[0].attr('r')).toBe(10);
+
+      context.event = {
+        x: 200,
+        y: 240,
+      };
+      maskAction.resize();
+      // @ts-ignore
+      expect(maskAction.maskShapes[0].attr('r')).toBe(20);
+      maskAction.end();
+    });
+
+    it('add multiple mask', () => {
+      context.event = {
+        x: 300,
+        y: 300,
+      };
+      maskAction.start();
+      context.event = {
+        x: 320,
+        y: 320,
+      };
+      maskAction.resize();
+      maskAction.end();
+
+      context.event = {
+        x: 400,
+        y: 400,
+      };
+      maskAction.start();
+      context.event = {
+        x: 460,
+        y: 460,
+      };
+      maskAction.resize();
+      maskAction.end();
+
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(3);
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(3);
+    })
+
+    it('hide', () => {
+      maskAction.hide();
+      // @ts-ignore
+      expect(maskAction.maskShapes.every(maskShape => maskShape.get('visible'))).toBe(false);
+    });
+
+    it('clear', () => {
+      maskAction.show();
+
+      // cursor on first mask, only clear this mask
+      context.event = {
+        x: 200,
+        y: 200,
+      };
+      maskAction.clear();
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(2);
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(2);
+
+      // cursor not on any mask, clear all
+      context.event = {
+        x: 200,
+        y: 200,
+      };
+      maskAction.clear();
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(0);
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(0);
+    })
+
+    it('destroy', () => {
+      maskAction.destroy();
+      // @ts-ignore
+      expect(maskAction.maskShapes.every((maskShape: IShape) => maskShape.destroyed)).toEqual(true);
+    });
+  });
+
+  describe('test path mask', () => {
+    const maskAction = new PathMultiMask(context);
+    let recordPoints;
+    let maskShapes;
+    it('start and end', () => {
+      // @ts-ignore
+      expect(maskAction.recordPoints).toBe(null);
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(0);
+      context.event = {
+        x: 100,
+        y: 100,
+      };
+      maskAction.start();
+      context.event = {
+        x: 100,
+        y: 120,
+      };
+      maskAction.addPoint();
+
+      // @ts-ignore
+      maskShapes = maskAction.maskShapes;
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(1);
+      // @ts-ignore
+      expect(maskShapes.length).toEqual(1);
+      expect(maskShapes[0].attr('path').length).toBe(3);
+
+      context.event = {
+        x: 150,
+        y: 150,
+      };
+      maskAction.addPoint();
+      expect(maskShapes[0].attr('path').length).toBe(4);
+
+      context.event = {
+        x: 150,
+        y: 80,
+      };
+      maskAction.addPoint();
+      expect(maskShapes[0].attr('path').length).toBe(5);
+      maskAction.end();
+    });
+
+    it('add multiple mask', () => {
+      context.event = {
+        x: 20,
+        y: 10,
+      };
+      maskAction.start();
+      context.event = {
+        x: 30,
+        y: 10,
+      };
+      maskAction.addPoint();
+      context.event = {
+        x: 30,
+        y: 20,
+      };
+      maskAction.addPoint();
+      context.event = {
+        x: 20,
+        y: 20,
+      };
+      maskAction.addPoint();
+      maskAction.end();
+      
+      context.event = {
+        x: 120,
+        y: 10,
+      };
+      maskAction.start();
+      context.event = {
+        x: 130,
+        y: 10,
+      };
+      maskAction.addPoint();
+      context.event = {
+        x: 130,
+        y: 20,
+      };
+      maskAction.addPoint();
+      context.event = {
+        x: 120,
+        y: 20,
+      };
+      maskAction.addPoint();
+      maskAction.end();
+
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(3);
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(3);
+    });
+
+
+    it('hide', () => {
+      maskAction.hide();
+      // @ts-ignore
+      expect(maskAction.maskShapes.every(maskShape => maskShape.get('visible'))).toBe(false);
+    });
+
+    it('clear', () => {
+      maskAction.show();
+
+      // cursor on first mask, only clear this mask
+      context.event = {
+        x: 25,
+        y: 15,
+      };
+      maskAction.clear();
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(2);
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(2);
+
+      // cursor not on any mask, clear all
+      context.event = {
+        x: 25,
+        y: 15,
+      };
+      maskAction.clear();
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(0);
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(0);
+    })
+
+    it('destroy', () => {
+      maskAction.destroy();
+      // @ts-ignore
+      expect(maskAction.maskShapes.every((maskShape: IShape) => maskShape.destroyed)).toEqual(true);
+    });
+  });
+
+  describe('test smooth path mask', () => {
+    const maskAction = new SmoothPathMultiMask(context);
+    let recordPoints;
+    let maskShapes;
+    it('start and end', () => {
+      // @ts-ignore
+      expect(maskAction.recordPoints).toBe(null);
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(0);
+      context.event = {
+        x: 100,
+        y: 100,
+      };
+      maskAction.start();
+      context.event = {
+        x: 100,
+        y: 120,
+      };
+      maskAction.addPoint();
+
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(1);
+      // @ts-ignore
+      maskShapes = maskAction.maskShapes;
+      // @ts-ignore
+      expect(maskShapes.length).toEqual(1);
+      expect(maskShapes[0].attr('path').length).toBe(2);
+
+      context.event = {
+        x: 150,
+        y: 150,
+      };
+      maskAction.addPoint();
+      expect(maskShapes[0].attr('path').length).toBe(4);
+
+      context.event = {
+        x: 150,
+        y: 80,
+      };
+      maskAction.addPoint();
+      expect(maskShapes[0].attr('path').length).toBe(5);
+      maskAction.end();
+    });
+
+    it('add multiple mask', () => {
+      context.event = {
+        x: 20,
+        y: 10,
+      };
+      maskAction.start();
+      context.event = {
+        x: 30,
+        y: 10,
+      };
+      maskAction.addPoint();
+      context.event = {
+        x: 30,
+        y: 20,
+      };
+      maskAction.addPoint();
+      context.event = {
+        x: 20,
+        y: 20,
+      };
+      maskAction.addPoint();
+      maskAction.end();
+      
+      context.event = {
+        x: 120,
+        y: 10,
+      };
+      maskAction.start();
+      context.event = {
+        x: 130,
+        y: 10,
+      };
+      maskAction.addPoint();
+      context.event = {
+        x: 130,
+        y: 20,
+      };
+      maskAction.addPoint();
+      context.event = {
+        x: 120,
+        y: 20,
+      };
+      maskAction.addPoint();
+      maskAction.end();
+
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(3);
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(3);
+    });
+
+
+    it('hide', () => {
+      maskAction.hide();
+      // @ts-ignore
+      expect(maskAction.maskShapes.every(maskShape => maskShape.get('visible'))).toBe(false);
+    });
+
+    it('clear', () => {
+      maskAction.show();
+
+      // cursor on first mask, only clear this mask
+      context.event = {
+        x: 25,
+        y: 15,
+      };
+      maskAction.clear();
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(2);
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(2);
+
+      // cursor not on any mask, clear all
+      context.event = {
+        x: 25,
+        y: 15,
+      };
+      maskAction.clear();
+      // @ts-ignore
+      expect(maskAction.maskShapes.length).toEqual(0);
+      // @ts-ignore
+      expect(maskAction.recordPoints.length).toEqual(0);
+    })
+
+    it('destroy', () => {
+      maskAction.destroy();
+      // @ts-ignore
+      expect(maskAction.maskShapes.every((maskShape: IShape) => maskShape.destroyed)).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
* **🎯 背景**: 项目业务需要在 AntV G2 气泡图中圈选出多个群组，每个群组的详细数据联动渲染在联动 AntV S2 交叉表上。因此需要实现多选模式的遮罩交互

* **🎨 效果**:
  - 动图
    - [rect-multi-mask.gif](https://img.alicdn.com/imgextra/i4/O1CN01uyqFIo1O9hSlakd21_!!6000000001663-1-tps-480-386.gif)
![rect-multi-mask](https://img.alicdn.com/imgextra/i4/O1CN01uyqFIo1O9hSlakd21_!!6000000001663-1-tps-480-386.gif "rect-multi-mask")
    - [x-rect-multi-mask.gif](https://img.alicdn.com/imgextra/i2/O1CN01pcQpd51aE4dQsDS7F_!!6000000003297-1-tps-480-386.gif)
![x-rect-multi-mask](https://img.alicdn.com/imgextra/i2/O1CN01pcQpd51aE4dQsDS7F_!!6000000003297-1-tps-480-386.gif "x-rect-multi-mask")

    - [y-rect-multi-mask.gif](https://img.alicdn.com/imgextra/i1/O1CN01Z8W7en1TgHiiH1ejS_!!6000000002411-1-tps-480-386.gif)
![y-rect-multi-mask](https://img.alicdn.com/imgextra/i1/O1CN01Z8W7en1TgHiiH1ejS_!!6000000002411-1-tps-480-386.gif "y-rect-multi-mask")

    - [circle-multi-mask.gif](https://img.alicdn.com/imgextra/i3/O1CN01kcm2t31rNYIgvcDMw_!!6000000005619-1-tps-480-386.gif)
![circle-multi-mask](https://img.alicdn.com/imgextra/i3/O1CN01kcm2t31rNYIgvcDMw_!!6000000005619-1-tps-480-386.gif "circle-multi-mask")

    - [path-multi-mask.gif](https://img.alicdn.com/imgextra/i3/O1CN01iSbjIN1Ij4MDsMpP7_!!6000000000928-1-tps-600-486.gif)
![path-multi-mask](https://img.alicdn.com/imgextra/i3/O1CN01iSbjIN1Ij4MDsMpP7_!!6000000000928-1-tps-600-486.gif "path-multi-mask")

    - [smooth-path-multi-mask.gif](https://img.alicdn.com/imgextra/i3/O1CN016yjgdL1QRgFELEu9i_!!6000000001973-1-tps-600-486.gif)
![smooth-path-multi-mask](https://img.alicdn.com/imgextra/i3/O1CN016yjgdL1QRgFELEu9i_!!6000000001973-1-tps-600-486.gif "smooth-path-multi-mask")

  - 相关交互
    - 光标在某个 mask 上拖动时，可移动该 mask
    - 光标在某个 mask 上双击时，可清除该 mask
    - 光标不在任何 mask 上时双击，可清除所有 mask


* **🎏 实现**:
  - 创建了一个 MultipleMaskBase 作为各种 multi-mask action 的基类。MultipleMaskBase 与原本的 MaskBase 类似，不同点是使用数组 maskShapes 保存多个 mask shape， 使用 recordPoints 记录每一次圈选操作过程的坐标点

  - 基于 MultipleMaskBase 创建了 rect, dim-rect, circle, path, smooth-path 的 multiple actions，它们的属性方法都复用了原 MaskBase 对应子类的方法

  - 修改了识别 mask context 和获取 mask 选中元素的相关方法，秉承开放封闭的原则，添加了支持 multi-mask 的逻辑

  - 更新了 multi-mask 的 api，仿照原有 api 写法，仅添加了 rect, circle, path 3种

  - 添加了 multi-mask action 的测试用例，包含了所有类型的 multi-mask action

  - 在内置交互中添加了element-x-multi-range-highlight，用于在图表示例中展示