### PR TITLE
fix(brush): handle brush:highlight once when emit

### DIFF
--- a/__tests__/integration/api-chart-render-brush-end.spec.ts
+++ b/__tests__/integration/api-chart-render-brush-end.spec.ts
@@ -10,18 +10,24 @@ describe('chart.render', () => {
       canvas,
       container: document.createElement('div'),
     });
+    chart.off();
+
+    const end = jest.fn();
+    const start = jest.fn();
+    chart.on('brush:highlight', () => {
+      start();
+    });
+    chart.on('brush:end', () => {
+      end();
+    });
     await finished;
     await sleep(20);
 
-    chart.off();
-    const fn = jest.fn();
-    chart.on('brush:end', () => {
-      fn();
-    });
     button.dispatchEvent(new CustomEvent('click'));
     await rerendered;
     await sleep(20);
-    expect(fn).toBeCalledTimes(0);
+    expect(start).toBeCalledTimes(1);
+    expect(end).toBeCalledTimes(0);
   });
 
   afterAll(() => {

--- a/__tests__/unit/api/options.spec.ts
+++ b/__tests__/unit/api/options.spec.ts
@@ -1,0 +1,22 @@
+import { Chart } from '../../../src';
+
+describe('API and Options', () => {
+  it('', () => {
+    const chart = new Chart({});
+
+    chart.options({
+      type: 'interval',
+      data: [
+        { genre: 'Sports', sold: 275 },
+        { genre: 'Strategy', sold: 115 },
+        { genre: 'Action', sold: 120 },
+        { genre: 'Shooter', sold: 350 },
+        { genre: 'Other', sold: 150 },
+      ],
+      encode: {
+        x: 'genre',
+        y: 'sold',
+      },
+    });
+  });
+});


### PR DESCRIPTION
- 问题：初始化，触发 emit 'brush:highlight', 会触发两次 highlight。
- 解决办法： brush.move 判断是否需要触发事件。