### PR TITLE
fix(OOM): clear interaction and cancel animation when rerendering

### DIFF
--- a/__tests__/integration/api-chart-render-clear-animation.spec.ts
+++ b/__tests__/integration/api-chart-render-clear-animation.spec.ts
@@ -1,0 +1,29 @@
+import { chartRenderClearAnimation as render } from '../plots/api/chart-render-clear-animation';
+import { createNodeGCanvas } from './utils/createNodeGCanvas';
+import './utils/useSnapshotMatchers';
+
+describe('chart.render', () => {
+  const canvas = createNodeGCanvas(640, 480);
+
+  it('chart.render should clear prev animation', async () => {
+    const { chart } = render({
+      canvas,
+      container: document.createElement('div'),
+    });
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const { animations: prevAnimations = [] } = chart.getContext();
+        chart.render();
+        setTimeout(() => {
+          const [animation] = prevAnimations;
+          expect(animation.playState).toBe('idle');
+          resolve();
+        }, 0);
+      }, 0);
+    });
+  });
+
+  afterAll(() => {
+    canvas?.destroy();
+  });
+});

--- a/__tests__/plots/api/chart-render-clear-animation.ts
+++ b/__tests__/plots/api/chart-render-clear-animation.ts
@@ -1,0 +1,40 @@
+import { Chart } from '../../../src';
+
+export function chartRenderClearAnimation(context) {
+  const { container, canvas } = context;
+
+  const button = document.createElement('button');
+  button.innerText = 'render';
+  button.style.display = 'block';
+  container.appendChild(button);
+
+  const div = document.createElement('div');
+  container.appendChild(div);
+
+  const chart = new Chart({ theme: 'classic', container: div, canvas });
+
+  chart.data([
+    { genre: 'Sports', sold: 275 },
+    { genre: 'Strategy', sold: 115 },
+    { genre: 'Action', sold: 120 },
+    { genre: 'Shooter', sold: 350 },
+    { genre: 'Other', sold: 150 },
+  ]);
+
+  chart
+    .interval()
+    .encode('x', 'genre')
+    .encode('y', 'sold')
+    .encode('color', 'genre');
+
+  const finished = chart.render();
+
+  let resolve;
+  const refreshed = new Promise((r) => (resolve = r));
+
+  button.onclick = () => {
+    chart.render()?.then(resolve);
+  };
+
+  return { chart, button, finished, refreshed };
+}

--- a/__tests__/plots/api/index.ts
+++ b/__tests__/plots/api/index.ts
@@ -13,3 +13,4 @@ export { viewFacetCircle } from './view-facetCircle';
 export { chartEmitLegendFilter } from './chart-emit-legend-filter';
 export { chartChangeSizePolar } from './chart-change-size-polar';
 export { chartChangeDataFacet } from './chart-change-data-facet';
+export { chartRenderClearAnimation } from './chart-render-clear-animation';

--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -1,4 +1,4 @@
-import { Canvas } from '@antv/g';
+import { Canvas, DisplayObject } from '@antv/g';
 import { Chart, createLibrary, VIEW_CLASS_NAME } from '../../../src';
 import { G2_CHART_KEY } from '../../../src/api/chart';
 import {
@@ -445,7 +445,7 @@ describe('Chart', () => {
     expect(count).toBe(0);
   });
 
-  it('chart should render after window resize.', (done) => {
+  it('chart.render() should be called after window resize.', (done) => {
     const div = document.createElement('div');
     const chart = new Chart({
       theme: 'classic',
@@ -488,7 +488,7 @@ describe('Chart', () => {
     });
   });
 
-  it('get instance information after chart render.', async () => {
+  it('chart.getInstance() should return internal instance after chart render.', async () => {
     const chart = new Chart({ theme: 'classic' });
 
     chart.data([
@@ -520,14 +520,14 @@ describe('Chart', () => {
     expect(chart.getScaleByChannel('shape')).not.toBeDefined();
   });
 
-  it('chart render before theme option must be specified.', async () => {
+  it('chart.render() should throw error.', async () => {
     // Catch error.
     // @ts-ignore
     const chart = new Chart({});
     await expect(chart.render()).rejects.toThrowError();
   });
 
-  it('chart.destroy()', async () => {
+  it('chart.destroy() should destroy group', async () => {
     const chart = new Chart({ theme: 'classic' });
     chart.data([
       { genre: 'Sports', sold: 275 },
@@ -549,7 +549,7 @@ describe('Chart', () => {
     expect(chart.getGroup()).toEqual(null);
   });
 
-  it('chart.clear()', async () => {
+  it('chart.clear() should clear group.', async () => {
     const chart = new Chart({ theme: 'classic' });
     chart.data([
       { genre: 'Sports', sold: 275 },
@@ -569,39 +569,6 @@ describe('Chart', () => {
     expect(chart.getGroup().id).toEqual(chart.attr('key'));
     chart.clear();
     expect(chart.getGroup()).toEqual(null);
-  });
-
-  it('chart.clear() should clear interaction', async () => {
-    const chart = new Chart({ theme: 'classic' });
-    chart.data([
-      { genre: 'Sports', sold: 275 },
-      { genre: 'Strategy', sold: 115 },
-      { genre: 'Action', sold: 120 },
-      { genre: 'Shooter', sold: 350 },
-      { genre: 'Other', sold: 150 },
-    ]);
-    chart
-      .interval()
-      .encode('x', 'genre')
-      .encode('y', 'sold')
-      .encode('color', 'genre')
-      .interaction('tooltip');
-    await chart.render();
-
-    const { canvas } = chart.getContext();
-    const fn = jest.fn();
-    // @ts-ignore
-    const [view] = canvas.document.getElementsByClassName(VIEW_CLASS_NAME);
-    const nameInteraction = view['nameInteraction'];
-    const interaction = nameInteraction.get('tooltip');
-    const { destroy } = interaction;
-    const newDestroy = () => {
-      destroy();
-      fn();
-    };
-    interaction.destroy = newDestroy;
-    chart.clear();
-    expect(fn).toBeCalledTimes(1);
   });
 
   it('chart.changeData() should update all children data although mark children have their own data', async () => {

--- a/__tests__/unit/api/interaction.spec.ts
+++ b/__tests__/unit/api/interaction.spec.ts
@@ -1,45 +1,87 @@
-import { VIEW_CLASS_NAME, Chart } from '../../../src';
+import { Chart, VIEW_CLASS_NAME } from '../../../src';
 
-describe('Interaction', () => {
-  it('should clear interaction after resize', async () => {
-    const chart = new Chart({ theme: 'classic' });
+function interactionOf(chart, name) {
+  const { canvas } = chart.getContext();
+  const [view] = canvas.document.getElementsByClassName(VIEW_CLASS_NAME);
+  const nameInteraction = view['nameInteraction'];
+  return nameInteraction.get(name);
+}
 
-    chart.data({
-      value: [
-        { genre: 'Sports', sold: 275 },
-        { genre: 'Strategy', sold: 115 },
-        { genre: 'Action', sold: 120 },
-        { genre: 'Shooter', sold: 350 },
-        { genre: 'Other', sold: 150 },
-      ],
-    });
+function mockInteraction(chart, name, fn) {
+  const interaction = interactionOf(chart, name);
+  const { destroy } = interaction;
+  const newDestroy = () => {
+    destroy();
+    fn();
+  };
+  interaction.destroy = newDestroy;
+}
 
-    chart
-      .interval()
-      .encode('x', 'genre')
-      .encode('y', 'sold')
-      .encode('color', 'genre');
+function createChart() {
+  const chart = new Chart({ theme: 'classic' });
 
-    chart.interaction('tooltip');
+  chart
+    .interval()
+    .data([
+      { genre: 'Sports', sold: 275 },
+      { genre: 'Strategy', sold: 115 },
+      { genre: 'Action', sold: 120 },
+      { genre: 'Shooter', sold: 350 },
+      { genre: 'Other', sold: 150 },
+    ])
+    .encode('x', 'genre')
+    .encode('y', 'sold')
+    .encode('color', 'genre');
+
+  return chart;
+}
+
+describe('Clear Interaction', () => {
+  it('chart.resize() should clear interaction.', async () => {
+    const chart = createChart();
     await chart.render();
 
-    const { canvas } = chart.getContext();
     const fn = jest.fn();
-
-    // Update interaction hook.
-    // @ts-ignore
-    const [view] = canvas.document.getElementsByClassName(VIEW_CLASS_NAME);
-    const nameInteraction = view['nameInteraction'];
-    const interaction = nameInteraction.get('tooltip');
-    const { destroy } = interaction;
-    const newDestroy = () => {
-      destroy();
-      fn();
-    };
-    interaction.destroy = newDestroy;
+    mockInteraction(chart, 'tooltip', fn);
 
     // Update size to call destroy.
     await chart.changeSize(600, 600);
     expect(fn).toBeCalledTimes(1);
+  });
+
+  it('chart.clear() should clear interaction.', async () => {
+    const chart = createChart();
+    await chart.render();
+
+    const fn = jest.fn();
+    mockInteraction(chart, 'tooltip', fn);
+    chart.clear();
+    expect(fn).toBeCalledTimes(1);
+  });
+
+  it('chart.render() should overwrite prev interaction.', async () => {
+    const chart = createChart();
+    await chart.render();
+
+    // Mock destroy of interaction.
+    const fn = jest.fn();
+    mockInteraction(chart, 'event', fn);
+
+    // Rerender
+    await chart.render();
+    await chart.render();
+    expect(fn).toBeCalledTimes(1);
+  });
+});
+
+describe('Clear EventEmitter', () => {
+  it('legendFilter.destroy() should clear legend:filter handler.', async () => {
+    const chart = createChart();
+    chart.legend('color', false);
+    await chart.render();
+    const { emitter } = chart.getContext();
+    const { destroy } = interactionOf(chart, 'legendFilter');
+    destroy();
+    expect(emitter?.getEvents()['legend:filter']).toBeUndefined();
   });
 });

--- a/src/interaction/legendFilter.ts
+++ b/src/interaction/legendFilter.ts
@@ -169,11 +169,14 @@ export function LegendFilter() {
     };
 
     if (!legends.length) {
-      emitter.on('legend:filter', (options) => {
+      const onFilter = (options) => {
         const { values, channel } = options;
         filter(channel, values);
-      });
-      return () => {};
+      };
+      emitter.on('legend:filter', onFilter);
+      return () => {
+        emitter.off('legend:filter', onFilter);
+      };
     }
 
     const removes = legends.map((legend) => {

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -250,7 +250,7 @@ export async function plot<T extends G2ViewTree>(
       // Apply new interaction.
       const interaction = useInteraction(option);
       const destroy = interaction(target, updateViewInstances, context.emitter);
-      nameInteraction.set(options.type, { destroy });
+      nameInteraction.set(option.type, { destroy });
     }
   }
 
@@ -272,6 +272,9 @@ export async function plot<T extends G2ViewTree>(
   }
 
   context.views = views;
+
+  // Clear and update animation.
+  context.animations?.forEach((animation) => animation?.cancel());
   context.animations = transitions;
 
   context.emitter.emit(ChartEvent.AFTER_PAINT);


### PR DESCRIPTION
# 内存泄漏

解决 https://github.com/antvis/G2/issues/4896 提到的问题的 95% 。

## 出现原因

- chart.render 之前没有取消之前的 animation。
- 多次调用 chart.render 的时候没有正确销毁之前的交互，导致 markState 这个变量一直没有销毁。

## 修复办法

- 在 render 之前把上一次的 animation 对象全部取消。
- 正确的保存和销毁交互

## 效果

可以发现内存增长的很慢了，这个部分需要 @xiaoiver 进一步在 g 里面看看：调用 animation.cancel 时候完全清除了动画。

![image](https://user-images.githubusercontent.com/49330279/233531850-f7c2d4c2-acb6-4a2c-8358-3df1a8209948.png)
