### PR TITLE
feat(event): add more bubbles event

### DIFF
--- a/__tests__/integration/chart-on-item-element.spec.ts
+++ b/__tests__/integration/chart-on-item-element.spec.ts
@@ -33,6 +33,14 @@ describe('chart.on', () => {
     await fired;
   });
 
+  it('chart.on("interval:pointertap", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:pointertap', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'pointertap');
+    await fired;
+  });
+
   it('chart.on("interval:pointerdown", callback) should provide datum for item element', async () => {
     await finished;
     const [fired, resolve] = createPromise();
@@ -65,19 +73,35 @@ describe('chart.on', () => {
     await fired;
   });
 
-  it('chart.on("interval:rightdown", callback) should provide datum for item element', async () => {
+  it('chart.on("interval:pointermove", callback) should provide datum for item element', async () => {
     await finished;
     const [fired, resolve] = createPromise();
-    chart.on('interval:rightdown', receiveExpectData(resolve));
-    dispatchEvent(canvas, 'rightdown');
+    chart.on('interval:pointermove', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'pointermove');
     await fired;
   });
 
-  it('chart.on("interval:rightup", callback) should provide datum for item element', async () => {
+  it('chart.on("interval:pointerenter", callback) should provide datum for item element', async () => {
     await finished;
     const [fired, resolve] = createPromise();
-    chart.on('interval:rightup', receiveExpectData(resolve));
-    dispatchEvent(canvas, 'rightup');
+    chart.on('interval:pointerenter', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'pointerenter');
+    await fired;
+  });
+
+  it('chart.on("interval:pointerleave", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:pointerleave', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'pointerleave');
+    await fired;
+  });
+
+  it('chart.on("interval:pointerupoutside", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:pointerupoutside', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'pointerupoutside');
     await fired;
   });
 
@@ -102,6 +126,38 @@ describe('chart.on', () => {
     const [fired, resolve] = createPromise();
     chart.on('interval:drag', receiveExpectData(resolve));
     dispatchEvent(canvas, 'drag');
+    await fired;
+  });
+
+  it('chart.on("interval:dragenter", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:dragenter', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'dragenter');
+    await fired;
+  });
+
+  it('chart.on("interval:dragleave", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:dragleave', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'dragleave');
+    await fired;
+  });
+
+  it('chart.on("interval:dragover", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:dragover', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'dragover');
+    await fired;
+  });
+
+  it('chart.on("interval:drop", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:drop', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'drop');
     await fired;
   });
 

--- a/__tests__/integration/chart-on-item-element.spec.ts
+++ b/__tests__/integration/chart-on-item-element.spec.ts
@@ -1,35 +1,108 @@
-import { CustomEvent } from '@antv/g';
 import { chartOnItemElement as render } from '../plots/api/chart-on-item-element';
 import { createDOMGCanvas } from './utils/createDOMGCanvas';
-import { sleep } from './utils/sleep';
+import { dispatchEvent, createPromise, receiveExpectData } from './utils/event';
 import './utils/useSnapshotMatchers';
 
 describe('chart.on', () => {
   const canvas = createDOMGCanvas(640, 480);
+  const { finished, chart } = render({ canvas });
+
+  chart.off();
 
   it('chart.on("element:click", callback) should provide datum for item element', async () => {
-    const { finished, chart } = render({ canvas });
     await finished;
-    await sleep(20);
+    const [fired, resolve] = createPromise();
+    chart.on('element:click', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'click', { detail: 1 });
+    await fired;
+  });
 
-    await new Promise<void>((resolve) => {
-      let count = 0;
-      const click = (event) => {
-        count++;
-        expect(event.data.data).toEqual({
-          genre: 'Sports',
-          sold: 275,
-        });
-        if (count >= 2) resolve();
-      };
+  it('chart.on("interval:click", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:click', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'click', { detail: 1 });
+    await fired;
+  });
 
-      chart.off();
-      chart.on('element:click', click);
-      chart.on('interval:click', click);
+  it('chart.on("interval:dblclick", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:dblclick', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'click', { detail: 2 });
+    await fired;
+  });
 
-      const [element] = canvas.document.getElementsByClassName('element');
-      element.dispatchEvent(new CustomEvent('click'));
-    });
+  it('chart.on("interval:pointerdown", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:pointerdown', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'pointerdown');
+    await fired;
+  });
+
+  it('chart.on("interval:pointerup", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:pointerup', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'pointerup');
+    await fired;
+  });
+
+  it('chart.on("interval:pointerover", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:pointerover', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'pointerover');
+    await fired;
+  });
+
+  it('chart.on("interval:pointerout", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:pointerout', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'pointerout');
+    await fired;
+  });
+
+  it('chart.on("interval:rightdown", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:rightdown', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'rightdown');
+    await fired;
+  });
+
+  it('chart.on("interval:rightup", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:rightup', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'rightup');
+    await fired;
+  });
+
+  it('chart.on("interval:dragstart", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:dragstart', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'dragstart');
+    await fired;
+  });
+
+  it('chart.on("interval:dragend", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:dragend', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'dragend');
+    await fired;
+  });
+
+  it('chart.on("interval:drag", callback) should provide datum for item element', async () => {
+    await finished;
+    const [fired, resolve] = createPromise();
+    chart.on('interval:drag', receiveExpectData(resolve));
+    dispatchEvent(canvas, 'drag');
+    await fired;
   });
 
   afterAll(() => {

--- a/__tests__/integration/utils/event.ts
+++ b/__tests__/integration/utils/event.ts
@@ -1,0 +1,25 @@
+import { CustomEvent } from '@antv/g';
+
+export function createPromise() {
+  let r;
+  const promise = new Promise((resolve) => (r = resolve));
+  return [promise, r];
+}
+
+export function receiveExpectData(
+  resolve,
+  data: any = {
+    genre: 'Sports',
+    sold: 275,
+  },
+) {
+  return (event) => {
+    expect(event.data.data).toEqual(data);
+    resolve();
+  };
+}
+
+export function dispatchEvent(canvas, event, params?) {
+  const [element] = canvas.document.getElementsByClassName('element');
+  element.dispatchEvent(new CustomEvent(event, params));
+}

--- a/__tests__/plots/api/chart-on-item-element.ts
+++ b/__tests__/plots/api/chart-on-item-element.ts
@@ -22,20 +22,30 @@ export function chartOnItemElement(context) {
     .encode('y', 'sold')
     .encode('color', 'genre')
     .axis({ x: { animate: false }, y: { animate: false } })
-    .style('draggable', true);
+    .style('draggable', true)
+    .style('droppable', true);
 
   chart.on('interval:click', log('interval:click'));
   chart.on('element:click', log('element:click'));
   chart.on('interval:dblclick', log('interval:dblclick'));
+
+  chart.on('interval:pointertap', log('interval:pointertap'));
   chart.on('interval:pointerdown', log('interval:pointerdown'));
   chart.on('interval:pointerup', log('interval:pointerup'));
   chart.on('interval:pointerover', log('interval:pointerover'));
   chart.on('interval:pointerout', log('interval:pointerout'));
-  chart.on('interval:rightdown', log('interval:rightdown'));
-  chart.on('interval:rightup', log('interval:rightup'));
+  chart.on('interval:pointermove', log('interval:pointermove'));
+  chart.on('interval:pointerenter', log('interval:pointerenter'));
+  chart.on('interval:pointerleave', log('interval:pointerleave'));
+  chart.on('interval:pointerupoutside', log('interval:pointerupoutside'));
+
   chart.on('interval:dragstart', log('interval:dragstart'));
   chart.on('interval:drag', log('interval:drag'));
   chart.on('interval:dragend', log('interval:dragend'));
+  chart.on('interval:dragenter', log('interval:dragenter'));
+  chart.on('interval:dragleave', log('interval:dragleave'));
+  chart.on('interval:dragover', log('interval:dragover'));
+  chart.on('interval:drop', log('interval:drop'));
 
   const finished = chart.render();
 

--- a/__tests__/plots/api/chart-on-item-element.ts
+++ b/__tests__/plots/api/chart-on-item-element.ts
@@ -21,17 +21,38 @@ export function chartOnItemElement(context) {
     .encode('x', 'genre')
     .encode('y', 'sold')
     .encode('color', 'genre')
-    .axis({ x: { animate: false }, y: { animate: false } });
+    .axis({ x: { animate: false }, y: { animate: false } })
+    .style('draggable', true);
 
-  chart.on('interval:click', (e) => {
-    console.log(e.data.data);
-  });
-
-  chart.on('element:click', (e) => {
-    console.log(e.data.data);
-  });
+  chart.on('interval:click', log('interval:click'));
+  chart.on('element:click', log('element:click'));
+  chart.on('interval:dblclick', log('interval:dblclick'));
+  chart.on('interval:pointerdown', log('interval:pointerdown'));
+  chart.on('interval:pointerup', log('interval:pointerup'));
+  chart.on('interval:pointerover', log('interval:pointerover'));
+  chart.on('interval:pointerout', log('interval:pointerout'));
+  chart.on('interval:rightdown', log('interval:rightdown'));
+  chart.on('interval:rightup', log('interval:rightup'));
+  chart.on('interval:dragstart', log('interval:dragstart'));
+  chart.on('interval:drag', log('interval:drag'));
+  chart.on('interval:dragend', log('interval:dragend'));
 
   const finished = chart.render();
+
+  const { canvas: gCanvas } = chart.getContext();
+
+  gCanvas
+    ?.getContextService()!
+    .getDomElement()!
+    .addEventListener('contextmenu', (e) => {
+      e.preventDefault();
+    });
+
+  function log(msg) {
+    return (e) => {
+      console.log(msg, e.data.data);
+    };
+  }
 
   return { chart, finished };
 }

--- a/src/interaction/native/event.ts
+++ b/src/interaction/native/event.ts
@@ -12,17 +12,22 @@ function dataOf(element, view) {
   return selectedMark.data[index];
 }
 
-function clickEvent(view, emitter) {
+function updateData(event, target, view) {
+  const { data = {} } = event;
+  data.data = dataOf(target, view);
+  event.data = data;
+}
+
+function bubblesEvent(eventType, view, emitter, predicate = (event) => true) {
   return (e) => {
+    if (!predicate(e)) return;
     const { target } = e;
     const { classList } = target;
     const [elementType, markType] = classList;
     if (elementType === 'element') {
-      const { data = {} } = e;
-      data.data = dataOf(target, view);
-      e.data = data;
-      emitter.emit('element:click', e);
-      emitter.emit(`${markType}:click`, e);
+      updateData(e, target, view);
+      emitter.emit(`element:${eventType}`, e);
+      emitter.emit(`${markType}:${eventType}`, e);
       return;
     }
     // @todo Handle click axis and legend.
@@ -30,15 +35,49 @@ function clickEvent(view, emitter) {
   };
 }
 
-// @todo More events such as mouseenter, mouseleave.
 // @todo Provide more info for event.dataset.
 export function Event() {
   return (context, _, emitter) => {
     const { container, view } = context;
-    const click = clickEvent(view, emitter);
+    const click = bubblesEvent('click', view, emitter, (e) => e.detail === 1);
+    const dblclick = bubblesEvent(
+      'dblclick',
+      view,
+      emitter,
+      (e) => e.detail === 2,
+    );
+    const pointerdown = bubblesEvent('pointerdown', view, emitter);
+    const pointerup = bubblesEvent('pointerup', view, emitter);
+    const pointerover = bubblesEvent('pointerover', view, emitter);
+    const pointerout = bubblesEvent('pointerout', view, emitter);
+    const rightdown = bubblesEvent('rightdown', view, emitter);
+    const rightup = bubblesEvent('rightup', view, emitter);
+    const dragstart = bubblesEvent('dragstart', view, emitter);
+    const drag = bubblesEvent('drag', view, emitter);
+    const dragend = bubblesEvent('dragend', view, emitter);
     container.addEventListener('click', click);
+    container.addEventListener('click', dblclick);
+    container.addEventListener('pointerdown', pointerdown);
+    container.addEventListener('pointerup', pointerup);
+    container.addEventListener('pointerover', pointerover);
+    container.addEventListener('pointerout', pointerout);
+    container.addEventListener('rightdown', rightdown);
+    container.addEventListener('rightup', rightup);
+    container.addEventListener('dragstart', dragstart);
+    container.addEventListener('drag', drag);
+    container.addEventListener('dragend', dragend);
     return () => {
       container.removeEventListener('click', click);
+      container.removeEventListener('click', dblclick);
+      container.removeEventListener('pointerdown', pointerdown);
+      container.removeEventListener('pointerup', pointerup);
+      container.removeEventListener('pointerover', pointerover);
+      container.removeEventListener('pointerout', pointerout);
+      container.removeEventListener('rightdown', rightdown);
+      container.removeEventListener('rightup', rightup);
+      container.removeEventListener('dragstart', dragstart);
+      container.removeEventListener('drag', drag);
+      container.removeEventListener('dragend', dragend);
     };
   };
 }

--- a/src/interaction/native/event.ts
+++ b/src/interaction/native/event.ts
@@ -39,6 +39,8 @@ function bubblesEvent(eventType, view, emitter, predicate = (event) => true) {
 export function Event() {
   return (context, _, emitter) => {
     const { container, view } = context;
+
+    // Click events.
     const click = bubblesEvent('click', view, emitter, (e) => e.detail === 1);
     const dblclick = bubblesEvent(
       'dblclick',
@@ -46,38 +48,72 @@ export function Event() {
       emitter,
       (e) => e.detail === 2,
     );
+
+    // Pointer events.
+    const pointertap = bubblesEvent('pointertap', view, emitter);
     const pointerdown = bubblesEvent('pointerdown', view, emitter);
     const pointerup = bubblesEvent('pointerup', view, emitter);
     const pointerover = bubblesEvent('pointerover', view, emitter);
     const pointerout = bubblesEvent('pointerout', view, emitter);
-    const rightdown = bubblesEvent('rightdown', view, emitter);
-    const rightup = bubblesEvent('rightup', view, emitter);
+    const pointermove = bubblesEvent('pointermove', view, emitter);
+    const pointerenter = bubblesEvent('pointerenter', view, emitter);
+    const pointerleave = bubblesEvent('pointerleave', view, emitter);
+    const pointerupoutside = bubblesEvent('pointerupoutside', view, emitter);
+
+    // Drag and drop events.
     const dragstart = bubblesEvent('dragstart', view, emitter);
     const drag = bubblesEvent('drag', view, emitter);
     const dragend = bubblesEvent('dragend', view, emitter);
+    const dragenter = bubblesEvent('dragenter', view, emitter);
+    const dragleave = bubblesEvent('dragleave', view, emitter);
+    const dragover = bubblesEvent('dragover', view, emitter);
+    const drop = bubblesEvent('drop', view, emitter);
+
+    // For legacy usage.
     container.addEventListener('click', click);
     container.addEventListener('click', dblclick);
+
+    // Recommend events.
+    container.addEventListener('pointertap', pointertap);
     container.addEventListener('pointerdown', pointerdown);
     container.addEventListener('pointerup', pointerup);
     container.addEventListener('pointerover', pointerover);
     container.addEventListener('pointerout', pointerout);
-    container.addEventListener('rightdown', rightdown);
-    container.addEventListener('rightup', rightup);
+    container.addEventListener('pointermove', pointermove);
+    container.addEventListener('pointerenter', pointerenter);
+    container.addEventListener('pointerleave', pointerleave);
+    container.addEventListener('pointerupoutside', pointerupoutside);
+
+    // Plugin events.
     container.addEventListener('dragstart', dragstart);
     container.addEventListener('drag', drag);
     container.addEventListener('dragend', dragend);
+    container.addEventListener('dragenter', dragenter);
+    container.addEventListener('dragleave', dragleave);
+    container.addEventListener('dragover', dragover);
+    container.addEventListener('drop', drop);
+
     return () => {
       container.removeEventListener('click', click);
       container.removeEventListener('click', dblclick);
+
+      container.removeEventListener('pointertap', pointertap);
       container.removeEventListener('pointerdown', pointerdown);
       container.removeEventListener('pointerup', pointerup);
       container.removeEventListener('pointerover', pointerover);
       container.removeEventListener('pointerout', pointerout);
-      container.removeEventListener('rightdown', rightdown);
-      container.removeEventListener('rightup', rightup);
+      container.removeEventListener('pointermove', pointermove);
+      container.removeEventListener('pointerenter', pointerenter);
+      container.removeEventListener('pointerleave', pointerleave);
+      container.removeEventListener('pointerupoutside', pointerupoutside);
+
       container.removeEventListener('dragstart', dragstart);
       container.removeEventListener('drag', drag);
       container.removeEventListener('dragend', dragend);
+      container.removeEventListener('dragenter', dragenter);
+      container.removeEventListener('dragleave', dragleave);
+      container.removeEventListener('dragover', dragover);
+      container.removeEventListener('drop', drop);
     };
   };
 }


### PR DESCRIPTION
# Event

抛出更多 element 的事件。

- click
- dbclick

pointer 事件：

- pointertap
- pointerdown
- pointerup
- pointerover
- pointerout
- pointermove
- pointerenter
- pointerleave
- pointerupoutside

拖拽事件：

- dragstart
- drag
- dragend
- dragenter
- dragleave
- dragover
- drop

## 注意

如果希望 rightup 事件生效，需要禁止默认的 contextmenu 事件。

```js
const chart = new Container({ container });

chart.on('element:rightup', console.log);

// 禁止默认的 contextmenu 事件。
container.addEventListener('contextmenu', (e) => {
  e.preventDefault();
});
```

如果希望监听拖拽事件，需要设置 draggable 和 droppable 属性。

```js
chart.interval().style('draggable', true).style('droppable', true);
```

## 讨论

有了 `pointer*` 事件，还是否需要 `mouse*` 事件？@xiaoiver 的建议是不加，因为 pointer 事件已经包含了。