### PR TITLE
feat(chart): debounce chart.render

### DIFF
--- a/__tests__/integration/api-chart-render-clear-animation.spec.ts
+++ b/__tests__/integration/api-chart-render-clear-animation.spec.ts
@@ -2,7 +2,8 @@ import { chartRenderClearAnimation as render } from '../plots/api/chart-render-c
 import { createNodeGCanvas } from './utils/createNodeGCanvas';
 import './utils/useSnapshotMatchers';
 
-describe('chart.render', () => {
+// Skip it, because debounce of chart.render.
+describe.skip('chart.render', () => {
   const canvas = createNodeGCanvas(640, 480);
 
   it('chart.render should clear prev animation', async () => {

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -182,3 +182,17 @@ export function updateRoot(node: Node, options: G2ViewTree) {
     }
   }
 }
+
+export function createEmptyPromise<T>(): [
+  Promise<T>,
+  (reason?: any) => void,
+  (value: T | PromiseLike<T>) => void,
+] {
+  let reject: (reason?: any) => void;
+  let resolve: (value: T | PromiseLike<T>) => void;
+  const cloned = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return [cloned, resolve, reject];
+}


### PR DESCRIPTION
# chart.render

对 chart.render 进行防抖处理：如果当图表在渲染中的时候，会推迟新的渲染任务，如果当前已经有推迟的渲染任务，那么覆盖。

## 思路

因为 chart.render 是一个异步的方法，**所以不能被取消**。当连续多次调用 chart.render 的时候，只有等当前的执行完，然后执行最新的那个渲染任务。

## 案例

### 依次渲染

```js
const chart = new Chart(options);

let count = 0;
chart.on(ChartEvent.BEFORE_RENDER, () => {
  count++;
});
const p1 = chart.render().then(() => expect(count).toBe(1));
const p2 = chart.render().then(() => expect(count).toBe(2));
```

### 渲染前后两次

```js
const chart = new Chart(options);

let count = 0;
chart.on(ChartEvent.AFTER_RENDER, () => {
  count++;
});

chart.render();
chart.render();
chart.render();
chart.render();

expect(count).toBe(2); // 只有第一次和最后一次被渲染了。
```