### PR TITLE
fix(tooltip): selected expected elements (close: #4650)

### DIFF
--- a/__tests__/integration/api-mark-change-data-tooltip.spec.ts
+++ b/__tests__/integration/api-mark-change-data-tooltip.spec.ts
@@ -1,0 +1,40 @@
+import { CustomEvent as GCustomEvent } from '@antv/g';
+import { markChangeDataTooltip as render } from '../plots/api/mark-change-data-tooltip';
+import { PLOT_CLASS_NAME } from '../../src';
+import { createDOMGCanvas } from './utils/createDOMGCanvas';
+import { sleep } from './utils/sleep';
+import './utils/useSnapshotMatchers';
+
+describe('mark.changeData tooltip', () => {
+  const canvas = createDOMGCanvas(640, 480);
+
+  it('mark.changeData(width, height) should rerender expected chart', async () => {
+    const { finished, button, chart } = render({
+      canvas,
+      container: document.createElement('div'),
+    });
+    await finished;
+
+    // Update data
+    button.dispatchEvent(new CustomEvent('click'));
+    await new Promise<void>((resolve) => chart.on('afterrender', resolve));
+    const dir = `${__dirname}/snapshots/api`;
+    await sleep(20);
+
+    // Trigger tooltip
+    const plot = canvas.document.getElementsByClassName(PLOT_CLASS_NAME)[0];
+    plot.dispatchEvent(
+      new GCustomEvent('pointermove', {
+        offsetX: 200,
+        offsetY: 300,
+      }),
+    );
+    await expect(canvas).toMatchDOMSnapshot(dir, render.name, {
+      selector: `.tooltip`,
+    });
+  });
+
+  afterAll(() => {
+    canvas?.destroy();
+  });
+});

--- a/__tests__/integration/snapshots/api/markChangeDataTooltip.html
+++ b/__tests__/integration/snapshots/api/markChangeDataTooltip.html
@@ -1,0 +1,46 @@
+<div
+  xmlns="http://www.w3.org/1999/xhtml"
+  class="tooltip"
+  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular;"
+>
+  <div
+    class="tooltip-title"
+    style="color: rgba(0, 0, 0, 0.45); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+  >
+    test2
+  </div>
+  <ul
+    class="tooltip-list"
+    style="margin: 0px; list-style-type: none; padding: 0px;"
+  >
+    <li
+      class="tooltip-list-item"
+      data-index="0"
+      style="list-style-type: none; margin-top: 12px; display: flex; line-height: 1em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="tooltip-list-item-marker"
+          style="background: rgb(91, 143, 249); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="tooltip-list-item-name-label"
+          title="frequency"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          frequency
+        </span>
+      </span>
+      <span
+        class="tooltip-list-item-value"
+        title="11"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        11
+      </span>
+    </li>
+  </ul>
+</div>;

--- a/__tests__/main.ts
+++ b/__tests__/main.ts
@@ -157,7 +157,9 @@ function createAPIRender(object) {
     return (container) => {
       // Select render is unnecessary for api tests.
       selectRenderer.style.display = 'none';
-      render({ container });
+      const { canvas } = render({ container });
+      // @ts-ignore
+      if (canvas instanceof Canvas) window.__g_instances__ = [canvas];
     };
   };
   return Object.fromEntries(

--- a/__tests__/plots/api/index.ts
+++ b/__tests__/plots/api/index.ts
@@ -3,3 +3,4 @@ export { registerShape } from './register-shape';
 export { chartChangeSize } from './chart-change-size';
 export { chartAutoFit } from './chart-auto-fit';
 export { markChangeData } from './mark-change-data';
+export { markChangeDataTooltip } from './mark-change-data-tooltip';

--- a/__tests__/plots/api/mark-change-data-tooltip.ts
+++ b/__tests__/plots/api/mark-change-data-tooltip.ts
@@ -1,0 +1,47 @@
+import { Chart } from '../../../src';
+
+export function markChangeDataTooltip(context) {
+  const { container, canvas } = context;
+
+  const button = document.createElement('button');
+  button.innerText = 'Update Data';
+  container.appendChild(button);
+
+  const div = document.createElement('div');
+  container.appendChild(div);
+
+  const chart = new Chart({
+    container: div,
+    canvas,
+  });
+
+  const line = chart
+    .line()
+    .data([
+      { letter: 'test1', frequency: 10 },
+      { letter: 'test2', frequency: 11 },
+      { letter: 'test3', frequency: 12 },
+      { letter: 'test4', frequency: 13 },
+      { letter: 'test5', frequency: 14 },
+      { letter: 'test6', frequency: 16 },
+    ])
+    .encode('x', 'letter')
+    .encode('y', 'frequency')
+    .axis('y', { labelFormatter: '.0%' })
+    .interaction('tooltip');
+
+  const finished = chart.render();
+
+  button.onclick = () => {
+    line.changeData([
+      { letter: 'test1', frequency: 20 },
+      { letter: 'test2', frequency: 11 },
+      { letter: 'test3', frequency: 12 },
+      { letter: 'test4', frequency: 13 },
+      { letter: 'test5', frequency: 14 },
+      { letter: 'test6', frequency: 16 },
+    ]);
+  };
+
+  return { chart, finished, button, canvas: chart.context().canvas };
+}

--- a/__tests__/plots/api/mark-change-data.ts
+++ b/__tests__/plots/api/mark-change-data.ts
@@ -40,5 +40,5 @@ export function markChangeData(context) {
     ]);
   };
 
-  return { chart, finished, button };
+  return { chart, finished, button, canvas: chart.context().canvas };
 }

--- a/src/interaction/native/utils.ts
+++ b/src/interaction/native/utils.ts
@@ -19,7 +19,10 @@ import { angle, angleBetween, sub } from '../../utils/vector';
  * Given root of chart returns elements to be manipulated
  */
 export function selectG2Elements(root: DisplayObject): DisplayObject[] {
-  return select(root).selectAll(`.${ELEMENT_CLASS_NAME}`).nodes();
+  return select(root)
+    .selectAll(`.${ELEMENT_CLASS_NAME}`)
+    .nodes()
+    .filter((d) => !d.__removed__);
 }
 
 export function selectFacetG2Elements(target, viewInstances): DisplayObject[] {


### PR DESCRIPTION
- fix: https://github.com/antvis/G2/issues/4650
- 原因：更新数据的时候，旧的元素不会马上删除（需要等到动画结束），于是交互把旧的元素也保存下来了，从而会同时显示新旧元素的 tooltip。