### PR TITLE
feat: add interactive on label config

### DIFF
--- a/src/shape/text/advance.ts
+++ b/src/shape/text/advance.ts
@@ -140,6 +140,7 @@ export const Advance = createElement((g) => {
     startMarker,
     endMarker,
     coordCenter,
+    interactive = true,
     ...rest
   } = g.attributes as TextShapeStyleProps;
   const { padding, ...backgroundStyle } = subObject(rest, 'background');
@@ -148,6 +149,10 @@ export const Advance = createElement((g) => {
     [+x0, +y0],
     [+x, +y],
   ];
+
+  // Response event, default is `true`.
+  g.interactive = interactive;
+
   const shape1 = select(g)
     .maybeAppend('text', 'text')
     .style('zIndex', 0)


### PR DESCRIPTION
fixed #4757

```ts
.label({
  text: 'value',
  position: 'inside',
  formatter: (v) => (v ? `${v}%` : ''),
  transform: [{ type: 'overlapDodgeY' }],
  interactive: false, // 👈🏻 加上这行，保证数据标签不响应事件
  style: {
    fill: '#000',
    fontSize: 10,
    interactive: false,
  },
})
```