### PR TITLE
fix: g can't clone undefined attribute

### DIFF
--- a/src/label-transform/overlapDodgeY.ts
+++ b/src/label-transform/overlapDodgeY.ts
@@ -2,6 +2,7 @@ import { DisplayObject } from '@antv/g';
 import { ascending } from 'd3-array';
 import { OverlapDodgeYTransform } from '../spec';
 import { LabelTransformComponent as LLC } from '../runtime';
+import { defined } from '../utils/helper';
 
 export type OverlapDodgeYOptions = Omit<OverlapDodgeYTransform, 'type'>;
 
@@ -16,13 +17,19 @@ function useMap<K, V>() {
   return [get, set] as const;
 }
 
+/**
+ * @todo fixme
+ */
 function getBoundsWithoutConnector(shape: DisplayObject) {
+  // Remove this line when @antv/g fixed
+  // https://github.com/antvis/G/pull/1269#pullrequestreview-1251209956
+  if (!defined(shape.style.stroke)) shape.style.stroke = '';
+
   const node = shape.cloneNode(true);
   const connectorShape = node.getElementById('connector');
   connectorShape && node.removeChild(connectorShape);
   const { min, max } = node.getRenderBounds();
   node.destroy();
-
   return { min, max };
 }
 


### PR DESCRIPTION
# 修复测试

G 这个 [PR](https://github.com/antvis/G/pull/1269#pullrequestreview-1251209956) 带来的问题。

## 原因

G 上述更新之后，`shape.clone` 无法 clone 没有定义的属性。

```js
const shape = new Rect({});
shape.style.stroke = undefiend;

shape.clone(true); // 报错
```

![image](https://user-images.githubusercontent.com/49330279/212865366-b46412b3-54da-41a8-ad5f-7890e657dc2b.png)

## 解决办法

在 G2 中目前只有 stroke 属性为 null 的问题，所以当 stroke 没有定义的时候，设置为空字符串。**当 G 修复之后，这里的修复代码可以去掉**。 @xiaoiver 