### PR TITLE
fix(site): disable css parsing

### DIFF
--- a/__tests__/unit/g/index.spec.ts
+++ b/__tests__/unit/g/index.spec.ts
@@ -1,0 +1,8 @@
+import '../../../src';
+import { runtime } from '@antv/g';
+
+describe('g.runtime.enableCSSParsing', () => {
+  it('should disable enableCSSParsing for g when import.', () => {
+    expect(runtime.enableCSSParsing).toBe(false);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
+import { runtime } from '@antv/g';
+
+runtime.enableCSSParsing = false;
+
 export {
   render,
   renderToMountedElement,
@@ -10,8 +14,13 @@ export {
   LABEL_CLASS_NAME,
   AREA_CLASS_NAME,
 } from './runtime';
+
 export type { G2Context } from './runtime';
+
 export { createLibrary } from './stdlib';
+
 export { Chart, MarkNode, CompositionNode, register } from './api';
-export * from './spec';
+
 export { ChartEvent } from './utils/event';
+
+export * from './spec';


### PR DESCRIPTION
# CSS Parsing

在 G2 代码里禁用 G 的 CSS Parsing 的能力。

## 存在问题

之前是在 GUI 里面禁用的，但是官网不知道设置失效（可能和打包顺序有关系），导致官网报错：

![image](https://github.com/antvis/G2/assets/49330279/ff8eb984-a3d8-4d7c-ae87-ea9de4007ae3)

## 解决办法

G2 的 index.ts 中显示指定为 false，这个 PR 合并之后需要重新部署官网。