### PR TITLE
chore: update to 5.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # G2 - Changelog
 
+## [5.0.10](https://github.com/antvis/g2/compare/5.0.9...5.0.10) (2023-05-25)
+
+### Bug Fixes
+
+- **site:** disable css parsing ([#5091](https://github.com/antvis/g2/issues/5091)) ([c21787f](https://github.com/antvis/g2/commit/c21787ffcef4600b7a24f7fb88189511c495b71b))
+
 ## [5.0.9](https://github.com/antvis/g2/compare/5.0.8...5.0.9) (2023-05-25)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2",
-  "version": "5.0.9",
+  "version": "5.0.10",
   "description": "the Grammar of Graphics in Javascript",
   "license": "MIT",
   "main": "lib/index.js",

--- a/site/package.json
+++ b/site/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.9",
+  "version": "5.0.10",
   "scripts": {
     "start": "dumi dev",
     "build": "dumi build",


### PR DESCRIPTION
这里的问题 https://github.com/antvis/G2/pull/5091 造成线上版本也有问题。