### PR TITLE
feat(mark): group animation options

### DIFF
--- a/__tests__/plots/animation/alphabet-interval-non-animate-enter.ts
+++ b/__tests__/plots/animation/alphabet-interval-non-animate-enter.ts
@@ -17,7 +17,7 @@ export function alphabetIntervalNonAnimateEnter(): G2Spec {
       color: 'steelblue',
     },
     animate: {
-      enterType: null,
+      enter: false,
     },
   };
 }

--- a/__tests__/plots/animation/alphabet-interval-scale-in-y.ts
+++ b/__tests__/plots/animation/alphabet-interval-scale-in-y.ts
@@ -17,7 +17,9 @@ export function alphabetIntervalScaleInY(): G2Spec {
       color: 'steelblue',
     },
     animate: {
-      enterDuration: 1000,
+      enter: {
+        duration: 1000,
+      },
     },
   };
 }

--- a/__tests__/plots/animation/deaths-rose-stack-enter.ts
+++ b/__tests__/plots/animation/deaths-rose-stack-enter.ts
@@ -24,7 +24,9 @@ export function deathsRoseStackEnter(): G2Spec {
     },
     legend: { color: { layout: { justifyContent: 'flex-start' } } },
     animate: {
-      enterType: 'waveIn',
+      enter: {
+        type: 'waveIn',
+      },
     },
   };
 }

--- a/__tests__/plots/animation/doughnut-purchases-line-path-in.ts
+++ b/__tests__/plots/animation/doughnut-purchases-line-path-in.ts
@@ -27,8 +27,10 @@ export function doughnutPurchasesLinePathIn(): G2Spec {
           gradientColor: 'start',
         },
         animate: {
-          enterType: 'pathIn',
-          enterDuration: 3000,
+          enter: {
+            type: 'pathIn',
+            duration: 3000,
+          },
         },
       },
       {

--- a/__tests__/plots/animation/fruits-interval-stack-enter-color-x.ts
+++ b/__tests__/plots/animation/fruits-interval-stack-enter-color-x.ts
@@ -14,7 +14,9 @@ export function fruitsIntervalStackEnterColorX(): G2Spec {
       enterDuration: 1000,
     },
     animate: {
-      enterDuration: 600,
+      enter: {
+        duration: 600,
+      },
     },
   };
 }

--- a/__tests__/plots/animation/fruits-interval-stack-enter-color.ts
+++ b/__tests__/plots/animation/fruits-interval-stack-enter-color.ts
@@ -14,7 +14,9 @@ export function fruitsIntervalStackEnterColor(): G2Spec {
       enterDuration: 1000,
     },
     animate: {
-      enterDuration: 900,
+      enter: {
+        duration: 900,
+      },
     },
   };
 }

--- a/__tests__/plots/animation/fruits-interval-stack-enter-defaults.ts
+++ b/__tests__/plots/animation/fruits-interval-stack-enter-defaults.ts
@@ -14,7 +14,9 @@ export function fruitsIntervalStackEnterDefaults(): G2Spec {
       enterDuration: 1000,
     },
     animate: {
-      enterDuration: 1000,
+      enter: {
+        duration: 1000,
+      },
     },
   };
 }

--- a/__tests__/plots/animation/fruits-interval-stack-enter-x-color.ts
+++ b/__tests__/plots/animation/fruits-interval-stack-enter-x-color.ts
@@ -14,7 +14,9 @@ export function fruitsIntervalStackEnterXColor(): G2Spec {
       enterDuration: 1000,
     },
     animate: {
-      enterDuration: 900,
+      enter: {
+        duration: 900,
+      },
     },
   };
 }

--- a/__tests__/plots/animation/os-area-stack-enter.ts
+++ b/__tests__/plots/animation/os-area-stack-enter.ts
@@ -23,7 +23,9 @@ export function osAreaStackEnter(): G2Spec {
       shape: 'smooth',
     },
     animate: {
-      enterType: 'growInX',
+      enter: {
+        type: 'growInX',
+      },
     },
   };
 }

--- a/__tests__/plots/animation/polio-point-stack-enter.ts
+++ b/__tests__/plots/animation/polio-point-stack-enter.ts
@@ -55,7 +55,9 @@ export function polioPointStackEnter(): G2Spec {
           fill: '#666',
         },
         animate: {
-          enterDelay: 5000,
+          enter: {
+            delay: 5000,
+          },
         },
       },
       {
@@ -70,7 +72,9 @@ export function polioPointStackEnter(): G2Spec {
           dy: 30,
         },
         animate: {
-          enterDelay: 5400,
+          enter: {
+            delay: 5400,
+          },
         },
       },
     ],

--- a/__tests__/plots/animation/population-interval-rose-keyframe.ts
+++ b/__tests__/plots/animation/population-interval-rose-keyframe.ts
@@ -18,7 +18,7 @@ export async function populationIntervalRoseKeyframe(): Promise<G2Spec> {
           startAngle: -Math.PI / 2,
         },
         transform: [{ type: 'groupX', y: 'sum' }],
-        animate: { enterType: 'waveIn' },
+        animate: { enter: { type: 'waveIn' } },
         scale: { y: { type: 'sqrt' } },
         encode: { x: 'year', y: 'people' },
         axis: {
@@ -38,7 +38,7 @@ export async function populationIntervalRoseKeyframe(): Promise<G2Spec> {
         },
         coordinate: { type: 'polar', outerRadius: 0.85, startAngle: 0 },
         transform: [{ type: 'groupX', y: 'sum' }],
-        animate: { enterType: 'waveIn' },
+        animate: { enter: { type: 'waveIn' } },
         scale: { y: { type: 'sqrt' } },
         encode: { x: 'year', y: 'people' },
         axis: {

--- a/__tests__/plots/animation/population2015-interval-wave-in-radius.ts
+++ b/__tests__/plots/animation/population2015-interval-wave-in-radius.ts
@@ -30,7 +30,7 @@ export function population2015IntervalWaveInRadius(): G2Spec {
           radius: 10,
         },
         animate: {
-          enterType: 'waveIn',
+          enter: { type: 'waveIn' },
         },
       },
     ],

--- a/__tests__/plots/animation/profit-interval-range.ts
+++ b/__tests__/plots/animation/profit-interval-range.ts
@@ -52,7 +52,7 @@ export async function profitIntervalRange(): Promise<G2Spec> {
             data: [{ y: [0, 2000000] }],
             encode: { y: 'y' },
             animate: {
-              enterType: 'fadeIn',
+              enter: { type: 'fadeIn' },
             },
           },
         ],

--- a/__tests__/plots/animation/sold-interval-pie-keyframe.ts
+++ b/__tests__/plots/animation/sold-interval-pie-keyframe.ts
@@ -23,7 +23,7 @@ export function soldIntervalPieKeyframe(): G2Spec {
           },
         ],
         animate: {
-          enterType: 'waveIn',
+          enter: { type: 'waveIn' },
         },
       },
       {
@@ -42,7 +42,7 @@ export function soldIntervalPieKeyframe(): G2Spec {
           },
         ],
         animate: {
-          enterType: 'waveIn',
+          enter: { type: 'waveIn' },
         },
       },
     ],

--- a/__tests__/plots/animation/stocks-keyframe.ts
+++ b/__tests__/plots/animation/stocks-keyframe.ts
@@ -21,7 +21,7 @@ const facetLine = (data) => ({
       frame: false,
       scale: { y: { zero: true, tickCount: 3 } },
       animate: {
-        enterType: 'pathIn',
+        enter: { type: 'pathIn' },
       },
     },
   ],
@@ -59,7 +59,7 @@ const facetArea = (data) => ({
       },
       scale: { y: { facet: false, zero: true, tickCount: 3 } },
       animate: {
-        exitType: 'fadeOut',
+        exit: { type: 'fadeOut' },
       },
     },
   ],

--- a/__tests__/plots/static/population2015-interval-pie.ts
+++ b/__tests__/plots/static/population2015-interval-pie.ts
@@ -40,8 +40,10 @@ export function population2015IntervalPie(): G2Spec {
       },
     ],
     animate: {
-      enterType: 'waveIn',
-      enterDuration: 1000,
+      enter: {
+        type: 'waveIn',
+        duration: 1000,
+      },
     },
   };
 }

--- a/__tests__/unit/api/mark.spec.ts
+++ b/__tests__/unit/api/mark.spec.ts
@@ -33,7 +33,7 @@ function setOptions(node) {
     .scale('x', { domain: [0, 1] })
     .transform({ type: 'stackY' })
     .style('stroke', 'black')
-    .animate('enterType', 'scaleInX')
+    .animate('enter', { type: 'scaleInX' })
     .attr('facet', true)
     .attr('key', 'mark')
     .attr('class', 'mark')
@@ -77,7 +77,7 @@ function getOptions() {
     scale: { x: { domain: [0, 1] } },
     transform: [{ type: 'stackY' }],
     style: { stroke: 'black' },
-    animate: { enterType: 'scaleInX' },
+    animate: { enter: { type: 'scaleInX' } },
     axis: { x: { tickCount: 10 } },
     legend: { y: { title: 'hello' } },
     slider: { x: {} },

--- a/site/docs/api/animation/fadeIn.zh.md
+++ b/site/docs/api/animation/fadeIn.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .interval()
   /* ... */
-  .animate('enterType', 'fadeIn');
+  .animate('enter', { type: 'fadeIn' });
 ```

--- a/site/docs/api/animation/fadeOut.zh.md
+++ b/site/docs/api/animation/fadeOut.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .interval()
   /* ... */
-  .animate('exitType', 'fadeOut');
+  .animate('exit', { type: 'fadeOut' });
 ```

--- a/site/docs/api/animation/growInX.zh.md
+++ b/site/docs/api/animation/growInX.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .interval()
   /* ... */
-  .animate('enterType', 'growInX');
+  .animate('enter', { type: 'growInX' });
 ```

--- a/site/docs/api/animation/growInY.zh.md
+++ b/site/docs/api/animation/growInY.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .interval()
   /* ... */
-  .animate('enterType', 'growInY');
+  .animate('enter', { type: 'growInY' });
 ```

--- a/site/docs/api/animation/morphing.zh.md
+++ b/site/docs/api/animation/morphing.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .area()
   /* ... */
-  .animate('enterType', 'morphing');
+  .animate('enter', { type: 'morphing' });
 ```

--- a/site/docs/api/animation/pathIn.zh.md
+++ b/site/docs/api/animation/pathIn.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .line()
   /* ... */
-  .animate('enterType', 'pathIn');
+  .animate('enter', { type: 'pathIn' });
 ```

--- a/site/docs/api/animation/scaleInX.zh.md
+++ b/site/docs/api/animation/scaleInX.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .interval()
   /* ... */
-  .animate('enterType', 'scaleInX');
+  .animate('enter', { type: 'scaleInX' });
 ```

--- a/site/docs/api/animation/scaleInY.zh.md
+++ b/site/docs/api/animation/scaleInY.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .interval()
   /* ... */
-  .animate('enterType', 'scaleInY');
+  .animate('enter', { type: 'scaleInY' });
 ```

--- a/site/docs/api/animation/scaleOutX.zh.md
+++ b/site/docs/api/animation/scaleOutX.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .interval()
   /* ... */
-  .animate('exitType', 'scaleOutX');
+  .animate('exit', { type: 'scaleOutX' });
 ```

--- a/site/docs/api/animation/scaleOutY.zh.md
+++ b/site/docs/api/animation/scaleOutY.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .interval()
   /* ... */
-  .animate('exitType', 'scaleOutY');
+  .animate('exit', { type: 'scaleOutY' });
 ```

--- a/site/docs/api/animation/waveIn.zh.md
+++ b/site/docs/api/animation/waveIn.zh.md
@@ -14,5 +14,5 @@ order: 1
 chart
   .interval()
   /* ... */
-  .animate('enterType', 'waveIn');
+  .animate('enter', { type: 'waveIn' });
 ```

--- a/site/docs/api/animation/zoomIn.zh.md
+++ b/site/docs/api/animation/zoomIn.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .interval()
   /* ... */
-  .animate('enterType', 'zoomIn');
+  .animate('enter', { type: 'zoomIn' });
 ```

--- a/site/docs/api/animation/zoomOut.zh.md
+++ b/site/docs/api/animation/zoomOut.zh.md
@@ -13,5 +13,5 @@ order: 1
 chart
   .interval()
   /* ... */
-  .animate('exitType', 'zoomOut');
+  .animate('exit', { type: 'zoomOut' });
 ```

--- a/site/docs/manual/animation.zh.md
+++ b/site/docs/manual/animation.zh.md
@@ -37,8 +37,10 @@ chart
   .encode('x', 'genre')
   .encode('y', 'sold')
   .encode('color', 'genre')
-  .animate('enterType', 'scaleInY') // 指定入场动画的类型
-  .animate('enterDuration', 1000); // 指定入场动画的执行时间
+  .animate('enter', {
+    type: 'scaleInY', // 指定入场动画的类型
+    duration: 1000, // 指定入场动画的执行时间
+  });
 ```
 
 ## 动画编码

--- a/site/docs/manual/more/use-in-framework.zh.md
+++ b/site/docs/manual/more/use-in-framework.zh.md
@@ -32,7 +32,7 @@ function renderBarChart(container) {
     .encode('x', 'genre') // 编码 x 通道
     .encode('y', 'sold') // 编码 y 通道
     .encode('key', 'genre') // 指定 key
-    .animate('updateDuration', 300); // 指定更新动画的时间
+    .animate('update', { duration: 300 }); // 指定更新动画的时间
 
   // 渲染可视化
   chart.render();

--- a/site/examples/animation/general/demo/fade.ts
+++ b/site/examples/animation/general/demo/fade.ts
@@ -17,9 +17,7 @@ chart
   .encode('x', 'genre')
   .encode('y', 'sold')
   .encode('color', 'genre')
-  .animate('enterType', 'fadeIn')
-  .animate('enterDuration', 1000)
-  .animate('exitType', 'fadeOut')
-  .animate('exitDuration', 2000);
+  .animate('enter', { type: 'fadeIn', duration: 1000 })
+  .animate('exit', { type: 'fadeOut', duration: 2000 });
 
 chart.render();

--- a/site/examples/animation/general/demo/path-in.ts
+++ b/site/examples/animation/general/demo/path-in.ts
@@ -17,7 +17,6 @@ chart
   })
   .encode('x', 'date')
   .encode('y', 'close')
-  .animate('enterType', 'pathIn')
-  .animate('enterDuration', 1000);
+  .animate('enter', { type: 'pathIn', duration: 1000 });
 
 chart.render();

--- a/site/examples/animation/general/demo/scale-x.ts
+++ b/site/examples/animation/general/demo/scale-x.ts
@@ -17,9 +17,7 @@ chart
   .encode('x', 'genre')
   .encode('y', 'sold')
   .encode('color', 'genre')
-  .animate('enterType', 'scaleInX')
-  .animate('enterDuration', 1000)
-  .animate('exitType', 'scaleOutX')
-  .animate('exitDuration', 2000);
+  .animate('enter', { type: 'scaleInX', duration: 1000 })
+  .animate('exit', { type: 'scaleOutX', duration: 2000 });
 
 chart.render();

--- a/site/examples/animation/general/demo/scale-y.ts
+++ b/site/examples/animation/general/demo/scale-y.ts
@@ -17,9 +17,7 @@ chart
   .encode('x', 'genre')
   .encode('y', 'sold')
   .encode('color', 'genre')
-  .animate('enterType', 'scaleInY')
-  .animate('enterDuration', 1000)
-  .animate('exitType', 'scaleOutY')
-  .animate('exitDuration', 2000);
+  .animate('enter', { type: 'scaleInY', duration: 1000 })
+  .animate('exit', { type: 'scaleOutY', duration: 2000 });
 
 chart.render();

--- a/site/examples/animation/general/demo/wave-in.ts
+++ b/site/examples/animation/general/demo/wave-in.ts
@@ -19,7 +19,6 @@ chart
   .transform({ type: 'stackY' })
   .encode('color', 'genre')
   .encode('y', 'sold')
-  .animate('enterType', 'waveIn')
-  .animate('enterDuration', 1000);
+  .animate('enter', { type: 'waveIn', duration: 1000 });
 
 chart.render();

--- a/site/examples/animation/general/demo/zoom-in.ts
+++ b/site/examples/animation/general/demo/zoom-in.ts
@@ -21,7 +21,6 @@ chart
   .scale('y', { domain: [65, 90] })
   .style('fillOpacity', 0.3)
   .style('lineWidth', 1)
-  .animate('enterType', 'zoomIn')
-  .animate('enterDuration', 1000);
+  .animate('enter', { type: 'zoomIn', duration: 1000 });
 
 chart.render();

--- a/site/examples/animation/group/demo/area.ts
+++ b/site/examples/animation/group/demo/area.ts
@@ -20,6 +20,6 @@ chart
   .encode('shape', 'smooth')
   .transform({ type: 'stackEnter', groupBy: 'color', duration: 5000 })
   .transform({ type: 'stackY', orderBy: 'value' })
-  .animate('enterType', 'growInX');
+  .animate('enter', { type: 'growInX' });
 
 chart.render();

--- a/site/examples/animation/group/demo/interval-polar.ts
+++ b/site/examples/animation/group/demo/interval-polar.ts
@@ -24,7 +24,7 @@ chart
   .scale('y', {
     type: 'sqrt',
   })
-  .animate('enterType', 'waveIn')
+  .animate('enter', { type: 'waveIn' })
   .axis('y', false);
 
 chart.render();

--- a/site/examples/animation/group/demo/interval.ts
+++ b/site/examples/animation/group/demo/interval.ts
@@ -22,7 +22,7 @@ chart
   .encode('y', 'value')
   .encode('color', 'type')
   .encode('color', 'type')
-  .animate('enterDuration', 500)
+  .animate('enter', { duration: 500 })
   .axis('y', false);
 
 chart.render();

--- a/site/examples/animation/group/demo/line.ts
+++ b/site/examples/animation/group/demo/line.ts
@@ -22,8 +22,7 @@ chart
   .scale('y', { zero: true, nice: true })
   .style('gradient', 'x')
   .style('gradientColor', 'start')
-  .animate('enterType', 'pathIn')
-  .animate('enterDuration', 3000)
+  .animate('enter', { type: 'pathIn', duration: 3000 })
   .axis('y', { labelFormatter: '~s' });
 
 chart
@@ -33,7 +32,7 @@ chart
   .encode('y', 'count')
   .encode('color', 'year')
   .encode('shape', 'point')
-  .animate('enterDuration', 300);
+  .animate('enter', { duration: 300 });
 
 chart
   .text()
@@ -41,7 +40,7 @@ chart
   .encode('x', 'year')
   .encode('y', 'count')
   .encode('text', 'year')
-  .animate('enterDuration', 300)
+  .animate('enter', { duration: 300 })
   .style('strokeWidth', 5)
   .style('stroke', '#fff')
   .style('textAlign', 'center')

--- a/site/examples/animation/group/demo/point.ts
+++ b/site/examples/animation/group/demo/point.ts
@@ -44,7 +44,7 @@ chart
   .style('textAlign', 'center')
   .style('fontSize', 24)
   .style('fill', '#666')
-  .animate('enterDelay', 2000);
+  .animate('enter', { delay: 2000 });
 
 chart
   .text()
@@ -55,6 +55,6 @@ chart
   .style('fontSize', 18)
   .style('fill', '#666')
   .style('dy', '30')
-  .animate('enterDelay', 2400);
+  .animate('enter', { delay: 2400 });
 
 chart.render();

--- a/site/examples/animation/storytelling/demo/facet-keyframe.ts
+++ b/site/examples/animation/storytelling/demo/facet-keyframe.ts
@@ -37,7 +37,7 @@ fetch(
       .call(utcX)
       .scale('y', { facet: false })
       .style('fillOpacity', 1)
-      .animate('enterType', 'scaleInY');
+      .animate('enter', { type: 'scaleInY' });
 
     keyframe
       .area()

--- a/site/examples/general/radial/demo/apple-activity.ts
+++ b/site/examples/general/radial/demo/apple-activity.ts
@@ -35,8 +35,7 @@ spaceLayer
   .axis('x', false)
   .axis('y', false)
   .style('fillOpacity', 0.25)
-  .animate('enterType', 'waveIn')
-  .animate('enterDuration', 400);
+  .animate('enter', { type: 'waveIn', duration: 400 });
 
 spaceLayer
   .view()
@@ -57,9 +56,11 @@ spaceLayer
       .style('shadowBlur', 20)
       .style('shadowOffsetX', -2)
       .style('shadowOffsetY', -5)
-      .animate('enterType', 'waveIn')
-      .animate('enterEasing', 'easing-out-bounce')
-      .animate('enterDuration', 1000),
+      .animate('enter', {
+        type: 'waveIn',
+        easing: 'easing-out-bounce',
+        duration: 1000,
+      }),
   )
   .call((node) =>
     node

--- a/site/examples/general/radial/demo/bar-cornered-radial.ts
+++ b/site/examples/general/radial/demo/bar-cornered-radial.ts
@@ -41,7 +41,6 @@ chart
   })
   .axis('x', { title: false })
   .axis('y', false)
-  .animate('enterType', 'waveIn')
-  .animate('enterDuration', 1000);
+  .animate('enter', { type: 'waveIn', duration: 1000 });
 
 chart.render();

--- a/site/examples/general/radial/demo/bar-radial.ts
+++ b/site/examples/general/radial/demo/bar-radial.ts
@@ -28,7 +28,6 @@ chart
   })
   .axis('y', { tickFilter: (d, i) => i !== 0 })
   .legend({ color: { length: 400, position: 'bottom' } })
-  .animate('enterType', 'waveIn')
-  .animate('enterDuration', 800);
+  .animate('enter', { type: 'waveIn', duration: 800 });
 
 chart.render();

--- a/site/examples/general/radial/demo/bar-stacked-radial.ts
+++ b/site/examples/general/radial/demo/bar-stacked-radial.ts
@@ -57,6 +57,6 @@ chart
     direction: 'center',
   })
   .axis('x', { position: 'inner' })
-  .animate('enterType', 'waveIn');
+  .animate('enter', { type: 'waveIn' });
 
 chart.render();

--- a/site/examples/general/radial/demo/donut.ts
+++ b/site/examples/general/radial/demo/donut.ts
@@ -35,7 +35,7 @@ chart
       dy: 12,
     },
   })
-  .animate('enterType', 'waveIn')
+  .animate('enter', { type: 'waveIn' })
   .legend(false);
 
 chart.render();

--- a/site/examples/general/radial/demo/pie.ts
+++ b/site/examples/general/radial/demo/pie.ts
@@ -38,7 +38,7 @@ chart
       dy: 12,
     },
   })
-  .animate('enterType', 'waveIn')
+  .animate('enter', { type: 'waveIn' })
   .legend(false);
 
 chart.render();

--- a/site/examples/general/radial/demo/rose-label.ts
+++ b/site/examples/general/radial/demo/rose-label.ts
@@ -29,6 +29,6 @@ chart
     transform: [{ type: 'overlapDodgeY' }],
   })
   .legend({ color: { length: 400 } })
-  .animate('enterType', 'waveIn');
+  .animate('enter', { type: 'waveIn' });
 
 chart.render();

--- a/site/examples/general/radial/demo/rose.ts
+++ b/site/examples/general/radial/demo/rose.ts
@@ -25,6 +25,6 @@ chart
     tickFilter: (d, i) => i !== 0,
     direction: 'right',
   })
-  .animate('enterType', 'waveIn');
+  .animate('enter', { type: 'waveIn' });
 
 chart.render();

--- a/site/examples/general/radial/demo/spider-label.ts
+++ b/site/examples/general/radial/demo/spider-label.ts
@@ -48,7 +48,7 @@ chart
   .style('radius', 4)
   .style('stroke', '#fff')
   .style('lineWidth', 2)
-  .animate('enterType', 'waveIn')
+  .animate('enter', { type: 'waveIn' })
   .legend(false);
 
 chart.render();

--- a/site/examples/plugin/lottie/demo/lottie.ts
+++ b/site/examples/plugin/lottie/demo/lottie.ts
@@ -18,10 +18,8 @@ chart
   .encode('x', 'genre')
   .encode('y', 'sold')
   .encode('color', 'genre')
-  .animate('enterType', 'fadeIn')
-  .animate('enterDuration', 1000)
-  .animate('exitType', 'fadeOut')
-  .animate('exitDuration', 2000);
+  .animate('enter', { type: 'fadeIn', duration: 1000 })
+  .animate('exit', { type: 'fadeOut', duration: 2000 });
 
 chart.render();
 

--- a/site/examples/theme/theme/demo/dark.ts
+++ b/site/examples/theme/theme/demo/dark.ts
@@ -47,8 +47,7 @@ chart
   })
   .style('radius', 4)
   .style('inset', 1)
-  .animate('enterType', 'waveIn')
-  .animate('enterDuration', 1000)
+  .animate('enter', { type: 'waveIn', duration: 1000 })
   .legend(false);
 
 chart.render();

--- a/src/composition/timingKeyframe.ts
+++ b/src/composition/timingKeyframe.ts
@@ -32,13 +32,19 @@ function setAnimation(node: G2ViewTree, duration: number, easing: string) {
     const n = discovered.pop();
     n.animate = deepMix(
       {
-        enterDuration: duration,
-        updateDuration: duration,
-        exitDuration: duration,
-        updateEasing: easing,
-        updateType: 'morphing',
-        updateFill: 'both',
-        exitType: 'fadeOut',
+        enter: {
+          duration,
+        },
+        update: {
+          duration,
+          easing,
+          type: 'morphing',
+          fill: 'both',
+        },
+        exit: {
+          type: 'fadeOut',
+          duration,
+        },
       },
       n.animate || {},
     );

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -1041,17 +1041,22 @@ function computeAnimationExtent(markState): [number, number] {
   for (const [mark, state] of markState) {
     const { animate = {} } = mark;
     const { data } = state;
+    const { enter = {}, update = {}, exit = {} } = animate;
     const {
-      updateType: defaultUpdateType,
-      updateDuration: defaultUpdateDuration = 300,
-      updateDelay: defaultUpdateDelay = 0,
-      enterType: defaultEnterType,
-      enterDuration: defaultEnterDuration = 300,
-      enterDelay: defaultEnterDelay = 0,
-      exitType: defaultExitType,
-      exitDuration: defaultExitDuration = 300,
-      exitDelay: defaultExitDelay = 0,
-    } = animate;
+      type: defaultUpdateType,
+      duration: defaultUpdateDuration = 300,
+      delay: defaultUpdateDelay = 0,
+    } = update;
+    const {
+      type: defaultEnterType,
+      duration: defaultEnterDuration = 300,
+      delay: defaultEnterDelay = 0,
+    } = enter;
+    const {
+      type: defaultExitType,
+      duration: defaultExitDuration = 300,
+      delay: defaultExitDelay = 0,
+    } = exit;
     for (const d of data) {
       const {
         updateType = defaultUpdateType,
@@ -1192,7 +1197,7 @@ function createAnimationFunction(
     shapeName(mark, defaultShape),
   ).props;
   const { [type]: defaultEffectTiming = {} } = theme;
-  const animate = subObject(mark.animate || {}, type);
+  const animate = mark.animate?.[type] || {};
   return (data, from, to) => {
     const {
       [`${type}Type`]: animation,

--- a/src/runtime/transform.ts
+++ b/src/runtime/transform.ts
@@ -190,9 +190,9 @@ export function maybeNonAnimate(
   if (animate || animate === undefined) return [I, mark];
   deepMix(mark, {
     animate: {
-      enterType: null,
-      exitType: null,
-      updateType: null,
+      enter: { type: null },
+      exit: { type: null },
+      update: { type: null },
     },
   });
   return [I, mark];

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -106,7 +106,11 @@ export type G2Mark = {
   scale?: Record<string, G2ScaleOptions>;
   encode?: Record<string, any | G2EncodeOptions>;
   type?: string | MarkComponent;
-  animate?: Record<string, Primitive>;
+  animate?: {
+    enter?: Record<string, Primitive>;
+    update?: Record<string, Primitive>;
+    exit?: Record<string, Primitive>;
+  };
   facet?: boolean;
   axis?: boolean | Record<string, any>;
   legend?: boolean | Record<string, any>;

--- a/src/spec/geometry.ts
+++ b/src/spec/geometry.ts
@@ -152,33 +152,9 @@ export type BaseGeometry<
   animate?:
     | boolean
     | {
-        enterType?: AnimationTypes;
-        enterDuration?: number;
-        enterDelay?: number;
-        enterEasing?: string;
-        enterFill?: 'forwards' | 'none' | 'backwards' | 'both' | 'auto';
-        updateType?: AnimationTypes;
-        updateDuration?: number;
-        updateDelay?: number;
-        updateEasing?: string;
-        updateFill?:
-          | 'forwards'
-          | 'none'
-          | 'backwards'
-          | 'forwards'
-          | 'both'
-          | 'auto';
-        exitType?: AnimationTypes;
-        exitDuration?: number;
-        exitDelay?: number;
-        exitEasing?: string;
-        exitFill?:
-          | 'forwards'
-          | 'none'
-          | 'backwards'
-          | 'forwards'
-          | 'both'
-          | 'auto';
+        enter?: Animation | null | boolean;
+        update?: Animation | null | boolean;
+        exit?: Animation | null | boolean;
       };
   cartesian?: boolean;
   layout?: Record<string, any>;
@@ -190,6 +166,14 @@ type StateOptions = {
   selected?: Record<string, any>; // @todo
   inactive?: Record<string, any>; // @todo
   unselected?: Record<string, any>; // @todo
+};
+
+export type Animation = {
+  type?: AnimationTypes;
+  duration?: number;
+  delay?: number;
+  easing?: string;
+  fill?: 'forwards' | 'none' | 'backwards' | 'both' | 'auto';
 };
 
 export type Axis = {


### PR DESCRIPTION
# Animation

调整动画的配置方式，为了风格的统一和更好的扩展性。

## 开始使用

```js
const before = {
  animate: { enterType: 'waveIn', enterDuration: 1000 },
};

const after = {
  animate: { enter: {type:'waveIn', duration: 1000} },
};
```

## 原因

但是拍平的原因是为了和 encode 里面保持统一，但是多了 mark.state API  之后，因为对不同的 state 增加动画，所以和 mark.state 的风格保持统一会更好一点。

```js
const options = {
  animate: {
    active: { type: 'blink' },
  },
  state: {
    active: {},
  },
};
```