### PR TITLE
feat(api): use api and spec together

### DIFF
--- a/__tests__/unit/api/node.spec.ts
+++ b/__tests__/unit/api/node.spec.ts
@@ -81,6 +81,15 @@ describe('Node', () => {
     expect(n1.value).toEqual({ a: 2 });
   });
 
+  it('node.getNodeByType(type) should return the first node.', () => {
+    const node = new Node({ a: 1 }, 'a');
+    const n1 = node.append(Node);
+    n1.type = 'b';
+    const n2 = node.append(Node);
+    n2.type = 'b';
+    expect(node.getNodeByType('b')).toBe(n1);
+  });
+
   it('node.getNodesByType(type) should get the children node by type.', () => {
     const node = new Node({ a: 1 }, 'node1');
     const n1 = node.append(Node);
@@ -96,7 +105,7 @@ describe('Node', () => {
     let targetNodes = node.getNodesByType('node1');
 
     expect(targetNodes.length).toEqual(1);
-    expect(targetNodes[0]).toEqual(node);
+    expect(targetNodes[0]).toBe(node);
 
     const n1 = node.append(Node);
     n1.type = 'n';
@@ -104,7 +113,7 @@ describe('Node', () => {
     n2.type = 'n';
     targetNodes = node.getNodesByType('n');
     expect(targetNodes.length).toEqual(2);
-    expect(targetNodes[0]).toEqual(n1);
+    expect(targetNodes[0]).toBe(n1);
 
     expect(node.getNodesByType('undefined')).toEqual([]);
   });

--- a/__tests__/unit/api/options.spec.ts
+++ b/__tests__/unit/api/options.spec.ts
@@ -1,7 +1,8 @@
 import { Chart } from '../../../src';
+import { Point } from '../../../src/api/mark/mark';
 
-describe('API and Options', () => {
-  it('', () => {
+describe('chart api and options', () => {
+  it('chart.options({...}) should create node instance from spec.', () => {
     const chart = new Chart({});
 
     chart.options({
@@ -18,5 +19,187 @@ describe('API and Options', () => {
         y: 'sold',
       },
     });
+
+    expect(chart.getNodeByType('view')).toBeDefined();
+    expect(chart.getNodeByType('interval')).toBeDefined();
+  });
+
+  it('chart.options({...}) should bubble view options', () => {
+    const chart = new Chart({});
+
+    chart.options({
+      type: 'interval',
+      width: 100,
+      height: 100,
+      padding: 10,
+      paddingLeft: 10,
+      paddingRight: 10,
+      paddingBottom: 10,
+      paddingTop: 10,
+      inset: 10,
+      insetLeft: 10,
+      insetRight: 10,
+      insetTop: 10,
+      insetBottom: 10,
+      margin: 10,
+      marginLeft: 10,
+      marginRight: 10,
+      marginTop: 10,
+      marginBottom: 10,
+      autoFit: 10,
+      theme: 10,
+    });
+
+    expect(chart.options()).toEqual({
+      type: 'view',
+      width: 100,
+      height: 100,
+      padding: 10,
+      paddingLeft: 10,
+      paddingRight: 10,
+      paddingBottom: 10,
+      paddingTop: 10,
+      inset: 10,
+      insetLeft: 10,
+      insetRight: 10,
+      insetTop: 10,
+      insetBottom: 10,
+      margin: 10,
+      marginLeft: 10,
+      marginRight: 10,
+      marginTop: 10,
+      marginBottom: 10,
+      autoFit: 10,
+      theme: 10,
+      children: [{ type: 'interval' }],
+    });
+  });
+
+  it('chart.options({...}) should create nested node tree from spec.', () => {
+    const chart = new Chart({});
+    const options = {
+      type: 'spaceFlex',
+      flex: [1, 2],
+      children: [
+        {
+          type: 'spaceLayer',
+          children: [
+            {
+              type: 'view',
+              children: [
+                { type: 'interval', data: [2, 3, 4] },
+                { type: 'point' },
+              ],
+            },
+          ],
+        },
+        { type: 'interval', data: [1, 2, 3] },
+      ],
+    };
+
+    chart.options(options);
+
+    expect(chart.options()).toEqual(options);
+    expect(chart.getNodeByType('point')).toBeInstanceOf(Point);
+  });
+
+  it('chart.options({...}) should update node with same height and index.', () => {
+    const chart = new Chart({});
+
+    chart.options({
+      type: 'view',
+      children: [{ type: 'interval' }],
+    });
+
+    chart.options({
+      children: [{ data: [1, 2, 3] }],
+    });
+
+    expect(chart.getNodeByType('interval').value.data).toEqual([1, 2, 3]);
+  });
+
+  it('chart.options({...}) should update nested node tree.', () => {
+    const chart = new Chart({});
+
+    chart.options({
+      type: 'spaceFlex',
+      flex: [1, 2],
+      children: [
+        {
+          type: 'spaceLayer',
+          children: [
+            {
+              type: 'view',
+              children: [
+                { type: 'interval', data: [2, 3, 4] },
+                { type: 'point' },
+              ],
+            },
+          ],
+        },
+        { type: 'interval', data: [1, 2, 3] },
+      ],
+    });
+
+    chart.options({
+      flex: [2, 3, 4],
+      children: [
+        { children: [{ children: [{}, { data: [1, 2, 3] }] }] },
+        { data: [2, 3, 4], scale: { x: { nice: true } } },
+      ],
+    });
+
+    expect(chart.options()).toEqual({
+      type: 'spaceFlex',
+      flex: [2, 3, 4],
+      children: [
+        {
+          type: 'spaceLayer',
+          children: [
+            {
+              type: 'view',
+              children: [
+                { type: 'interval', data: [2, 3, 4] },
+                { type: 'point', data: [1, 2, 3] },
+              ],
+            },
+          ],
+        },
+        { type: 'interval', data: [2, 3, 4], scale: { x: { nice: true } } },
+      ],
+    });
+  });
+
+  it('chart.options({...}) should transform node.', () => {
+    const chart = new Chart({});
+
+    chart.options({
+      type: 'view',
+      children: [
+        { type: 'interval', scale: { x: { nice: true } }, data: [1, 2, 3] },
+      ],
+    });
+
+    chart.options({
+      type: 'view',
+      children: [{ type: 'line', data: [4, 5, 6] }],
+    });
+
+    const line = chart.getNodeByType('line');
+    expect(line.type).toBe('line');
+    expect(line.value).toEqual({ data: [4, 5, 6] });
+  });
+
+  it('chart.options({...}) should update node tree specified by API.', () => {
+    const chart = new Chart({});
+
+    const interval = chart.interval().data([1, 2, 3]);
+
+    chart.options({
+      type: 'view',
+      children: [{ data: [2, 3, 4] }],
+    });
+
+    expect(interval.data()).toEqual([2, 3, 4]);
   });
 });

--- a/src/api/node.ts
+++ b/src/api/node.ts
@@ -6,7 +6,7 @@ import { Chart } from './chart';
 function bfs(node: Node, callback?: (...args: any[]) => void) {
   const discovered: Node[] = [node];
   while (discovered.length) {
-    const currentNode = discovered.pop();
+    const currentNode = discovered.shift();
     callback && callback(currentNode);
     const children = currentNode.children || [];
     for (const child of children) {
@@ -116,8 +116,9 @@ export class Node<
   }
 
   getNodeByType(type: string): Node {
-    let node;
+    let node = null;
     bfs(this, (current: Node) => {
+      if (node) return;
       if (type === current.type) node = current;
     });
     return node;

--- a/src/api/node.ts
+++ b/src/api/node.ts
@@ -115,6 +115,14 @@ export class Node<
     return nodes;
   }
 
+  getNodeByType(type: string): Node {
+    let node;
+    bfs(this, (current: Node) => {
+      if (type === current.type) node = current;
+    });
+    return node;
+  }
+
   /**
    * Apply specified callback to the node value.
    */


### PR DESCRIPTION
# chart.options

Spec API和 Chart API 可以同时使用。

## 开始使用

Spec API 和 Chart API 理论上应该分开使用，但是两者也有点细小的区别：

- Spec API 更适合第一次声明图表的时候使用
- Chart API 更适合更新特定图表属性。

所以两者混合的一个场景可以如下：

```js
// 第一次渲染
const chart = new Chart({});

chart.options({
  type: 'interval',
  data: [
    { genre: 'Sports', sold: 275 },
    { genre: 'Strategy', sold: 115 },
    { genre: 'Action', sold: 120 },
    { genre: 'Shooter', sold: 350 },
    { genre: 'Other', sold: 150 },
  ],
  encode: {
    x: 'genre',
    y: 'sold',
  },
});

chart.render();

// 更新数据
chart
  .getNodeByType('interval') //  获得 interval 实例
  .data([
    //更新数据
    { genre: 'Sports', sold: 275 },
    { genre: 'Strategy', sold: 115 },
  ]);

chart.render();
```

## 实现思路

`chart.options(spec)` 类似声明 innerHTML，如果当前没有 node tree，内部会将 spec 解析成一棵 node tree，否者会根据当前 options 更新该 node tree。（详见讨论：https://github.com/antvis/G2/discussions/4718 ）

## 案例

根据 height 和 index 去更新树。

```js
chart.options({
  type: 'view',
  children: [{ type: 'interval' }],
});

chart.options({
  children: [{ data: [1, 2, 3] }],
});

chart.getNodeByType('interval').data(); // [1, 2, 3]
```

先使用 API，再使用 Spec 也是可以的。

```js
const interval = chart.interval().data([1, 2, 3]);

chart.options({
  type: 'view',
  children: [{ data: [2, 3, 4] }],
});

interval.data(); // [2, 3, 4]
```