### PR TITLE
fix(ci): lock version of canvas to 2.11.0

### DIFF
--- a/__tests__/plots/interaction/penguins-point-highlight.ts
+++ b/__tests__/plots/interaction/penguins-point-highlight.ts
@@ -1,8 +1,6 @@
 import { G2Spec, ELEMENT_CLASS_NAME } from '../../../src';
 import { step, disableDelay } from './utils';
 
-// @todo Two circles are not drawn correctly.
-
 export function penguinsPointHighlight(): G2Spec {
   return {
     type: 'point',

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@typescript-eslint/parser": "^4.18.0",
     "ali-oss": "^6.17.1",
     "archiver": "^5.3.1",
-    "canvas": "^2.10.2",
+    "canvas": "2.11.0",
     "conventional-changelog-cli": "^2.2.2",
     "cross-env": "^7.0.3",
     "d3-dsv": "^3.0.1",


### PR DESCRIPTION
修复 node canvas [v2.11.1](https://github.com/Automattic/node-canvas/releases/tag/v2.11.1) 升级带来的问题。

- 问题原因：node canvas 修复了之前 letter-spacing 不正确的问题，导致截图有文本的地方全部不匹配。
- 解决办法：暂时锁定版本到 v2.11.0，因为之后要替换测试为 playwright，到时候再统一升级。