### PR TITLE
fix: chart clear retain theme (fixed #5018)

### DIFF
--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -573,6 +573,28 @@ describe('Chart', () => {
     expect(chart.getGroup()).toEqual(null);
   });
 
+  it('chart.clear() should retain theme attribute', async () => {
+    const chart = new Chart({ theme: 'classic' });
+    chart.data([
+      { genre: 'Sports', sold: 275 },
+      { genre: 'Strategy', sold: 115 },
+      { genre: 'Action', sold: 120 },
+      { genre: 'Shooter', sold: 350 },
+      { genre: 'Other', sold: 150 },
+    ]);
+    chart
+      .interval()
+      .attr('key', 'interval')
+      .encode('x', 'genre')
+      .encode('y', 'sold')
+      .encode('color', 'genre');
+
+    await chart.render();
+
+    chart.clear();
+    expect(chart.options().theme).toEqual('classic');
+  });
+
   it('chart.clear() should clear group.', async () => {
     const chart = new Chart({ theme: 'classic' });
     chart.data([

--- a/src/api/chart.ts
+++ b/src/api/chart.ts
@@ -1,7 +1,7 @@
 import { IRenderer, RendererPlugin, Canvas as GCanvas } from '@antv/g';
 import { Renderer as CanvasRenderer } from '@antv/g-canvas';
 import { Plugin as DragAndDropPlugin } from '@antv/g-plugin-dragndrop';
-import { debounce, deepMix } from '@antv/util';
+import { debounce, deepMix, pick } from '@antv/util';
 import EventEmitter from '@antv/event-emitter';
 import { G2Context, render, destroy } from '../runtime';
 import { ViewComposition } from '../spec';
@@ -204,19 +204,25 @@ export class Chart extends View<ChartOptions> {
   }
 
   clear() {
+    const CLEAR_RETAIN_OPTIONS = [
+      'autoFit',
+      'container',
+      'theme',
+      'width',
+      'height',
+    ];
     const options = this.options();
     this.emit(ChartEvent.BEFORE_CLEAR);
-    this._options = {};
-    destroy(options, this._context, false);
+    this.options(pick(options, CLEAR_RETAIN_OPTIONS));
+    destroy(this._context, false);
     this.emit(ChartEvent.AFTER_CLEAR);
   }
 
   destroy() {
-    const options = this.options();
     this.emit(ChartEvent.BEFORE_DESTROY);
     this._unbindAutoFit();
     this._options = {};
-    destroy(options, this._context, true);
+    destroy(this._context, true);
     removeContainer(this._container);
     this.emit(ChartEvent.AFTER_DESTROY);
   }

--- a/src/runtime/render.ts
+++ b/src/runtime/render.ts
@@ -155,11 +155,7 @@ export function renderToMountedElement<T extends G2ViewTree = G2ViewTree>(
   return group;
 }
 
-export function destroy<T extends G2ViewTree = G2ViewTree>(
-  options: T,
-  context: G2Context = {},
-  isDestroyCanvas = false,
-) {
+export function destroy(context: G2Context = {}, isDestroyCanvas = false) {
   const { canvas, emitter } = context;
   if (canvas) {
     destroyAllInteractions(canvas);


### PR DESCRIPTION
issue: #5018 

- 问题描述：调用 `chart.clear()` 后报错 theme 找不到，无法继续调用 `chart.render()`
- 解决方法：clear 方法清空 options 时保存初始化的信息。