### PR TITLE
chore: show treeshaking effects via bundle analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ site/.dumi/tmp-production
 
 # Editor
 .vscode
+
+# Bundle analyzer
+analyse.html

--- a/__tests__/treeshaking/index.html
+++ b/__tests__/treeshaking/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>G2: Preview</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/__tests__/treeshaking/index.html
+++ b/__tests__/treeshaking/index.html
@@ -6,7 +6,7 @@
     <title>G2: Preview</title>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="container"></div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/__tests__/treeshaking/main.ts
+++ b/__tests__/treeshaking/main.ts
@@ -1,4 +1,4 @@
-import { Chart } from '../../src';
+import { Chart } from '../../esm';
 
 const $container = document.getElementById('app')!;
 const chart = new Chart({ theme: 'classic', container: $container });

--- a/__tests__/treeshaking/main.ts
+++ b/__tests__/treeshaking/main.ts
@@ -1,7 +1,6 @@
 import { Chart } from '../../esm';
 
-const $container = document.getElementById('app')!;
-const chart = new Chart({ theme: 'classic', container: $container });
+const chart = new Chart({ theme: 'classic', container: 'container' });
 
 chart.data([
   { genre: 'Sports', sold: 275 },

--- a/__tests__/treeshaking/main.ts
+++ b/__tests__/treeshaking/main.ts
@@ -1,0 +1,20 @@
+import { Chart } from '../../src';
+
+const $container = document.getElementById('app')!;
+const chart = new Chart({ theme: 'classic', container: $container });
+
+chart.data([
+  { genre: 'Sports', sold: 275 },
+  { genre: 'Strategy', sold: 115 },
+  { genre: 'Action', sold: 120 },
+  { genre: 'Shooter', sold: 350 },
+  { genre: 'Other', sold: 150 },
+]);
+
+chart
+  .interval()
+  .encode('x', 'genre')
+  .encode('y', 'sold')
+  .encode('color', 'genre');
+
+chart.render();

--- a/__tests__/treeshaking/vite.config.js
+++ b/__tests__/treeshaking/vite.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import { visualizer } from 'rollup-plugin-visualizer';
+
+export default defineConfig({
+  root: './__tests__/treeshaking',
+  server: {
+    port: 8081,
+    open: '/',
+  },
+  plugins: [
+    visualizer({
+      template: 'treemap', // or sunburst
+      open: true,
+      gzipSize: true,
+      brotliSize: true,
+      filename: 'analyse.html', // will be saved in project's root
+    }),
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "node --expose-gc --max-old-space-size=4096 --unhandled-rejections=strict node_modules/jest/bin/jest __tests__/ --coverage -i  --logHeapUsage",
     "test:unit": "node --expose-gc --max-old-space-size=4096 --unhandled-rejections=strict node_modules/jest/bin/jest __tests__/unit/ --coverage -i  --logHeapUsage",
     "test:integration": "node --expose-gc --max-old-space-size=4096 --unhandled-rejections=strict node_modules/jest/bin/jest __tests__/integration/ --coverage -i  --logHeapUsage",
+    "test:treeshaking": "vite build -c ./__tests__/treeshaking/vite.config.js",
     "test-live": "cross-env DEBUG_MODE=1 jest --watch",
     "build:umd": "rimraf ./dist && rollup -c && npm run size",
     "build:cjs": "rimraf ./lib && tsc --module commonjs --outDir lib",


### PR DESCRIPTION
为了验证使用 G2 的项目是否能够享受 treeshaking 特性。在 `__tests__/treeshaking` 下创建了一个测试项目（依赖构建后的 esm），使用 rollup-plugin-visualizer 验证效果：

```bash
$ npm run build
$ npm run test:treeshaking
```

执行后会在根目录下生成一个 `analyser.html` 文件：

<img width="1837" alt="截屏2023-05-25 下午5 47 36" src="https://github.com/antvis/G2/assets/3608471/c141d9a5-c2f2-43d1-83b7-84049644e658">