### PR TITLE
fix(animate): 部分动画覆盖 callback 配置导致外部的 callback 配置失效

### DIFF
--- a/src/animate/animation/sector-path-update.ts
+++ b/src/animate/animation/sector-path-update.ts
@@ -1,5 +1,5 @@
 import { getArcParams } from '@antv/g-canvas';
-import { isNumberEqual, isEqual } from '@antv/util';
+import { isNumberEqual, isEqual, isFunction } from '@antv/util';
 
 import { IShape, PathCommand } from '../../dependents';
 import { GAnimateCfg } from '../../interface';
@@ -153,6 +153,7 @@ export function sectorPathUpdate(shape: IShape, animateCfg: GAnimateCfg, cfg: An
       callback: () => {
         // 将 path 保持原始态，否则会影响 setState() 的动画
         shape.attr('path', path);
+        isFunction(animateCfg.callback) && animateCfg.callback();
       },
     }
   );

--- a/src/animate/animation/wave-in.ts
+++ b/src/animate/animation/wave-in.ts
@@ -1,3 +1,4 @@
+import { isFunction } from '@antv/util';
 import { IGroup, IShape } from '../../dependents';
 import { GAnimateCfg } from '../../interface';
 import { getCoordinateClipCfg } from '../../util/coordinate';
@@ -32,6 +33,7 @@ export function waveIn(element: IShape | IGroup, animateCfg: GAnimateCfg, cfg: A
         element.set('clipShape', null);
       }
       clipShape.remove(true); // 动画结束需要将剪切图形销毁
+      isFunction(animateCfg.callback) && animateCfg.callback();
     },
   });
 }

--- a/src/animate/animation/zoom.ts
+++ b/src/animate/animation/zoom.ts
@@ -1,5 +1,5 @@
 import { ext } from '@antv/matrix-util';
-import { each } from '@antv/util';
+import { each, isFunction } from '@antv/util';
 import { IGroup, IShape } from '../../dependents';
 import { GAnimateCfg } from '../../interface';
 import { AnimateExtraCfg } from '../interface';
@@ -46,6 +46,7 @@ function doShapeZoom(shape: IShape | IGroup, animateCfg: GAnimateCfg, type: 'zoo
           ...animateCfg,
           callback: () => {
             shape.remove(true);
+            isFunction(animateCfg.callback) && animateCfg.callback();
           },
         }
       );

--- a/tests/unit/animate/animate-callback-spec.ts
+++ b/tests/unit/animate/animate-callback-spec.ts
@@ -1,0 +1,169 @@
+import { getCoordinate } from '@antv/coord';
+import { getSectorPath } from '../../../src/util/graphics';
+import { doAnimate } from '../../../src/animate';
+import { createCanvas, createDiv, removeDom } from '../../util/dom';
+import { delay } from '../../util/delay';
+
+const CartesianCoordinate = getCoordinate('rect');
+const PolarCoordinate = getCoordinate('polar');
+
+describe('Animate callback', () => {
+  const rectCoord = new CartesianCoordinate({
+    start: { x: 0, y: 300 },
+    end: { x: 300, y: 0 },
+  });
+  const polarCoord = new PolarCoordinate({
+    start: { x: 0, y: 300 },
+    end: { x: 300, y: 0 },
+  });
+
+  const div = createDiv();
+  const canvas = createCanvas({
+    container: div,
+    width: 400,
+    height: 400,
+  });
+
+  it('waveIn callback', async () => {
+    let res = '';
+    const rect = canvas.addShape({
+      type: 'rect',
+      attrs: {
+        x: 20,
+        y: 20,
+        width: 30,
+        height: 150,
+        fill: '#1890ff',
+        fillOpacity: 0.5,
+      },
+      origin: {
+        data: { x: 10, y: 10 },
+      },
+    });
+    const animateCfg = {
+      animation: 'wave-in',
+      duration: () => 30,
+      delay: () => 0,
+      easing: () => 'easeLinear',
+      callback: () => {
+        res = 'wave-in';
+      }
+    };
+    doAnimate(rect, animateCfg, {
+      coordinate: rectCoord,
+      toAttrs: rect.attr(),
+    });
+
+    await delay(800);
+    expect(res).toBe('wave-in');
+  });
+
+  it('sector-path-update callback', async () => {
+    let res = '';
+    const path1 = getSectorPath(200, 140, 104.99999475, 1.3180245040922702, 2.834655440308032, 0);
+    const path2 = getSectorPath(200, 140, 104.99999475, 1, 2, 0);
+    const sector = canvas.addShape({
+      type: 'path',
+      attrs: {
+        path: path1,
+        fill: 'red',
+      },
+    });
+    const animateCfg = {
+      animation: 'sector-path-update',
+      duration: () => 30,
+      delay: () => 0,
+      easing: () => 'easeLinear',
+      callback: () => {
+        res = 'sector-path-update';
+      }
+    };
+    doAnimate(sector, animateCfg, {
+      coordinate: polarCoord,
+      toAttrs: {
+        ...sector.attr(),
+        path: path2,
+      },
+    });
+
+    await delay(800);
+    expect(res).toBe('sector-path-update');
+  });
+
+  it('zoom-in callback', async () => {
+    let res = '';
+    const rect = canvas.addShape({
+      type: 'rect',
+      attrs: {
+        x: 20,
+        y: 20,
+        width: 30,
+        height: 150,
+        fill: '#1890ff',
+        fillOpacity: 0.5,
+      },
+      origin: {
+        data: { x: 10, y: 10 },
+      },
+    });
+    const animateCfg = {
+      animation: 'zoom-in',
+      duration: () => 30,
+      delay: () => 0,
+      easing: () => 'easeLinear',
+      callback: () => {
+        res = 'zoom-in';
+      }
+    };
+    doAnimate(rect, animateCfg, {
+      coordinate: rectCoord,
+      toAttrs: rect.attr(),
+    });
+
+    await delay(800);
+    expect(res).toBe('zoom-in');
+  });
+
+  it('zoom-out callback', async () => {
+    let res = '';
+    const rect = canvas.addShape({
+      type: 'rect',
+      attrs: {
+        x: 20,
+        y: 20,
+        width: 30,
+        height: 150,
+        fill: '#1890ff',
+        fillOpacity: 0.5,
+      },
+      origin: {
+        data: { x: 10, y: 10 },
+      },
+    });
+    const animateCfg = {
+      animation: 'zoom-out',
+      duration: () => 30,
+      delay: () => 0,
+      easing: () => 'easeLinear',
+      callback: () => {
+        res = 'zoom-out';
+      }
+    };
+    doAnimate(rect, animateCfg, {
+      coordinate: rectCoord,
+      toAttrs: rect.attr(),
+    });
+
+    await delay(800);
+    expect(res).toBe('zoom-out');
+  });
+
+  afterEach(() => {
+    canvas.clear();
+  });
+
+  afterAll(() => {
+    canvas.destroy();
+    removeDom(div);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

1. It's RECOMMENDED to submit PR for typo or tiny bug fix.
2. If this's a FEATURE request, please provide: details, pseudo codes if necessary.
3. If this's a BUG, please provide: course repetition, error log and configuration. Fill in as much of the template below as you're able.
4. It will be nice to use to provide a CodePen Link which can reproduce the issue, we provide a CodePen template [g2-github-issue](https://codepen.io/leungwensen/pen/WXJgox).

感谢您向我们反馈问题。

1. 提交问题前，请先阅读 README 中的贡献帮助文档。
2. 我们推荐如果是小问题（错别字修改，小的 bug fix）直接提交 PR。
3. 如果是一个新需求，请提供：详细需求描述，最好是有伪代码实现。
4. 如果是一个 BUG，请提供：复现步骤，错误日志以及相关配置，并尽量填写下面的模板中的条目。
5. 如果可以，请提供尽可能精简的 CodePen 链接，可使用 CodePen 模板 https://codepen.io/leungwensen/pen/WXJgox，方便我们排查问题。
6. 扩展阅读：[如何向开源项目提交无法解答的问题](https://zhuanlan.zhihu.com/p/25795393)
-->

* **G2 Version**: v4
fixes #4627

内置动画通过 callback 实现时确保外部 callback 配置生效

<!-- Enter your issue details below this comment. -->