### PR TITLE
fix(tooltip): show falsy item by default

### DIFF
--- a/__tests__/integration/snapshots/tooltip/mock-line-falsy/step0.html
+++ b/__tests__/integration/snapshots/tooltip/mock-line-falsy/step0.html
@@ -1,13 +1,13 @@
 <div
   xmlns="http://www.w3.org/1999/xhtml"
   class="tooltip"
-  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular; left: 110px; top: 98px;"
+  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular; left: 210px; top: 310px;"
 >
   <div
     class="tooltip-title"
     style="color: rgba(0, 0, 0, 0.45); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
   >
-    Thu, 10 Jan 2008 00:00:00 GMT
+    北京
   </div>
   <ul
     class="tooltip-list"
@@ -24,22 +24,22 @@
       >
         <span
           class="tooltip-list-item-marker"
-          style="background: black; width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+          style="background: rgb(91, 143, 249); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
         />
         <span
           class="tooltip-list-item-name-label"
-          title="close"
+          title="value"
           style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
         >
-          close
+          value
         </span>
       </span>
       <span
         class="tooltip-list-item-value"
-        title="NaN"
+        title="null"
         style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
       >
-        NaN
+        null
       </span>
     </li>
   </ul>

--- a/__tests__/integration/snapshots/tooltip/mock-line-falsy/step1.html
+++ b/__tests__/integration/snapshots/tooltip/mock-line-falsy/step1.html
@@ -1,13 +1,13 @@
 <div
   xmlns="http://www.w3.org/1999/xhtml"
   class="tooltip"
-  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular; left: 110px; top: 98px;"
+  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular; left: 285px; top: 310px;"
 >
   <div
     class="tooltip-title"
     style="color: rgba(0, 0, 0, 0.45); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
   >
-    Thu, 10 Jan 2008 00:00:00 GMT
+    河北
   </div>
   <ul
     class="tooltip-list"
@@ -24,22 +24,22 @@
       >
         <span
           class="tooltip-list-item-marker"
-          style="background: black; width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+          style="background: rgb(91, 143, 249); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
         />
         <span
           class="tooltip-list-item-name-label"
-          title="close"
+          title="value"
           style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
         >
-          close
+          value
         </span>
       </span>
       <span
         class="tooltip-list-item-value"
-        title="NaN"
+        title="0"
         style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
       >
-        NaN
+        0
       </span>
     </li>
   </ul>

--- a/__tests__/integration/snapshots/tooltip/mock-line-falsy/step2.html
+++ b/__tests__/integration/snapshots/tooltip/mock-line-falsy/step2.html
@@ -1,13 +1,13 @@
 <div
   xmlns="http://www.w3.org/1999/xhtml"
   class="tooltip"
-  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular; left: 110px; top: 98px;"
+  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular; left: 430px; top: 310px;"
 >
   <div
     class="tooltip-title"
     style="color: rgba(0, 0, 0, 0.45); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
   >
-    Thu, 10 Jan 2008 00:00:00 GMT
+    海南
   </div>
   <ul
     class="tooltip-list"
@@ -24,22 +24,22 @@
       >
         <span
           class="tooltip-list-item-marker"
-          style="background: black; width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+          style="background: rgb(91, 143, 249); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
         />
         <span
           class="tooltip-list-item-name-label"
-          title="close"
+          title="value"
           style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
         >
-          close
+          value
         </span>
       </span>
       <span
         class="tooltip-list-item-value"
-        title="NaN"
+        title="undefined"
         style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
       >
-        NaN
+        undefined
       </span>
     </li>
   </ul>

--- a/__tests__/integration/snapshots/tooltip/profit-interval-legend-filter-ordinal/step1.html
+++ b/__tests__/integration/snapshots/tooltip/profit-interval-legend-filter-ordinal/step1.html
@@ -42,5 +42,34 @@
         387264
       </span>
     </li>
+    <li
+      class="tooltip-list-item"
+      data-index="1"
+      style="list-style-type: none; display: flex; line-height: 2em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="tooltip-list-item-marker"
+          style="background: rgb(91, 143, 249); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="tooltip-list-item-name-label"
+          title="start"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          start
+        </span>
+      </span>
+      <span
+        class="tooltip-list-item-value"
+        title="0"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        0
+      </span>
+    </li>
   </ul>
 </div>;

--- a/__tests__/plots/tooltip/index.ts
+++ b/__tests__/plots/tooltip/index.ts
@@ -58,3 +58,4 @@ export { aaplLineSliderFilter } from './appl-line-slider-filter';
 export { aaplLineAreaBasicSample } from './aapl-line-area-basic-sample';
 export { aaplAreaMissingDataTranspose } from './aapl-area-missing-data-transpose';
 export { alphabetIntervalBrushTooltip } from './alphabet-interval-brush-tooltip';
+export { mockLineFalsy } from './mock-line-falsy';

--- a/__tests__/plots/tooltip/london-tube-lines-geo.ts
+++ b/__tests__/plots/tooltip/london-tube-lines-geo.ts
@@ -22,6 +22,7 @@ export async function londonTubeLineGeo(): Promise<G2Spec> {
     width: 700,
     height: 500,
     padding: 10,
+    interaction: { tooltip: { filter: (d) => d.value !== null } },
     children: [
       {
         type: 'geoPath',

--- a/__tests__/plots/tooltip/mock-line-falsy.ts
+++ b/__tests__/plots/tooltip/mock-line-falsy.ts
@@ -1,0 +1,48 @@
+import { G2Spec } from '../../../src';
+import { seriesTooltipSteps } from './utils';
+
+export function mockLineFalsy(): G2Spec {
+  return {
+    type: 'line',
+    data: [
+      {
+        city: '杭州',
+        value: 400,
+      },
+      {
+        city: '上海',
+        value: 300,
+      },
+      {
+        city: '北京',
+        value: null,
+      },
+      {
+        city: '河北',
+        value: 0,
+      },
+      {
+        city: '苏州',
+        value: 500,
+      },
+      {
+        city: '海南',
+        value: undefined,
+      },
+      {
+        city: '成都',
+        value: 400,
+      },
+      {
+        city: '重庆',
+        value: 200,
+      },
+    ],
+    encode: {
+      x: 'city',
+      y: 'value',
+    },
+  };
+}
+
+mockLineFalsy.steps = seriesTooltipSteps([200, 300], [275, 300], [420, 300]);

--- a/src/interaction/tooltip.ts
+++ b/src/interaction/tooltip.ts
@@ -102,6 +102,11 @@ function destroyTooltip(root) {
   }
 }
 
+function showUndefined(item) {
+  const { value } = item;
+  return { ...item, value: value === undefined ? 'undefined' : value };
+}
+
 function singleItem(element) {
   const { __data__: datum } = element;
   const { title, items = [] } = datum;
@@ -110,7 +115,8 @@ function singleItem(element) {
     .map(({ color = itemColorOf(element), ...item }) => ({
       ...item,
       color,
-    }));
+    }))
+    .map(showUndefined);
   return {
     ...(title && { title }),
     items: newItems,
@@ -164,22 +170,24 @@ function groupItems(
     data.map((d) => d.title),
     key,
   ).filter(defined);
-  const newItems = data.flatMap((datum, i) => {
-    const element = elements[i];
-    const { items = [], title } = datum;
-    return items
-      .filter(defined)
-      .map(({ color = itemColorOf(element), name, ...item }) => {
-        const name1 = groupName
-          ? groupNameOf(scale, datum) || name
-          : name || groupNameOf(scale, datum);
-        return {
-          ...item,
-          color,
-          name: name1 || title,
-        };
-      });
-  });
+  const newItems = data
+    .flatMap((datum, i) => {
+      const element = elements[i];
+      const { items = [], title } = datum;
+      return items
+        .filter(defined)
+        .map(({ color = itemColorOf(element), name, ...item }) => {
+          const name1 = groupName
+            ? groupNameOf(scale, datum) || name
+            : name || groupNameOf(scale, datum);
+          return {
+            ...item,
+            color,
+            name: name1 || title,
+          };
+        });
+    })
+    .map(showUndefined);
   return {
     ...(T.length > 0 && { title: T.join(',') }),
     items: unique(newItems, (d) => `(${key(d.name)}, ${key(d.value)})`),

--- a/src/runtime/transform.ts
+++ b/src/runtime/transform.ts
@@ -170,13 +170,11 @@ export function extractTooltip(
           : definedChannel
           ? encode[channel].value[i]
           : null;
-        if (value1) {
-          values[i] = {
-            name: name1,
-            color,
-            value: normalizedValueFormatter(value1),
-          };
-        }
+        values[i] = {
+          name: name1,
+          color,
+          value: normalizedValueFormatter(value1),
+        };
       }
       return values;
     }


### PR DESCRIPTION
fix https://github.com/antvis/G2/issues/4891 ，目前 tooltip items 不会自动过滤 falsy 的值：

- null
- undefined
- NaN
- 0

如果希望过滤这些值，可以通过自定义 filter 函数：

```js
chart.interaction('tooltip', {
  filter: (d) =>
    d.value !== null && d.value !== undefined && !Number.isNaN(d.value),
});
```