### PR TITLE
feat: chart bind autoFit in render

### DIFF
--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -619,4 +619,38 @@ describe('Chart', () => {
     expect(chart.width()).toBeUndefined();
     expect(chart.height()).toBeUndefined();
   });
+
+  it('chart.options({ autoFit: true }) should bind autoFit.', async () => {
+    const div = document.createElement('div');
+    const chart = new Chart({
+      container: div,
+    });
+    chart.options({
+      autoFit: true,
+      theme: 'classic',
+      type: 'interval',
+      encode: {
+        x: 'genre',
+        y: 'sold',
+      },
+      data: [
+        { genre: 'Sports', sold: 275 },
+        { genre: 'Strategy', sold: 115 },
+        { genre: 'Action', sold: 120 },
+        { genre: 'Shooter', sold: 350 },
+        { genre: 'Other', sold: 150 },
+      ],
+    });
+
+    expect(chart['_hasBindAutoFit']).toBe(false);
+
+    await chart.render();
+    expect(chart['_hasBindAutoFit']).toBe(true);
+
+    chart.options({
+      autoFit: false,
+    });
+    await chart.render();
+    expect(chart['_hasBindAutoFit']).toBe(false);
+  });
 });

--- a/src/api/chart.ts
+++ b/src/api/chart.ts
@@ -178,6 +178,8 @@ export class Chart extends View<ChartOptions> {
   private _options: G2ViewTree;
   private _width: number;
   private _height: number;
+  // Identifies whether bindAutoFit.
+  private _hasBindAutoFit = false;
 
   constructor(options: ChartOptions) {
     const { container, canvas, ...rest } = options || {};
@@ -185,10 +187,11 @@ export class Chart extends View<ChartOptions> {
     this._container = normalizeContainer(container);
     this._emitter = new EventEmitter();
     this._context = { library, emitter: this._emitter, canvas };
-    this._bindAutoFit();
   }
 
   render(): Promise<Chart> {
+    this._bindAutoFit();
+
     if (!this._context.canvas) {
       // Init width and height.
       const { renderer, plugins } = this.options();
@@ -339,15 +342,22 @@ export class Chart extends View<ChartOptions> {
   private _bindAutoFit() {
     const options = this.options();
     const { autoFit } = options;
+
+    if (this._hasBindAutoFit) {
+      // If it was bind before, unbind it now.
+      if (!autoFit) this._unbindAutoFit();
+      return;
+    }
+
     if (autoFit) {
+      this._hasBindAutoFit = true;
       window.addEventListener('resize', this._onResize);
     }
   }
 
   private _unbindAutoFit() {
-    const options = this.options();
-    const { autoFit } = options;
-    if (autoFit) {
+    if (this._hasBindAutoFit) {
+      this._hasBindAutoFit = false;
       window.removeEventListener('resize', this._onResize);
     }
   }


### PR DESCRIPTION
#### 问题描述
在 `Chart.options` 中申明 autoFit 属性无法正常绑定 onResize 事件。因为该事件绑定在 Chart 的初始化中进行，此时拿不到 autoFit 属性。
修改方式：将 `bindAutoFit` 方法放在 render 函数中执行。

```js
import { Chart } from "@antv/g2";

const chart = new Chart({ container: "container" });

chart.options({
  type: "interval",
  theme: "classic",
  autoFit: true,
  data: {
    type: "fetch",
    value:
      "https://gw.alipayobjects.com/os/bmw-prod/fb9db6b7-23a5-4c23-bbef-c54a55fee580.csv",
  },
  encode: { x: "letter", y: "frequency" },
  axis: { y: { labelFormatter: ".0%" } },
});

chart.render();
```