### PR TITLE
fix(event): there is no target for pointerupoutside event

### DIFF
--- a/__tests__/integration/api-chart-on-item-element.spec.ts
+++ b/__tests__/integration/api-chart-on-item-element.spec.ts
@@ -108,13 +108,10 @@ describe('chart.on', () => {
     await fired;
   });
 
-  it('chart.on("interval:pointerupoutside", callback) should provide datum for item element', async () => {
+  it('chart.on("plot:pointerupoutside", callback) should provide datum for item element', async () => {
     await finished;
     const [fired, resolve] = createPromise();
-    chart.on(
-      `interval:${ChartEvent.POINTER_UPOUTSIDE}`,
-      receiveExpectData(resolve),
-    );
+    chart.on(`plot:${ChartEvent.POINTER_UPOUTSIDE}`, resolve);
     dispatchFirstElementEvent(canvas, 'pointerupoutside');
     await fired;
   });

--- a/__tests__/plots/api/chart-on-item-element.ts
+++ b/__tests__/plots/api/chart-on-item-element.ts
@@ -35,7 +35,7 @@ export function chartOnItemElement(context) {
   chart.on('interval:pointermove', log('interval:pointermove'));
   chart.on('interval:pointerenter', log('interval:pointerenter'));
   chart.on('interval:pointerleave', log('interval:pointerleave'));
-  chart.on('interval:pointerupoutside', log('interval:pointerupoutside'));
+  chart.on('plot:pointerupoutside', () => console.log('plot:pointerupoutside'));
 
   chart.on('interval:dragstart', log('interval:dragstart'));
   chart.on('interval:drag', log('interval:drag'));

--- a/src/interaction/event.ts
+++ b/src/interaction/event.ts
@@ -17,11 +17,16 @@ export function dataOf(element, view) {
 function bubblesEvent(eventType, view, emitter, predicate = (event) => true) {
   return (e) => {
     if (!predicate(e)) return;
-    const { target } = e;
-    const { className: elementType, markType } = target;
 
     // Emit plot events.
     emitter.emit(`plot:${eventType}`, e);
+
+    const { target } = e;
+
+    // There is no target for pointerupoutside event if out of canvas.
+    if (!target) return;
+
+    const { className: elementType, markType } = target;
 
     // If target area is plot area, do not emit extra events.
     if (elementType === 'plot') return;


### PR DESCRIPTION
`pointerupoutside` 这个事件没有 target 对象，`chart.emit` 需要注意。

![image](https://github.com/antvis/G2/assets/49330279/4aeca73c-8fb3-43e7-8d38-a7757a8629a5)
