### PR TITLE
chore(dev): make @antv/gui linkable

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "dev": "vite",
+    "dev:link": "cross-env LINK=true vite",
     "clean": "rimraf lib esm dist",
     "lint-staged": "lint-staged",
     "size": "limit-size",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,29 @@
 import { defineConfig } from 'vite';
+import { deepMix } from '@antv/util';
 
-export default defineConfig({
-  root: './__tests__/',
-  server: {
-    port: 8080,
-    open: '/',
-  },
-});
+const linkOptions =
+  process.env.LINK === true
+    ? {
+        server: {
+          watch: {
+            ignored: ['!**/node_modules/@antv/gui/**'],
+          },
+        },
+        optimizeDeps: {
+          exclude: ['@antv/gui'],
+        },
+      }
+    : {};
+
+export default defineConfig(
+  deepMix(
+    {
+      root: './__tests__/',
+      server: {
+        port: 8080,
+        open: '/',
+      },
+    },
+    linkOptions,
+  ),
+);


### PR DESCRIPTION
# Link @antv/gui

让 GUI 可以本地 link 调试，link 了 GUI 之后，运行以下命令。

```js
npm run dev:link
```

- 开发的时候修改本地 GUI package.json 的 module 字段为 "./src/index.ts"。
- 测试的时候修改本地 GUI package.json 的 module 字段为 'esm/index.js'。


## 存在问题

- 无法调试：每次需要发布一个 GUI 版本看效果。
- 没有热更新：每次需要 build，然后再看效果。
