### PR TITLE
fix: chart.theme as unrequired params

### DIFF
--- a/__tests__/plots/api/chart-options.ts
+++ b/__tests__/plots/api/chart-options.ts
@@ -4,12 +4,12 @@ export function chartOptions(context) {
   const { container, canvas } = context;
 
   const chart = new Chart({
-    theme: 'classic',
     container,
     canvas,
   });
 
   chart.options({
+    theme: 'classic',
     type: 'line',
     clip: true,
     data: {

--- a/src/api/chart.ts
+++ b/src/api/chart.ts
@@ -130,7 +130,7 @@ export type ChartOptions = ViewComposition & {
   autoFit?: boolean;
   renderer?: CanvasRenderer;
   plugins?: RendererPlugin[];
-  theme: string;
+  theme?: string;
 };
 
 type ChartProps = Concrete<ViewComposition>;


### PR DESCRIPTION
#### 描述
theme 属性支持在 `chart.options()` 里申明：
```js
const chart = new Chart({ container });

chart.options({
  theme: 'classic',
  type: 'line',
  clip: true,
  data: {
    type: 'fetch',
    value: 'data/aapl.csv',
  },
  encode: {
    x: 'date',
    y: 'close',
  },
});

chart.render();
```