### PR TITLE
refactor(api): add emitter

### DIFF
--- a/__tests__/integration/snapshot-animation.spec.ts
+++ b/__tests__/integration/snapshot-animation.spec.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import EventEmitter from '@antv/event-emitter';
 import { G2Context, render } from '../../src';
 import * as tests from './animations';
 import { fetch } from './fetch';
@@ -63,7 +64,8 @@ describe('Animations', () => {
           const options = await generateOptions();
           const { width = 640, height = 480 } = options;
           [canvas, nodeCanvas] = createGCanvas(width, height);
-          const context: G2Context = { canvas };
+          const emitter = new EventEmitter();
+          const context: G2Context = { canvas, emitter };
 
           let frameCount = 0;
           const { intervals: I } = generateOptions;
@@ -113,17 +115,8 @@ describe('Animations', () => {
           // Render chart and listen afterpaint event for every node.
           // eslint-disable-next-line no-async-promise-executor
           await new Promise<void>(async (resolve) => {
-            const on = { afterpaint: [onframe] };
-            // @ts-ignore
-            const { children, ...rest } = options;
-            const listenedOptions = {
-              ...rest,
-              ...(children && {
-                children: children.map((d) => ({ ...d, on })),
-              }),
-              on,
-            };
-            render(listenedOptions, context, resolve);
+            emitter.on('afterpaint', onframe);
+            render(options, context, resolve);
           });
 
           // Asset the last state of this animation.

--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -399,6 +399,28 @@ describe('Chart', () => {
     };
   });
 
+  it('chart.render() should update finished promise', (done) => {
+    const chart = new Chart({
+      container: createDiv(),
+    });
+
+    chart.data([
+      { genre: 'Sports', sold: 275 },
+      { genre: 'Strategy', sold: 115 },
+      { genre: 'Action', sold: 120 },
+      { genre: 'Shooter', sold: 350 },
+      { genre: 'Other', sold: 150 },
+    ]);
+
+    chart
+      .interval()
+      .encode('x', 'genre')
+      .encode('y', 'sold')
+      .encode('color', 'genre');
+
+    chart.render().finished.then(() => done());
+  });
+
   it('chart.render({...}) should rerender chart with updated size', () => {
     const div = createDiv();
     const button = document.createElement('button');
@@ -473,20 +495,13 @@ describe('Chart', () => {
     };
   });
 
-  it('chart.on({...}) should register chart event.', () => {
+  it('chart.on(event, callback) should register chart event.', (done) => {
     const div = createDiv();
 
     const chart = new Chart({
       container: div,
     });
 
-    // 1. chart.on('eventName', callback)
-    chart.on('afterrender', () => console.log('afterrender event.'));
-    // 2. chart.on('eventName', [callback])
-    chart.on('beforerender', [
-      () => console.log('beforerender event 1'),
-      () => console.log('beforerender event 2'),
-    ]);
     chart.data([
       { genre: 'Sports', sold: 275 },
       { genre: 'Strategy', sold: 115 },
@@ -501,7 +516,47 @@ describe('Chart', () => {
       .encode('y', 'sold')
       .encode('color', 'genre');
 
+    let beforerender = false;
+    let beforepaint = false;
+    let afterpaint = false;
+    chart
+      .on('beforerender', () => (beforerender = true))
+      .on('beforepaint', () => (beforepaint = true))
+      .on('afterpaint', () => (afterpaint = true))
+      .on('afterrender', () => {
+        expect(beforerender).toBe(true);
+        expect(beforepaint).toBe(true);
+        expect(afterpaint).toBe(true);
+        done();
+      });
+
     chart.render();
+  });
+
+  it('chart.once(event, callback) should call callback once.', () => {
+    const chart = new Chart();
+    let count = 0;
+    chart.once('foo', () => count++);
+    chart.emit('foo');
+    chart.emit('foo');
+    expect(count).toBe(1);
+  });
+
+  it('chart.emit(event, ...params) should emit event.', () => {
+    const chart = new Chart();
+    let sum = 0;
+    chart.on('foo', (a, b) => (sum = a + b));
+    chart.emit('foo', 1, 2);
+    expect(sum).toBe(3);
+  });
+
+  it('chart.off(event) should remove event.', () => {
+    const chart = new Chart();
+    let count = 0;
+    chart.on('foo', () => count++);
+    chart.off('foo');
+    chart.emit('foo');
+    expect(count).toBe(0);
   });
 
   it('chart should render after window resize.', (done) => {

--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -334,7 +334,7 @@ describe('Chart', () => {
       .encode('y', 'sold')
       .encode('color', 'genre');
 
-    expect(chart.render()).toBe(chart);
+    chart.render();
     expect(chart.context().canvas?.getConfig().container).toBe(container);
   });
 

--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -399,7 +399,7 @@ describe('Chart', () => {
     };
   });
 
-  it('chart.render() should update finished promise', (done) => {
+  it('chart.render() should return promise', (done) => {
     const chart = new Chart({
       container: createDiv(),
     });
@@ -418,7 +418,10 @@ describe('Chart', () => {
       .encode('y', 'sold')
       .encode('color', 'genre');
 
-    chart.render().finished.then(() => done());
+    chart.render().then((c) => {
+      expect(c).toBe(chart);
+      done();
+    });
   });
 
   it('chart.render({...}) should rerender chart with updated size', () => {

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
   },
   "dependencies": {
     "@antv/coord": "^0.4.1",
+    "@antv/event-emitter": "^0.1.3",
     "@antv/g": "^5.7.4",
     "@antv/g-canvas": "^1.7.4",
     "@antv/g-plugin-dragndrop": "^1.6.1",

--- a/src/api/props.ts
+++ b/src/api/props.ts
@@ -1,7 +1,3 @@
-import { isObject, deepMix, get, isString, isArray } from '@antv/util';
-
-type EventListener = (...args: any[]) => void;
-
 export type NodePropertyDescriptor = {
   type: 'object' | 'value' | 'array' | 'node' | 'container' | 'event';
   name: string;
@@ -51,24 +47,6 @@ function defineContainerProp(Node, { name, ctor }: NodePropertyDescriptor) {
   };
 }
 
-function defineEventProp(Node, { name, key = name }: NodePropertyDescriptor) {
-  Node.prototype[name] = function (
-    eventName: string,
-    listener: EventListener | EventListener[],
-  ) {
-    const events = this.attr(key) || {};
-    if (arguments.length === 0) return events;
-    if (arguments.length === 1) return events[eventName];
-    const listeners = events[eventName];
-    if (listeners) {
-      isArray(listener) ? listeners.concat(listener) : listeners.push(listener);
-    } else {
-      events[eventName] = isArray(listener) ? listener : [listener];
-    }
-    return this.attr(key, events);
-  };
-}
-
 /**
  * A decorator to define different type of attribute setter or
  * getter for current node.
@@ -82,7 +60,6 @@ export function defineProps(descriptors: NodePropertyDescriptor[]) {
       else if (type === 'object') defineObjectProp(Node, descriptor);
       else if (type === 'node') defineNodeProp(Node, descriptor);
       else if (type === 'container') defineContainerProp(Node, descriptor);
-      else if (type === 'event') defineEventProp(Node, descriptor);
     }
     return Node;
   };

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -165,7 +165,7 @@ export async function plot<T extends G2ViewTree>(
     }
   }
 
-  context.dispatch.emit(CHART_LIFE_CIRCLE.BEFORE_PAINT);
+  context.emitter.emit(CHART_LIFE_CIRCLE.BEFORE_PAINT);
 
   // Plot chart.
   const enterContainer = new Map<G2ViewDescriptor, DisplayObject>();
@@ -268,7 +268,7 @@ export async function plot<T extends G2ViewTree>(
   context.views = views;
   context.animations = transitions;
 
-  context.dispatch.emit(CHART_LIFE_CIRCLE.AFTER_PAINT);
+  context.emitter.emit(CHART_LIFE_CIRCLE.AFTER_PAINT);
 
   // Note!!!
   // The returned promise will never resolved if one of nodeGenerator

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -4,7 +4,7 @@ import { deepMix, upperFirst } from '@antv/util';
 import { group } from 'd3-array';
 import { format } from 'd3-format';
 import { mapObject } from '../utils/array';
-import { CHART_LIFE_CIRCLE, emitEvent } from '../utils/event';
+import { CHART_LIFE_CIRCLE } from '../utils/event';
 import {
   appendTransform,
   compose,
@@ -165,8 +165,7 @@ export async function plot<T extends G2ViewTree>(
     }
   }
 
-  const { on } = options;
-  emitEvent(on, CHART_LIFE_CIRCLE.BEFORE_PAINT);
+  context.dispatch.emit(CHART_LIFE_CIRCLE.BEFORE_PAINT);
 
   // Plot chart.
   const enterContainer = new Map<G2ViewDescriptor, DisplayObject>();
@@ -269,7 +268,7 @@ export async function plot<T extends G2ViewTree>(
   context.views = views;
   context.animations = transitions;
 
-  emitEvent(on, CHART_LIFE_CIRCLE.AFTER_PAINT);
+  context.dispatch.emit(CHART_LIFE_CIRCLE.AFTER_PAINT);
 
   // Note!!!
   // The returned promise will never resolved if one of nodeGenerator

--- a/src/runtime/render.ts
+++ b/src/runtime/render.ts
@@ -2,9 +2,10 @@ import { Canvas as GCanvas, DisplayObject, Group } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Plugin as DragAndDropPlugin } from '@antv/g-plugin-dragndrop';
 import { deepMix } from '@antv/util';
+import EventEmitter from '@antv/event-emitter';
 import { createLibrary } from '../stdlib';
 import { select } from '../utils/selection';
-import { emitEvent, CHART_LIFE_CIRCLE, offEvent } from '../utils/event';
+import { CHART_LIFE_CIRCLE } from '../utils/event';
 import { G2Context, G2ViewTree } from './types/options';
 import { plot } from './plot';
 
@@ -65,12 +66,17 @@ export function render<T extends G2ViewTree = G2ViewTree>(
   // Initialize the context if it is not provided.
   const { width = 640, height = 480, on } = options;
   const keyed = inferKeys(options);
-  const { canvas = Canvas(width, height), library = createLibrary() } = context;
+  const {
+    canvas = Canvas(width, height),
+    library = createLibrary(),
+    dispatch = new EventEmitter(),
+  } = context;
   context.canvas = canvas;
   context.library = library;
+  context.dispatch = dispatch;
   canvas.resize(width, height);
 
-  emitEvent(on, CHART_LIFE_CIRCLE.BEFORE_RENDER);
+  dispatch.emit(CHART_LIFE_CIRCLE.BEFORE_RENDER);
 
   // Plot the chart and mutate context.
   // Make sure that plot chart after container is ready for every time.
@@ -79,8 +85,8 @@ export function render<T extends G2ViewTree = G2ViewTree>(
     .then(() =>
       plot<T>({ ...keyed, width, height }, selection, library, context),
     )
-    .then(callback)
-    .then(() => emitEvent(on, CHART_LIFE_CIRCLE.AFTER_RENDER));
+    .then(() => dispatch.emit(CHART_LIFE_CIRCLE.AFTER_RENDER))
+    .then(callback);
 
   // Return the container HTML element wraps the canvas or svg element.
   return normalizeContainer(canvas.getConfig().container);
@@ -94,7 +100,11 @@ export function renderToMountedElement<T extends G2ViewTree = G2ViewTree>(
   // Initialize the context if it is not provided.
   const { width = 640, height = 480, on } = options;
   const keyed = inferKeys(options);
-  const { library = createLibrary(), group = new Group() } = context;
+  const {
+    library = createLibrary(),
+    group = new Group(),
+    dispatch = new EventEmitter(),
+  } = context;
 
   if (!group?.parentElement) {
     throw new Error(
@@ -105,13 +115,14 @@ export function renderToMountedElement<T extends G2ViewTree = G2ViewTree>(
   const selection = select(group);
   context.group = group;
   context.library = library;
+  context.dispatch = dispatch;
 
-  emitEvent(on, CHART_LIFE_CIRCLE.BEFORE_RENDER);
+  dispatch.emit(CHART_LIFE_CIRCLE.BEFORE_RENDER);
   // Plot the chart and mutate context.
   // Make sure that plot chart after container is ready for every time.
   plot<T>({ ...keyed, width, height }, selection, library, context)
-    .then(callback)
-    .then(() => emitEvent(on, CHART_LIFE_CIRCLE.AFTER_RENDER));
+    .then(() => dispatch.emit(CHART_LIFE_CIRCLE.AFTER_RENDER))
+    .then(callback);
 
   // Return the Group wraps the canvas or svg element.
   return group;
@@ -121,12 +132,11 @@ export function destroy<T extends G2ViewTree = G2ViewTree>(
   options: T,
   context: G2Context = {},
 ) {
-  const { on } = options;
-  const { canvas } = context;
+  const { canvas, dispatch } = context;
   if (canvas) {
     canvas.destroy();
   }
-  offEvent(on);
+  dispatch.off();
 }
 
 function normalizeContainer(container: HTMLElement | string): HTMLElement {

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -1,5 +1,6 @@
 import { Canvas, IAnimation as GAnimation } from '@antv/g';
 import type { DisplayObject } from '@antv/g';
+import EventEmitter from '@antv/event-emitter';
 import {
   G2Title,
   G2ViewDescriptor,
@@ -52,6 +53,7 @@ export type G2Library = Record<
 export type G2Context = {
   library?: G2Library;
   canvas?: Canvas;
+  dispatch?: EventEmitter;
   group?: DisplayObject;
   animations?: GAnimation[];
   views?: G2ViewDescriptor[];

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -53,7 +53,7 @@ export type G2Library = Record<
 export type G2Context = {
   library?: G2Library;
   canvas?: Canvas;
-  dispatch?: EventEmitter;
+  emitter?: EventEmitter;
   group?: DisplayObject;
   animations?: GAnimation[];
   views?: G2ViewDescriptor[];

--- a/src/spec/composition.ts
+++ b/src/spec/composition.ts
@@ -61,7 +61,6 @@ export type ViewComposition = {
   axis?: Record<string, any>;
   // @todo
   legend?: Record<string, any>;
-  on?: Record<string, EventType | EventType[]>;
   // @todo
   style?: Record<string, any>;
   clip?: boolean;

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -18,29 +18,3 @@ export enum CHART_LIFE_CIRCLE {
   BEFORE_CHANGE_SIZE = 'beforechangesize',
   AFTER_CHANGE_SIZE = 'afterchangesize',
 }
-
-export function emitEvent(
-  event: Record<string, EventListener[]>,
-  eventName: string,
-  ...args: any[]
-) {
-  if (!event) return;
-  const listeners = event[eventName] || [];
-  listeners.forEach((listener) => {
-    listener.apply(this, args);
-  });
-}
-
-export function offEvent(
-  event: Record<string, EventListener[]>,
-  eventName?: string,
-) {
-  if (!event) return;
-  // Unbind all event.
-  if (!eventName) {
-    event = {};
-    return;
-  }
-
-  delete event[eventName];
-}


### PR DESCRIPTION
# Add Emitter

之前是希望事件也可以声明式的定义，所以增加了 `options.on` 的字段，但是目前看来没有必要，所以给 Chart 对象增加了一个 EventEmitter 作为一个事件总线：emitter，并且传递给了 runtime 的 render 函数。

## API

- chart.on()
- chart.off()
- chart.emit()
- chart.once()
- chart.render() 返回一个 promise

```js
chart.render().then((c) => {
  expect(c).toBe(chart);
})
```

## 未来工作

下一个 PR 将实现以下功能：

```js
chart.emit('tooltip:show', {});
chart.emit('tooltip:hide');
chart.emit('tooltip:lock');
chart.emit('tooltip:unlock');
```