### PR TITLE
refactor(tooltip): enhance tooltip

### DIFF
--- a/__tests__/integration/snapshots/tooltip/alphabet-interval-full/step0.html
+++ b/__tests__/integration/snapshots/tooltip/alphabet-interval-full/step0.html
@@ -1,0 +1,75 @@
+<div
+  xmlns="http://www.w3.org/1999/xhtml"
+  class="tooltip"
+  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular; left: 10px; top: 10px;"
+>
+  <div
+    class="tooltip-title"
+    style="color: rgba(0, 0, 0, 0.45); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+  >
+    steelblue
+  </div>
+  <ul
+    class="tooltip-list"
+    style="margin: 0px; list-style-type: none; padding: 0px;"
+  >
+    <li
+      class="tooltip-list-item"
+      data-index="0"
+      style="list-style-type: none; margin-top: 12px; display: flex; line-height: 1em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="tooltip-list-item-marker"
+          style="background: steelblue; width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="tooltip-list-item-name-label"
+          title="letter"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          letter
+        </span>
+      </span>
+      <span
+        class="tooltip-list-item-value"
+        title="A"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        A
+      </span>
+    </li>
+    <li
+      class="tooltip-list-item"
+      data-index="1"
+      style="list-style-type: none; margin-top: 12px; display: flex; line-height: 1em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="tooltip-list-item-marker"
+          style="background: steelblue; width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="tooltip-list-item-name-label"
+          title="frequency"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          frequency
+        </span>
+      </span>
+      <span
+        class="tooltip-list-item-value"
+        title="0.08167"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        0.08167
+      </span>
+    </li>
+  </ul>
+</div>;

--- a/__tests__/integration/snapshots/tooltip/alphabet-interval-multi-field/step0.html
+++ b/__tests__/integration/snapshots/tooltip/alphabet-interval-multi-field/step0.html
@@ -1,0 +1,75 @@
+<div
+  xmlns="http://www.w3.org/1999/xhtml"
+  class="tooltip"
+  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular; left: 10px; top: 10px;"
+>
+  <div
+    class="tooltip-title"
+    style="color: rgba(0, 0, 0, 0.45); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+  >
+    A
+  </div>
+  <ul
+    class="tooltip-list"
+    style="margin: 0px; list-style-type: none; padding: 0px;"
+  >
+    <li
+      class="tooltip-list-item"
+      data-index="0"
+      style="list-style-type: none; margin-top: 12px; display: flex; line-height: 1em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="tooltip-list-item-marker"
+          style="background: steelblue; width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="tooltip-list-item-name-label"
+          title="letter"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          letter
+        </span>
+      </span>
+      <span
+        class="tooltip-list-item-value"
+        title="A"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        A
+      </span>
+    </li>
+    <li
+      class="tooltip-list-item"
+      data-index="1"
+      style="list-style-type: none; margin-top: 12px; display: flex; line-height: 1em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="tooltip-list-item-marker"
+          style="background: steelblue; width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="tooltip-list-item-name-label"
+          title="frequency"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          frequency
+        </span>
+      </span>
+      <span
+        class="tooltip-list-item-value"
+        title="0.08167"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        0.08167
+      </span>
+    </li>
+  </ul>
+</div>;

--- a/__tests__/integration/snapshots/tooltip/morley-box-channel/step0.html
+++ b/__tests__/integration/snapshots/tooltip/morley-box-channel/step0.html
@@ -1,0 +1,162 @@
+<div
+  xmlns="http://www.w3.org/1999/xhtml"
+  class="tooltip"
+  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular; left: 10px; top: 10px;"
+>
+  <div
+    class="tooltip-title"
+    style="color: rgba(0, 0, 0, 0.45); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+  >
+    1
+  </div>
+  <ul
+    class="tooltip-list"
+    style="margin: 0px; list-style-type: none; padding: 0px;"
+  >
+    <li
+      class="tooltip-list-item"
+      data-index="0"
+      style="list-style-type: none; margin-top: 12px; display: flex; line-height: 1em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="tooltip-list-item-marker"
+          style="background: rgb(170, 170, 170); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="tooltip-list-item-name-label"
+          title="min"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          min
+        </span>
+      </span>
+      <span
+        class="tooltip-list-item-value"
+        title="740"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        740
+      </span>
+    </li>
+    <li
+      class="tooltip-list-item"
+      data-index="1"
+      style="list-style-type: none; margin-top: 12px; display: flex; line-height: 1em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="tooltip-list-item-marker"
+          style="background: rgb(170, 170, 170); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="tooltip-list-item-name-label"
+          title="q1"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          q1
+        </span>
+      </span>
+      <span
+        class="tooltip-list-item-value"
+        title="850"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        850
+      </span>
+    </li>
+    <li
+      class="tooltip-list-item"
+      data-index="2"
+      style="list-style-type: none; margin-top: 12px; display: flex; line-height: 1em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="tooltip-list-item-marker"
+          style="background: rgb(170, 170, 170); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="tooltip-list-item-name-label"
+          title="q2"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          q2
+        </span>
+      </span>
+      <span
+        class="tooltip-list-item-value"
+        title="940"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        940
+      </span>
+    </li>
+    <li
+      class="tooltip-list-item"
+      data-index="3"
+      style="list-style-type: none; margin-top: 12px; display: flex; line-height: 1em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="tooltip-list-item-marker"
+          style="background: rgb(170, 170, 170); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="tooltip-list-item-name-label"
+          title="q3"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          q3
+        </span>
+      </span>
+      <span
+        class="tooltip-list-item-value"
+        title="980"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        980
+      </span>
+    </li>
+    <li
+      class="tooltip-list-item"
+      data-index="4"
+      style="list-style-type: none; margin-top: 12px; display: flex; line-height: 1em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="tooltip-list-item-marker"
+          style="background: red; width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="tooltip-list-item-name-label"
+          title="max"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          max
+        </span>
+      </span>
+      <span
+        class="tooltip-list-item-value"
+        title="1070"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        1070
+      </span>
+    </li>
+  </ul>
+</div>;

--- a/__tests__/plots/tooltip/aapl-line.ts
+++ b/__tests__/plots/tooltip/aapl-line.ts
@@ -14,6 +14,8 @@ export function aaplLine(): G2Spec {
         encode: {
           x: 'date',
           y: 'close',
+        },
+        tooltip: {
           title: (d) => new Date(d.date).toUTCString(),
         },
       },

--- a/__tests__/plots/tooltip/alphabet-interval-full.ts
+++ b/__tests__/plots/tooltip/alphabet-interval-full.ts
@@ -1,0 +1,27 @@
+import { G2Spec } from '../../../src';
+import { tooltipSteps } from './utils';
+
+export function alphabetIntervalFull(): G2Spec {
+  return {
+    type: 'interval',
+    padding: 0,
+    data: {
+      type: 'fetch',
+      value: 'data/alphabet.csv',
+    },
+    axis: false,
+    legend: false,
+    encode: {
+      x: 'letter',
+      y: 'frequency',
+      color: 'steelblue',
+    },
+    tooltip: {
+      title: { channel: 'color' },
+      items: ['letter', 'frequency'],
+    },
+    interaction: { tooltip: true },
+  };
+}
+
+alphabetIntervalFull.steps = tooltipSteps(0);

--- a/__tests__/plots/tooltip/alphabet-interval-multi-field.ts
+++ b/__tests__/plots/tooltip/alphabet-interval-multi-field.ts
@@ -1,7 +1,7 @@
 import { G2Spec } from '../../../src';
 import { tooltipSteps } from './utils';
 
-export function alphabetIntervalMulti(): G2Spec {
+export function alphabetIntervalMultiField(): G2Spec {
   return {
     type: 'view',
     children: [
@@ -19,7 +19,7 @@ export function alphabetIntervalMulti(): G2Spec {
           y: 'frequency',
           color: 'steelblue',
         },
-        tooltip: ['letter', 'frequency'],
+        tooltip: [{ field: 'letter' }, { field: 'frequency' }],
       },
     ],
     interaction: {
@@ -28,4 +28,4 @@ export function alphabetIntervalMulti(): G2Spec {
   };
 }
 
-alphabetIntervalMulti.steps = tooltipSteps(0);
+alphabetIntervalMultiField.steps = tooltipSteps(0);

--- a/__tests__/plots/tooltip/alphabet-interval-object.ts
+++ b/__tests__/plots/tooltip/alphabet-interval-object.ts
@@ -18,17 +18,19 @@ export function alphabetIntervalObject(): G2Spec {
           x: 'letter',
           y: 'frequency',
           color: 'steelblue',
-          tooltip: (d) => ({
+        },
+        tooltip: [
+          (d) => ({
             color: 'red',
             value: d.frequency,
             name: 'F',
           }),
-          tooltip1: (d) => ({
+          (d) => ({
             color: 'yellow',
             value: d.letter,
             name: 'L',
           }),
-        },
+        ],
       },
     ],
     interaction: {

--- a/__tests__/plots/tooltip/alphabet-interval-title.ts
+++ b/__tests__/plots/tooltip/alphabet-interval-title.ts
@@ -18,6 +18,8 @@ export function alphabetIntervalTitle(): G2Spec {
           x: 'letter',
           y: 'frequency',
           color: 'steelblue',
+        },
+        tooltip: {
           title: 'frequency',
         },
       },

--- a/__tests__/plots/tooltip/index.ts
+++ b/__tests__/plots/tooltip/index.ts
@@ -18,3 +18,6 @@ export { alphabetInterval1dMounted } from './alphabet-interval-1d-mounted';
 export { indicesLineItems } from './indices-line-items';
 export { flareTreemapPoptip } from './flare-treemap-poptip';
 export { flareTreemapPoptipCustom } from './flare-treemap-poptip-custom';
+export { morleyBoxChannel } from './morley-box-channel';
+export { alphabetIntervalMultiField } from './alphabet-interval-multi-field';
+export { alphabetIntervalFull } from './alphabet-interval-full';

--- a/__tests__/plots/tooltip/indices-line-chart-facet.ts
+++ b/__tests__/plots/tooltip/indices-line-chart-facet.ts
@@ -26,6 +26,8 @@ export async function indicesLineChartFacet(): Promise<G2Spec> {
           y: 'Close',
           color: 'Symbol',
           key: 'Symbol',
+        },
+        tooltip: {
           title: (d) => new Date(d.Date).toUTCString(),
         },
       },

--- a/__tests__/plots/tooltip/indices-line-items.ts
+++ b/__tests__/plots/tooltip/indices-line-items.ts
@@ -23,14 +23,17 @@ export async function indicesLineItems(): Promise<G2Spec> {
           y: 'Close',
           color: 'Symbol',
           key: 'Symbol',
+        },
+        tooltip: {
           title: (d) => new Date(d.Date).toUTCString(),
+          items: [
+            (d, i, D, V) => ({ name: 'Close', value: V.y.value[i].toFixed(1) }),
+          ],
         },
       },
     ],
     interaction: {
-      tooltip: {
-        item: ({ value }) => ({ value: value.toFixed(1) }),
-      },
+      tooltip: true,
     },
   };
 }

--- a/__tests__/plots/tooltip/indices-line-point-reverse.ts
+++ b/__tests__/plots/tooltip/indices-line-point-reverse.ts
@@ -29,9 +29,8 @@ export async function indicesLinePointReverse(): Promise<G2Spec> {
           y: 'Close',
           color: 'Symbol',
           key: 'Symbol',
-          title: null,
-          tooltip: null,
         },
+        tooltip: null,
       },
       {
         type: 'point',
@@ -40,8 +39,8 @@ export async function indicesLinePointReverse(): Promise<G2Spec> {
           y: 'Close',
           color: 'Symbol',
           key: 'Symbol',
-          tooltip: (d) => new Date(d.Date).toUTCString(),
         },
+        tooltip: (d) => new Date(d.Date).toUTCString(),
       },
     ],
     interaction: {

--- a/__tests__/plots/tooltip/indices-line-reverse.ts
+++ b/__tests__/plots/tooltip/indices-line-reverse.ts
@@ -22,8 +22,8 @@ export async function indicesLineReverse(): Promise<G2Spec> {
           y: 'Close',
           color: 'Symbol',
           key: 'Symbol',
-          title: (d) => new Date(d.Date).toUTCString(),
         },
+        tooltip: { title: (d) => new Date(d.Date).toUTCString() },
       },
     ],
     interaction: {

--- a/__tests__/plots/tooltip/morley-box-channel.ts
+++ b/__tests__/plots/tooltip/morley-box-channel.ts
@@ -1,0 +1,38 @@
+import { G2Spec } from '../../../src';
+import { tooltipSteps } from './utils';
+
+export function morleyBoxChannel(): G2Spec {
+  return {
+    type: 'view',
+    children: [
+      {
+        type: 'boxplot',
+        inset: 6,
+        data: {
+          type: 'fetch',
+          value: 'data/morley.csv',
+        },
+        encode: {
+          x: 'Expt',
+          y: 'Speed',
+        },
+        style: {
+          boxFill: '#aaa',
+          pointStroke: '#000',
+        },
+        tooltip: [
+          { name: 'min', channel: 'y' },
+          { name: 'q1', channel: 'y1' },
+          { name: 'q2', channel: 'y2' },
+          { name: 'q3', channel: 'y3' },
+          { name: 'max', color: 'red', channel: 'y4' },
+        ],
+      },
+    ],
+    interaction: {
+      tooltip: true,
+    },
+  };
+}
+
+morleyBoxChannel.steps = tooltipSteps(0);

--- a/__tests__/plots/tooltip/morley-box.ts
+++ b/__tests__/plots/tooltip/morley-box.ts
@@ -2,13 +2,7 @@ import { G2Spec } from '../../../src';
 import { tooltipSteps } from './utils';
 
 export function morleyBox(): G2Spec {
-  const names = {
-    tooltip: 'min',
-    tooltip1: 'q1',
-    tooltip2: 'q2',
-    tooltip3: 'q3',
-    tooltip4: 'max',
-  };
+  const format = (d) => `${d / 1000}k`;
   return {
     type: 'view',
     children: [
@@ -27,16 +21,33 @@ export function morleyBox(): G2Spec {
           boxFill: '#aaa',
           pointStroke: '#000',
         },
+        tooltip: [
+          (d, i, D, V) => ({
+            name: 'min',
+            value: format(V.y.value[i]),
+          }),
+          (d, i, D, V) => ({
+            name: 'q1',
+            value: format(V.y1.value[i]),
+          }),
+          (d, i, D, V) => ({
+            name: 'q2',
+            value: format(V.y2.value[i]),
+          }),
+          (d, i, D, V) => ({
+            name: 'q3',
+            value: format(V.y3.value[i]),
+          }),
+          (d, i, D, V) => ({
+            name: 'max',
+            color: 'red',
+            value: format(V.y4.value[i]),
+          }),
+        ],
       },
     ],
     interaction: {
-      tooltip: {
-        item: ({ channel, value }) => ({
-          name: names[channel],
-          color: channel === 'tooltip4' ? 'red' : undefined,
-          value: `${value / 1000}k`,
-        }),
-      },
+      tooltip: true,
     },
   };
 }

--- a/__tests__/plots/tooltip/stateages-interval-shared.ts
+++ b/__tests__/plots/tooltip/stateages-interval-shared.ts
@@ -16,7 +16,6 @@ export function stateAgesIntervalShared(): G2Spec {
           type: 'fetch',
           value: 'data/stateages.csv',
         },
-        axis: false,
         legend: false,
         encode: {
           x: 'state',

--- a/__tests__/plots/tooltip/temperatures-line-point-discrete.ts
+++ b/__tests__/plots/tooltip/temperatures-line-point-discrete.ts
@@ -21,12 +21,9 @@ export function temperaturesLinePointDiscrete(): G2Spec {
           x: 'month',
           y: 'temperature',
           color: 'city',
-          tooltip: null,
-          title: null,
         },
-        style: {
-          fill: 'white',
-        },
+        tooltip: null,
+        style: { fill: 'white' },
       },
     ],
     interaction: {

--- a/__tests__/unit/api/mark.spec.ts
+++ b/__tests__/unit/api/mark.spec.ts
@@ -54,6 +54,8 @@ function setOptions(node) {
     .attr('insetRight', 40)
     .axis('x', { tickCount: 10 })
     .legend('y', { title: 'hello' })
+    .tooltip('a')
+    .tooltip('b')
     .slider('x', {})
     .scrollbar('x', {})
     .label({ text: 'hello' })
@@ -107,6 +109,7 @@ function getOptions() {
       active: { fill: 'red' },
       inactive: { fill: 'blue' },
     },
+    tooltip: { items: ['a', 'b'] },
   };
 }
 

--- a/__tests__/unit/api/props.spec.ts
+++ b/__tests__/unit/api/props.spec.ts
@@ -96,4 +96,27 @@ describe('defineProps', () => {
     expect(n1).toBeInstanceOf(Node);
     expect(n.type).toBeNull();
   });
+
+  it('definedProps([...]) should define mix prop', () => {
+    const N = defineProps([{ type: 'mix', name: 'mix' }])(Node);
+    const n = new N();
+    n.mix('a');
+    n.mix('b');
+    expect(n.mix()).toEqual({ items: ['a', 'b'] });
+    n.mix(['c', 'd']);
+    expect(n.mix()).toEqual({ items: ['c', 'd'] });
+    n.mix({ items: ['f', 'g'] });
+    expect(n.mix()).toEqual({
+      items: ['f', 'g'],
+    });
+    n.mix({ title: 'hello' });
+    expect(n.mix()).toEqual({
+      title: 'hello',
+    });
+    n.mix({ name: 'min', channel: 'y' });
+    expect(n.mix()).toEqual({
+      title: 'hello',
+      items: [{ name: 'min', channel: 'y' }],
+    });
+  });
 });

--- a/site/docs/api/mark/polygon.zh.md
+++ b/site/docs/api/mark/polygon.zh.md
@@ -58,7 +58,6 @@ chart
   .scale('x', { domain: [0, 800] })
   .scale('y', { domain: [0, 600] })
   .axis(false)
-  .scale('tooltip', { field: 'value' })
   .style('stroke', '#fff')
   .style('fillOpacity', 0.65);
 

--- a/site/examples/general/.polygon/demo/treemap.ts
+++ b/site/examples/general/.polygon/demo/treemap.ts
@@ -41,8 +41,10 @@ chart
   .encode('y', 'y')
   .encode('size', 'r')
   .encode('color', (d) => d.parent.data.name)
-  .encode('tooltip', (d) => d.parent.data.name)
-  .encode('title', '')
+  .tooltip({
+    title: '',
+    items: [(d) => d.parent.data.name],
+  })
   .scale('x', { domain: [0, 1] })
   .scale('y', { domain: [0, 1], range: [0, 1] })
   .scale('size', { type: 'identity' })

--- a/site/examples/general/.polygon/demo/voronoi.ts
+++ b/site/examples/general/.polygon/demo/voronoi.ts
@@ -45,7 +45,6 @@ chart
   .encode('color', (d) => d.data.value)
   .scale('x', { domain: [0, 800] })
   .scale('y', { domain: [0, 600] })
-  .scale('tooltip', { field: 'value' })
   .axis(false)
   .style('stroke', '#fff')
   .style('fillOpacity', 0.65);

--- a/site/examples/interaction/interaction/demo/tooltip-custom.ts
+++ b/site/examples/interaction/interaction/demo/tooltip-custom.ts
@@ -6,14 +6,6 @@ const chart = new Chart({
   inset: 6,
 });
 
-const names = {
-  tooltip: 'min',
-  tooltip1: 'q1',
-  tooltip2: 'q2',
-  tooltip3: 'q3',
-  tooltip4: 'max',
-};
-
 chart
   .boxplot()
   .data({
@@ -21,14 +13,13 @@ chart
     value: 'https://assets.antv.antgroup.com/g2/morley.json',
   })
   .encode('x', 'Expt')
-  .encode('y', 'Speed');
+  .encode('y', 'Speed')
+  .tooltip({ name: 'min', channel: 'y' })
+  .tooltip({ name: 'q1', channel: 'y1' })
+  .tooltip({ name: 'q2', channel: 'y2' })
+  .tooltip({ name: 'q3', channel: 'y3' })
+  .tooltip({ name: 'max', color: 'red', channel: 'y4' });
 
-chart.interaction('tooltip', {
-  item: ({ channel, value }) => ({
-    name: names[channel],
-    color: channel === 'tooltip4' ? 'red' : undefined,
-    value: `${value / 1000}k`,
-  }),
-});
+chart.interaction('tooltip', true);
 
 chart.render();

--- a/site/examples/interaction/interaction/demo/tooltip-series.ts
+++ b/site/examples/interaction/interaction/demo/tooltip-series.ts
@@ -15,8 +15,16 @@ chart
   .encode('x', (d) => new Date(d.Date))
   .encode('y', 'Close')
   .encode('color', 'Symbol')
-  .encode('title', (d) => d.Date.toLocaleString())
   .axis('y', { title: '↑ Change in price (%)' })
+  .tooltip({
+    title: (d) => new Date(d.Date).toUTCString(),
+    items: [
+      (d, i, data, column) => ({
+        name: 'Close',
+        value: column.y.value[i].toFixed(1),
+      }),
+    ],
+  })
   .label({
     text: 'Symbol',
     selector: 'last',
@@ -25,8 +33,6 @@ chart
     },
   });
 
-chart.interaction('tooltip', {
-  item: ({ value }) => ({ value: value.toFixed(1) }),
-});
+chart.interaction('tooltip', true);
 
 chart.render();

--- a/src/api/composition/base.ts
+++ b/src/api/composition/base.ts
@@ -1,10 +1,8 @@
 import { DisplayObject } from '@antv/g';
 import { Coordinate } from '@antv/coord';
-import { defineProps } from '../props';
 import { Node } from '../node';
 import { G2Theme, G2ViewDescriptor } from '../../runtime';
 
-@defineProps([{ name: 'on', type: 'event' }])
 export class CompositionNode<
   Value extends Record<string, any> = Record<string, any>,
   ParentValue extends Record<string, any> = Record<string, any>,

--- a/src/api/mark/mark.ts
+++ b/src/api/mark/mark.ts
@@ -149,6 +149,7 @@ export const props: NodePropertyDescriptor[] = [
   { name: 'slider', type: 'object' },
   { name: 'scrollbar', type: 'object' },
   { name: 'state', type: 'object' },
+  { name: 'tooltip', type: 'mix' },
 ];
 
 @defineProps(props)

--- a/src/api/mark/types.ts
+++ b/src/api/mark/types.ts
@@ -17,4 +17,5 @@ export type API<Props extends Geometry, Mark> = {
   scrollbar: ObjectAttribute<Props['scrollbar'], Mark>;
   legend: ObjectAttribute<Props['legend'], Mark>;
   layout: ValueAttribute<Props['layout'], Mark>;
+  tooltip: ValueAttribute<Props['tooltip'], Mark>;
 };

--- a/src/mark/utils.ts
+++ b/src/mark/utils.ts
@@ -26,11 +26,7 @@ export function baseChannels(options: ChannelOptions = {}): Channel[] {
 }
 
 export function baseGeometryChannels(options: ChannelOptions = {}): Channel[] {
-  return [
-    ...baseChannels(options),
-    { name: 'title', scale: 'identity' },
-    { name: 'tooltip', scale: 'identity', independent: true },
-  ];
+  return [...baseChannels(options), { name: 'title', scale: 'identity' }];
 }
 
 export function tooltip2d() {

--- a/src/runtime/mark.ts
+++ b/src/runtime/mark.ts
@@ -26,6 +26,8 @@ import {
   maybeVisualChannel,
   addGuideToScale,
   maybeNonAnimate,
+  normalizeTooltip,
+  extractTooltip,
 } from './transform';
 
 export async function initializeMark(
@@ -41,7 +43,7 @@ export async function initializeMark(
     context,
   );
 
-  const { encode, scale, data } = transformedMark;
+  const { encode, scale, data, tooltip } = transformedMark;
 
   // Skip mark with non-tabular data. Do not skip empty
   // data, they are useful for facet to display axes.
@@ -109,7 +111,7 @@ export async function initializeMark(
       });
     });
 
-  return [transformedMark, { ...partialProps, index: I, channels }];
+  return [transformedMark, { ...partialProps, index: I, channels, tooltip }];
 }
 
 export function createColumnOf(library: G2Library): ColumnOf {
@@ -152,9 +154,11 @@ async function applyMarkTransform(
     maybeArrayField,
     maybeNonAnimate,
     addGuideToScale,
+    normalizeTooltip,
     ...preInference.map(useTransform),
     ...transform.map(useTransform),
     ...postInference.map(useTransform),
+    extractTooltip,
   ];
   let index = [];
   let transformedMark = mark;

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -520,7 +520,7 @@ function initializeState(
       modifier,
       key: markKey,
     } = mark;
-    const { index, channels } = state;
+    const { index, channels, tooltip } = state;
     const scale = Object.fromEntries(
       channels.map(({ name, scale }) => [name, scale]),
     );
@@ -541,6 +541,8 @@ function initializeState(
     );
     const count = dataDomain || I.length;
     const T = modifier ? modifier(P, count, layout) : [];
+    const titleOf = (i) => tooltip.title?.[i]?.value;
+    const itemsOf = (i) => tooltip.items.map((V) => V[i]);
     const visualData: Record<string, any>[] = I.map((d, i) => {
       const datum = {
         points: P[i],
@@ -548,12 +550,20 @@ function initializeState(
         index: d,
         markKey,
         viewKey: key,
+        ...(tooltip && {
+          title: titleOf(d),
+          items: itemsOf(d),
+        }),
       };
       for (const [k, V] of Object.entries(value)) {
         datum[k] = V[d];
         if (S) datum[`series${upperFirst(k)}`] = S[i].map((i) => V[i]);
       }
       if (S) datum['seriesIndex'] = S[i];
+      if (S && tooltip) {
+        datum['seriesItems'] = S[i].map((si) => itemsOf(si));
+        datum['seriesTitle'] = S[i].map((si) => titleOf(si));
+      }
       return datum;
     });
     state.data = visualData;

--- a/src/runtime/types/common.ts
+++ b/src/runtime/types/common.ts
@@ -68,6 +68,7 @@ export type G2MarkState = {
   index?: number[];
   data?: Record<string, any>[];
   channels?: ChannelGroups[];
+  tooltip?: any; // @todo
 } & Omit<MarkProps, 'channels'>;
 
 export type MaybeArray<T> = T | T[];

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -112,6 +112,7 @@ export type G2Mark = {
   legend?: boolean | Record<string, any>;
   slider?: Record<string, any>;
   scrollbar?: Record<string, any>;
+  tooltip?: any; // @todo
   filter?: (i: number) => boolean;
   children?: G2MarkChildrenCallback;
   dataDomain?: number;

--- a/src/spec/geometry.ts
+++ b/src/spec/geometry.ts
@@ -1,4 +1,4 @@
-import { MarkComponent } from '../runtime';
+import { MarkComponent, Primitive } from '../runtime';
 import { Encode } from './encode';
 import { Transform } from './transform';
 import { Scale } from './scale';
@@ -93,8 +93,7 @@ export type ChannelTypes =
   | 'groupKey'
   | 'label'
   | 'position'
-  | 'series'
-  | `tooltip${number}`;
+  | 'series';
 
 export type BaseGeometry<
   T extends GeometryTypes,
@@ -149,6 +148,7 @@ export type BaseGeometry<
   frame?: boolean;
   labels?: Record<string, any>[];
   stack?: boolean;
+  tooltip?: Tooltip;
   animate?:
     | boolean
     | {
@@ -325,3 +325,25 @@ export type WordCloudMark = BaseGeometry<
 };
 
 export type CustomComponent = BaseGeometry<MarkComponent>;
+
+export type Tooltip =
+  | TooltipItem
+  | TooltipItem[]
+  | { title?: Encodeable<TooltipTitle>; items?: TooltipItem[] }
+  | null;
+
+export type TooltipTitle = string | { field?: string; channel?: string };
+
+export type TooltipItem =
+  | string
+  | { name?: string; color?: string; channel?: string; field?: string }
+  | Encodeable<Primitive>
+  | Encodeable<{
+      name?: string;
+      color?: string;
+      value?: Primitive;
+    }>;
+
+export type Encodeable<T> =
+  | T
+  | ((d: any, index: number, data: any[], column: any) => T);

--- a/src/transform/maybeTitle.ts
+++ b/src/transform/maybeTitle.ts
@@ -1,6 +1,6 @@
 import { deepMix } from '@antv/util';
 import { TransformComponent as TC } from '../runtime';
-import { column, columnOf } from './utils/helper';
+import { columnOf } from './utils/helper';
 
 export type MaybeTitleOptions = {
   channel?: string;
@@ -13,10 +13,18 @@ export const MaybeTitle: TC<MaybeTitleOptions> = (options = {}) => {
   const { channel = 'x' } = options;
   return (I, mark) => {
     const { encode } = mark;
-    const { title } = encode;
+    const { tooltip } = mark;
+    if (tooltip === null) return [I, mark];
+    const { title } = tooltip;
     if (title !== undefined) return [I, mark];
     const [T, ft] = columnOf(encode, channel);
-    return [I, deepMix({}, mark, { encode: { title: column(T, ft) } })];
+    if (!T) return [I, mark];
+    return [
+      I,
+      deepMix({}, mark, {
+        tooltip: { title: T.map((d) => ({ value: d, name: ft })) },
+      }),
+    ];
   };
 };
 

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -112,5 +112,10 @@ export function maybePercentage(x: number | string, size: number) {
 }
 
 export function isStrictObject(d: any): boolean {
-  return typeof d === 'object' && !(d instanceof Date) && d !== null;
+  return (
+    typeof d === 'object' &&
+    !(d instanceof Date) &&
+    d !== null &&
+    !Array.isArray(d)
+  );
 }


### PR DESCRIPTION
# Tooltip

修改了配置 Tooltip Items 和 Title 的方式，参考这个 https://github.com/antvis/G2/pull/4491#issuecomment-1357171206 中的讨论。


## 开始使用

```js
const before = {
  encode: {
    tooltip: 'a',
    tooltip1: 'b',
    title: 'c',
  },
};
```
```js
// Spec
const after = {
  tooltip: {
    title: 'c',
    items: ['a', 'b']
  }
};

// API
mark.tooltip({
  title: 'c',
  items: ['a', 'b'],
});
```

## 结构

tooltip 完整的结构如下：

```js
// Spec
const mark = {
  tooltip: {
    title: 'c',
    items: ['a', 'b']
  }
};

// API
mark.tooltip({
  title: 'c',
  items: ['a', 'b'],
});
```

有以下两种语法糖：

```js
// Spec
const mark = {
  tooltip: 'a',
};

// API
mark.tooltip('a');

// 等效于
const mark = {
  tooltip: {
    items: ['a'],
  },
};
```
```js
// Spec
const mark = {
  tooltip: ['a', 'b'],
};

// API
mark.tooltip('a').tooltip('b');

// 等效于
const mark = {
  tooltip: {
    items: ['a', 'b'],
  },
};
```

## title 和 item

title 和每一个 item 除了上述的字符串形式之外，还支持如下形式:

- 对象形式

```js
// 指定 item 为字段 a
const mark = {
  tooltip: [{ color: 'red', field: 'a' }],
};

// 指定 item 为通道 y 的值
const mark = {
  tooltip: [{ color: 'red', channel: 'y', name: 'Y' }],
};
```

- 回调形式

```js
// 指定为字段 a
const mark = {
  tooltip: [(d) => ({ value: d.a, color: 'red' })],
};

// 指定为通道 y
const mark = {
  tooltip: [(d, i, data, value) => ({ value: value.y.value[i], color: 'red' })],
};
```
