### PR TITLE
chore(version): bump to 5.0.0-beta.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2",
-  "version": "5.0.0-beta.9",
+  "version": "5.0.0-beta.10",
   "description": "the Grammar of Graphics in Javascript",
   "license": "MIT",
   "main": "lib/index.js",
@@ -124,7 +124,7 @@
     "@antv/g": "^5.7.4",
     "@antv/g-canvas": "^1.7.4",
     "@antv/g-plugin-dragndrop": "^1.6.1",
-    "@antv/gui": "^0.4.3-alpha.71",
+    "@antv/gui": "0.4.3-alpha.75",
     "@antv/path-util": "^3.0.1",
     "@antv/scale": "^0.4.7",
     "@antv/util": "^2.0.17",

--- a/site/package.json
+++ b/site/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.0-beta.9",
+  "version": "5.0.0-beta.10",
   "scripts": {
     "start": "dumi dev",
     "build": "dumi build",


### PR DESCRIPTION
- 更新版本到 5.0.0-beta.10
- 锁定 gui 版本，防止这周 gui 有 breaking change。