### PR TITLE
feat(ci): throw error for .only and missing snapshot

### DIFF
--- a/__tests__/integration/utils/filterTests.ts
+++ b/__tests__/integration/utils/filterTests.ts
@@ -4,6 +4,9 @@ export function filterTests(test) {
     // @ts-ignore
     ([, { only = false }]) => only,
   );
+  if (onlys.length !== 0 && process.env.CI === 'true') {
+    throw new Error('Please remove `test.only`.');
+  }
   const runnables = onlys.length === 0 ? tests : onlys;
   return runnables.filter(
     // @ts-ignore

--- a/__tests__/integration/utils/toMatchCanvasSnapshot.ts
+++ b/__tests__/integration/utils/toMatchCanvasSnapshot.ts
@@ -66,6 +66,9 @@ export async function toMatchCanvasSnapshot(
   try {
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
     if (!fs.existsSync(expectedPath)) {
+      if (process.env.CI === 'true') {
+        throw new Error(`Please generate golden image for ${namePath}`);
+      }
       console.warn(`! generate ${namePath}`);
       await writePNG(canvas, expectedPath);
       return {

--- a/__tests__/integration/utils/toMatchDOMSnapshot.ts
+++ b/__tests__/integration/utils/toMatchDOMSnapshot.ts
@@ -37,6 +37,9 @@ export async function toMatchDOMSnapshot(
       : 'null';
 
     if (!fs.existsSync(expectedPath)) {
+      if (process.env.CI === 'true') {
+        throw new Error(`Please generate golden image for ${namePath}`);
+      }
       console.warn(`! generate ${namePath}`);
       await fs.writeFileSync(expectedPath, actual);
       return {


### PR DESCRIPTION
之前线上 CI 反复出现两个问题：

- 新增集成测试案例之后，本地没有生成新的截图就推到远端了。
- 本地调试的时候把某些案例设置成 only，但是忘记删除了就推到远端了。

为了防止这两个问题出现，通过 `process.env.CI` 的值去判断是否需要抛出异常。