### PR TITLE
feat(scale): add constant

### DIFF
--- a/src/runtime/mark.ts
+++ b/src/runtime/mark.ts
@@ -82,12 +82,13 @@ export async function initializeMark(
       );
       return valuesArray.map(([channel, values], i) => {
         const visual = values.some((d) => d.visual);
+        const constant = values.some((d) => d.constant);
         const {
           independent = false,
           // Use channel name as default scale key.
           key = scaleKey || channel,
           // Visual channel use identity scale.
-          type = visual ? 'identity' : scaleType,
+          type = constant ? 'constant' : visual ? 'identity' : scaleType,
           ...scaleOptions
         } = scale[channel] || {};
         return {

--- a/src/runtime/scale.ts
+++ b/src/runtime/scale.ts
@@ -248,6 +248,8 @@ function inferScaleRange(
     }
     case 'sequential':
       return undefined;
+    case 'constant':
+      return [values[0][0]];
     default:
       return [];
   }

--- a/src/runtime/transform.ts
+++ b/src/runtime/transform.ts
@@ -77,7 +77,6 @@ export function inferChannelsType(
   return [I, { ...mark, encode: typedEncode }];
 }
 
-// @todo Move visual property to style instead of flagging visual.
 export function maybeVisualChannel(
   I: number[],
   mark: G2Mark,
@@ -88,7 +87,7 @@ export function maybeVisualChannel(
   const newEncode = mapObject(encode, (channel, name) => {
     const { type } = channel;
     if (type !== 'constant' || isPosition(name)) return channel;
-    return { ...channel, visual: true };
+    return { ...channel, constant: true };
   });
   return [I, { ...mark, encode: newEncode }];
 }

--- a/src/scale/constant.ts
+++ b/src/scale/constant.ts
@@ -1,0 +1,11 @@
+import { Constant as ConstantScale } from '@antv/scale';
+import { ConstantScale as ConstantScaleSpec } from '../spec';
+import { ScaleComponent as SC } from '../runtime';
+
+export type ConstantOptions = Omit<ConstantScaleSpec, 'type'>;
+
+export const Constant: SC<ConstantOptions> = (options) => {
+  return new ConstantScale(options);
+};
+
+Constant.props = {};

--- a/src/scale/index.ts
+++ b/src/scale/index.ts
@@ -11,6 +11,7 @@ export { Quantile } from './quantile';
 export { Quantize } from './quantize';
 export { Sqrt } from './sqrt';
 export { Sequential } from './sequential';
+export { Constant } from './constant';
 
 export type { BandOptions } from './band';
 export type { LinearOptions } from './linear';
@@ -25,3 +26,4 @@ export type { QuantileOptions } from './quantile';
 export type { QuantizeOptions } from './quantize';
 export type { SqrtOptions } from './sqrt';
 export type { SequentialOptions } from './sequential';
+export type { ConstantOptions } from './constant';

--- a/src/spec/scale.ts
+++ b/src/spec/scale.ts
@@ -12,6 +12,7 @@ import {
   QuantizeOptions,
   SqrtOptions,
   SequentialOptions,
+  ConstantOptions,
 } from '@antv/scale';
 import { ScaleComponent } from '../runtime';
 import { Palette } from './palette';
@@ -30,7 +31,8 @@ export type Scale =
   | QuantizeScale
   | QuantileScale
   | SequentialScale
-  | CustomScale;
+  | CustomScale
+  | ConstantScale;
 
 export type ScaleTypes =
   | 'linear'
@@ -46,6 +48,7 @@ export type ScaleTypes =
   | 'quantize'
   | 'quantile'
   | 'sequential'
+  | 'constant'
   | ScaleComponent;
 
 export type BaseScale<T extends ScaleTypes, O> = {
@@ -87,5 +90,7 @@ export type QuantileScale = BaseScale<'quantile', QuantileOptions>;
 export type QuantizeScale = BaseScale<'quantize', QuantizeOptions>;
 
 export type SequentialScale = BaseScale<'sequential', SequentialOptions>;
+
+export type ConstantScale = BaseScale<'constant', ConstantOptions>;
 
 export type CustomScale = BaseScale<ScaleComponent, { [key: string]: any }>;

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -76,6 +76,7 @@ import {
   Quantize,
   Sqrt,
   Sequential,
+  Constant as ConstantScale,
 } from '../scale';
 import {
   Rect as RectShape,
@@ -410,6 +411,7 @@ export function createLibrary(): G2Library {
     'scale.quantile': Quantile,
     'scale.quantize': Quantize,
     'scale.sequential': Sequential,
+    'scale.constant': ConstantScale,
     'shape.interval.rect': RectShape,
     'shape.interval.hollow': HollowRect,
     'shape.interval.funnel': Funnel,


### PR DESCRIPTION
# Constant

增加 constant 比例尺。

## 解决问题

当某一个通道的值为固定值的时候，比如：

```js
const mark = {
  encode: {
    color: 'steelblue',
  }
}
```

这个通道对应的比例尺可以是 constant，也可以是 identity。区别在于 constant 比例尺的 range 会把这个值存下来，但是 identity 不会，这样就会出现下图中的问题：没有办法给图例加颜色。所以把非位置通道的常量通道设置成 constant 比例尺。

![image](https://user-images.githubusercontent.com/49330279/219829419-22fbf66d-ddfc-4518-ab7a-43a8ab2d4263.png)

这个 PR 为解决 https://github.com/antvis/G2/issues/4603 提到的一个问题提供了基础。@Aarebecca