### PR TITLE
docs: fix simple typo, transfrom -> transform

### DIFF
--- a/site/docs/spec/transform/sample.zh.md
+++ b/site/docs/spec/transform/sample.zh.md
@@ -66,5 +66,5 @@ chart
   .line()
   .encode('x', 'x')
   .encode('y', 'y')
-  .transfrom([{ type: 'sample', strategy }]);
+  .transform([{ type: 'sample', strategy }]);
 ```


### PR DESCRIPTION
There is a small typo in site/docs/spec/transform/sample.zh.md.

Should read `transform` rather than `transfrom`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md