### PR TITLE
fix(chart): chart.options should remove node

### DIFF
--- a/__tests__/unit/api/options.spec.ts
+++ b/__tests__/unit/api/options.spec.ts
@@ -241,4 +241,23 @@ describe('chart api and options', () => {
 
     expect(interval.data()).toEqual([2, 3, 4]);
   });
+
+  it('chart.options({...}) should remove node.', () => {
+    const chart = new Chart({});
+
+    chart.options({
+      type: 'view',
+      children: [{ type: 'line' }, { type: 'point' }],
+    });
+
+    chart.options({
+      type: 'view',
+      children: [{ type: 'line' }],
+    });
+
+    expect(chart.options()).toEqual({
+      type: 'view',
+      children: [{ type: 'line' }],
+    });
+  });
 });

--- a/src/api/node.ts
+++ b/src/api/node.ts
@@ -74,10 +74,15 @@ export class Node<
   ): Node<ChildValue, Value> {
     const node = new Ctor({});
     node.children = [];
+    this.push(node);
+    return node;
+  }
+
+  push(node: Node<ChildValue, Value>): this {
     node.parentNode = this;
     node.index = this.children.length;
     this.children.push(node);
-    return node;
+    return this;
   }
 
   /**

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -151,7 +151,7 @@ function appendNode(parent: Node, newOptions: G2ViewTree) {
   while (discovered.length) {
     const [parent, nodeOptions] = discovered.shift();
     const node = createNode(nodeOptions);
-    if (Array.isArray(parent.children)) parent.children.push(node);
+    if (Array.isArray(parent.children)) parent.push(node);
     const { children } = nodeOptions;
     if (Array.isArray(children)) {
       for (const child of children) {
@@ -174,6 +174,8 @@ export function updateRoot(
     // If there is no oldNode, create a node tree directly.
     if (!oldNode) {
       appendNode(parent, newNode);
+    } else if (!newNode) {
+      oldNode.remove();
     } else {
       updateNode(oldNode, newNode);
       const { children: newChildren } = newNode;
@@ -181,7 +183,8 @@ export function updateRoot(
       if (Array.isArray(newChildren) && Array.isArray(oldChildren)) {
         // Only update node specified in newChildren,
         // the extra oldChildren will remain still.
-        for (let i = 0; i < newChildren.length; i++) {
+        const n = Math.max(newChildren.length, oldChildren.length);
+        for (let i = 0; i < n; i++) {
           const newChild = newChildren[i];
           const oldChild = oldChildren[i];
           discovered.push([oldNode, oldChild, newChild]);


### PR DESCRIPTION
修复 chart.options 不能删除节点的问题：

```js
const chart = new Chart({});

chart.options({
  type: 'view',
  children: [{ type: 'line' }, { type: 'point' }],
});

chart.options({
  type: 'view',
  children: [{ type: 'line' }],
});

expect(chart.options()).toEqual({
  type: 'view',
  children: [{ type: 'line' }],
});
```