### PR TITLE
fix(chart): chart.forceFit rerender only when size changing

### DIFF
--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -681,4 +681,41 @@ describe('Chart', () => {
     await chart.render();
     expect(chart['_hasBindAutoFit']).toBe(false);
   });
+
+  it('chart.forceFit() should be not rerender if size of container do not change.', async () => {
+    const div = document.createElement('div');
+    div.style.width = '500px';
+    div.style.height = '400px';
+
+    const chart = new Chart({
+      theme: 'classic',
+      container: div,
+      autoFit: true,
+    });
+
+    chart
+      .interval()
+      .data([
+        { genre: 'Sports', sold: 275 },
+        { genre: 'Strategy', sold: 115 },
+        { genre: 'Action', sold: 120 },
+        { genre: 'Shooter', sold: 350 },
+        { genre: 'Other', sold: 150 },
+      ])
+      .encode('x', 'genre')
+      .encode('y', 'sold')
+      .encode('color', 'genre');
+
+    // Track chart render;
+    const fn = jest.fn();
+    const render = chart.render.bind(chart);
+    chart.render = () => {
+      fn();
+      return render();
+    };
+    await chart.render();
+
+    await chart.forceFit();
+    expect(fn).toBeCalledTimes(1);
+  });
 });

--- a/src/api/chart.ts
+++ b/src/api/chart.ts
@@ -222,9 +222,14 @@ export class Chart extends View<ChartOptions> {
   }
 
   forceFit() {
+    // Don't fit if size do not change.
+    this.options['autoFit'] = true;
+    const { width, height } = sizeOf(this.options(), this._container);
+    if (width === this._width && height === this._height) {
+      return Promise.resolve(this);
+    }
+
     // Don't call changeSize to prevent update width and height of options.
-    // @ts-ignore
-    this.options.autoFit = true;
     this.emit(ChartEvent.BEFORE_CHANGE_SIZE);
     const finished = this.render();
     finished.then(() => {


### PR DESCRIPTION
当容器大小没有发生变化的时候，调用 `chart.forceFit` 不会重新渲染。