### PR TITLE
fix: add force param when tooltip hide

### DIFF
--- a/src/chart/controller/tooltip.ts
+++ b/src/chart/controller/tooltip.ts
@@ -47,14 +47,14 @@ export default class Tooltip extends Controller<TooltipOption> {
     return 'tooltip';
   }
 
-  public init() { }
+  public init() {}
 
   private isVisible() {
     const option = this.view.getOptions().tooltip;
     return option !== false;
   }
 
-  public render() { }
+  public render() {}
 
   /**
    * Shows tooltip
@@ -149,7 +149,11 @@ export default class Tooltip extends Controller<TooltipOption> {
     }
   }
 
-  public hideTooltip() {
+  /**
+   * 隐藏 Tooltip
+   * @param force 是否强制隐藏 Tooltip
+   */
+  public hideTooltip(force: boolean = false) {
     const { follow } = this.getTooltipCfg();
     if (!follow) {
       this.point = null;
@@ -175,9 +179,7 @@ export default class Tooltip extends Controller<TooltipOption> {
     if (tooltip) {
       tooltip.hide();
     }
-
-    this.view.emit('tooltip:hide', Event.fromData(this.view, 'tooltip:hide', {}));
-
+    this.view.emit('tooltip:hide', Event.fromData(this.view, 'tooltip:hide', { force }));
     this.point = null;
   }
 
@@ -342,7 +344,7 @@ export default class Tooltip extends Controller<TooltipOption> {
     return [];
   }
 
-  public layout() { }
+  public layout() {}
 
   public update() {
     if (this.point) {

--- a/src/interaction/action/component/tooltip/geometry.ts
+++ b/src/interaction/action/component/tooltip/geometry.ts
@@ -45,8 +45,8 @@ class TooltipAction extends Action {
    * 隐藏 Tooltip。
    * @returns
    */
-  public hide() {
-    const view = this.context.view;
+  public hide(cfg?: { force: boolean }) {
+    const { view, event } = this.context;
 
     const tooltip = view.getController('tooltip');
     const { clientX, clientY } = this.context.event;
@@ -56,8 +56,8 @@ class TooltipAction extends Action {
       return;
     }
 
-    // 锁定 tooltip 时不隐藏
-    if (view.isTooltipLocked()) {
+    // 锁定 tooltip 时不隐藏 / force 标识 tooltip 强制隐藏
+    if (view.isTooltipLocked() && !event?.data?.force && !cfg?.force) {
       return;
     }
     this.hideTooltip(view);


### PR DESCRIPTION
#### 问题描述
目前 tooltip:hide 逻辑是：检测没有锁定 tooltip 时才隐藏。
<img width="535" alt="image" src="https://user-images.githubusercontent.com/109653633/228179473-a48e2e28-b43a-4fb3-a96a-f2539267ca38.png">

特殊交互场景：
1. 锁定 tooltip
2. 点击 tooltip 某些按钮做交互
3. **调用 `view.hideTooltip()` 隐藏 Tooltip**
4. `view.hideTooltip()` 方法检测到 tooltip 为 lock 状态，不作隐藏处理

![iShot_2023-03-28_16 45 15](https://user-images.githubusercontent.com/109653633/228181140-15e6e2e0-4014-4753-9ec6-af2a6afb0985.gif)


#### 解决方案
`view.hideTooltip(force:boolean)` 支持传入参数
```js
view.hideTooltip(true); // 强制隐藏 Tooltip
```
