### PR TITLE
fix(test): transform esm to cmjs in node_modules

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --on-install lint-staged
+npx lint-staged
 npm run-s lint

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,24 @@
+// Modules installed by tnpm or cnpm will use underscore as prefix.
+// In this case _{module} is also necessary.
+const esm = ['d3-*'].map((d) => `_${d}|${d}`).join('|');
+
+module.exports = {
+  runner: 'jest-electron/runner',
+  testEnvironment: 'jest-electron/environment',
+  testTimeout: 30000,
+  preset: 'ts-jest/presets/js-with-ts',
+  globals: {
+    'ts-jest': {
+      tsconfig: {
+        allowJs: true,
+        sourceMap: true,
+      },
+    },
+  },
+  collectCoverage: false,
+  testRegex: '/tests/.*-spec\\.ts?$',
+  // Transform esm to cjs.
+  transformIgnorePatterns: [`<rootDir>/node_modules/(?!(${esm}))`],
+  collectCoverageFrom: ['src/**/*.{ts,js}', '!**/node_modules/**', '!**/vendor/**'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};

--- a/package.json
+++ b/package.json
@@ -105,24 +105,6 @@
       "lint-md ./docs --fix"
     ]
   },
-  "jest": {
-    "runner": "jest-electron/runner",
-    "testEnvironment": "jest-electron/environment",
-    "testTimeout": 30000,
-    "preset": "ts-jest",
-    "collectCoverage": false,
-    "collectCoverageFrom": [
-      "src/**/*.{ts,js}",
-      "!**/node_modules/**",
-      "!**/vendor/**"
-    ],
-    "testRegex": "/tests/.*-spec\\.ts?$",
-    "moduleFileExtensions": [
-      "ts",
-      "js",
-      "json"
-    ]
-  },
   "homepage": "https://g2.antv.vision",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# 修复单测

这个 PR：https://github.com/antvis/G2/pull/4584 的开发者提到本地单测不通过，所以在这里修复该问题。

## 存在问题

![image](https://user-images.githubusercontent.com/49330279/212598708-ff306855-070a-4135-8d85-a9c2ba3ee98e.png)

这个问题是因为 G 4.0 这个 PR https://github.com/antvis/G/pull/1216/files 升级了 d3-interpolate 的版本，d3-interpolate 该版本只提供了 esm 文件，而 jest 只能使用 cjs 文件。


## 解决办法

通过 `confg. transformIgnorePatterns` 转换 node_modules 里面的 d3-interpolate 成 cjs 文件。

```js
// Installing third-party modules by tnpm or cnpm will name modules with underscore as prefix.
// In this case _{module} is also necessary.
const esm = ['d3-*'].map((d) => `_${d}|${d}`).join('|');

module.exports = {
  // ...
  transformIgnorePatterns: [`<rootDir>/node_modules/(?!(${esm}))`],
  // ....
};
```

同时还需要让 jest 使用 js 文件，需要修改 preset 为 `js-with-ts`，同时修改测试使用的 `tsconfig` 支持 js。

```js
module.exports = {
  preset: 'ts-jest/presets/js-with-ts',
  globals: {
    'ts-jest': {
      tsconfig: {
        allowJs: true,
        sourceMap: true,
      },
    },
  },
};
```