### PR TITLE
feat: tooltip interaction emit events when body hide

### DIFF
--- a/__tests__/integration/api-chart-emit-item-tooltip-hide-content.spec.ts
+++ b/__tests__/integration/api-chart-emit-item-tooltip-hide-content.spec.ts
@@ -1,0 +1,20 @@
+import { chartEmitItemTooltipHideContent as render } from '../plots/api/chart-emit-item-tooltip-hide-content';
+import './utils/useSnapshotMatchers';
+import { sleep } from './utils/sleep';
+import { createDOMGCanvas } from './utils/createDOMGCanvas';
+
+describe('chart.emit', () => {
+  const canvas = createDOMGCanvas(800, 500);
+
+  it('chart.emit and chart.on should control item tooltip display.', async () => {
+    const { finished } = render({ canvas });
+    const dir = `${__dirname}/snapshots/api`;
+    await finished;
+    await sleep(20);
+    await expect(canvas).toMatchCanvasSnapshot(dir, render.name);
+  });
+
+  afterAll(() => {
+    canvas?.destroy();
+  });
+});

--- a/__tests__/integration/api-chart-emit-item-tooltip-hide-content.spec.ts
+++ b/__tests__/integration/api-chart-emit-item-tooltip-hide-content.spec.ts
@@ -1,17 +1,28 @@
 import { chartEmitItemTooltipHideContent as render } from '../plots/api/chart-emit-item-tooltip-hide-content';
 import './utils/useSnapshotMatchers';
-import { sleep } from './utils/sleep';
+import {
+  dispatchFirstElementEvent,
+  createPromise,
+  receiveExpectData,
+} from './utils/event';
 import { createDOMGCanvas } from './utils/createDOMGCanvas';
 
 describe('chart.emit', () => {
   const canvas = createDOMGCanvas(800, 500);
 
-  it('chart.emit and chart.on should control item tooltip display.', async () => {
-    const { finished } = render({ canvas });
-    const dir = `${__dirname}/snapshots/api`;
+  it('chart.tooltip hide body should emit events.', async () => {
+    const { finished, chart, clear } = render({
+      canvas,
+      container: document.createElement('div'),
+    });
     await finished;
-    await sleep(20);
-    await expect(canvas).toMatchCanvasSnapshot(dir, render.name);
+    clear();
+
+    // chart.on("tooltip:hide") should be called when hiding tooltip.
+    const [tooltipHided, resolveHide] = createPromise();
+    chart.on('tooltip:hide', receiveExpectData(resolveHide, null));
+    dispatchFirstElementEvent(canvas, 'pointerout');
+    await tooltipHided;
   });
 
   afterAll(() => {

--- a/__tests__/plots/api/chart-emit-item-tooltip-hide-content.ts
+++ b/__tests__/plots/api/chart-emit-item-tooltip-hide-content.ts
@@ -1,0 +1,71 @@
+import { Chart } from '../../../src';
+
+export function chartEmitItemTooltipHideContent(context) {
+  const { container, canvas } = context;
+
+  // wrapperDiv
+  const wrapperDiv = document.createElement('div');
+  container.appendChild(wrapperDiv);
+
+  // button
+  const button = document.createElement('button');
+  button.innerText = 'Hide tooltip';
+  container.appendChild(button);
+
+  // p
+  const p = document.createElement('p');
+  p.innerText = '';
+  container.appendChild(p);
+
+  const chart = new Chart({
+    theme: 'classic',
+    container: wrapperDiv,
+    canvas,
+  });
+
+  chart
+    .interval()
+    .data([
+      { genre: 'Sports', sold: 275 },
+      { genre: 'Strategy', sold: 115 },
+      { genre: 'Action', sold: 120 },
+      { genre: 'Shooter', sold: 350 },
+      { genre: 'Other', sold: 150 },
+    ])
+    .encode('x', 'genre')
+    .encode('y', 'sold')
+    .encode('color', 'genre')
+    .interaction('tooltip', {
+      body: false,
+    });
+
+  const finished = chart.render();
+
+  finished.then((chart) =>
+    chart.emit('tooltip:show', {
+      data: { data: { sold: 115 } },
+    }),
+  );
+
+  chart.on('tooltip:show', ({ data }) => {
+    p.innerText = JSON.stringify(data);
+  });
+
+  const hide = () => {
+    console.log('hide');
+  };
+  chart.on('tooltip:hide', hide);
+
+  button.onclick = () => {
+    chart.emit('tooltip:hide');
+  };
+
+  return {
+    chart,
+    button,
+    finished,
+    clear: () => {
+      chart.off('tooltip:hide', hide);
+    },
+  };
+}

--- a/__tests__/plots/api/chart-emit-item-tooltip-hide-content.ts
+++ b/__tests__/plots/api/chart-emit-item-tooltip-hide-content.ts
@@ -51,9 +51,8 @@ export function chartEmitItemTooltipHideContent(context) {
     p.innerText = JSON.stringify(data);
   });
 
-  const hide = () => {
-    console.log('hide');
-  };
+  const hide = () => (p.innerText = 'null');
+
   chart.on('tooltip:hide', hide);
 
   button.onclick = () => {

--- a/__tests__/plots/api/index.ts
+++ b/__tests__/plots/api/index.ts
@@ -35,3 +35,4 @@ export { chartEmitBrushHighlightAxisHorizontal } from './chart-emit-brush-highli
 export { chartEmitBrushHighlightAxisCross } from './chart-emit-brush-highlight-axis-cross';
 export { chartEmitScrollbarFilter } from './chart-emit-scrollbar-filter';
 export { chartOptionsCompositeMark } from './chart-options-composite-mark';
+export { chartEmitItemTooltipHideContent } from './chart-emit-item-tooltip-hide-content';

--- a/src/interaction/tooltip.ts
+++ b/src/interaction/tooltip.ts
@@ -138,13 +138,13 @@ function showTooltip({
 }
 
 function hideTooltip({ root, single, emitter, nativeEvent = true, mount }) {
+  if (nativeEvent) {
+    emitter.emit('tooltip:hide', { nativeEvent });
+  }
   const container = single ? getContainer(root, mount) : root;
   const { tooltipElement } = container;
   if (tooltipElement) {
     tooltipElement.hide();
-    if (nativeEvent) {
-      emitter.emit('tooltip:hide', { nativeEvent });
-    }
   }
 }
 
@@ -640,6 +640,7 @@ export function tooltip(
     view,
     mount,
     bounding,
+    body = true,
   }: Record<string, any>,
 ) {
   const elements = elementsof(root);
@@ -674,19 +675,21 @@ export function tooltip(
       }
 
       const { offsetX, offsetY } = event;
-      showTooltip({
-        root,
-        data,
-        x: offsetX,
-        y: offsetY,
-        render,
-        event,
-        single,
-        position,
-        enterable,
-        mount,
-        bounding,
-      });
+      if (body) {
+        showTooltip({
+          root,
+          data,
+          x: offsetX,
+          y: offsetY,
+          render,
+          event,
+          single,
+          position,
+          enterable,
+          mount,
+          bounding,
+        });
+      }
 
       emitter.emit('tooltip:show', {
         ...event,


### PR DESCRIPTION
#### 描述
`chart.on('tooltip:show', () => {})` 依赖 tooltip 显示才能调用。
业务层期望使用 tooltip:show 但不使用 G2 tooltip 组件，使用业务层的 tooltip 组件。
 
```js
chart
  .interval()
  .data([
    { genre: 'Sports', sold: 275 },
    { genre: 'Strategy', sold: 115 },
    { genre: 'Action', sold: 120 },
    { genre: 'Shooter', sold: 350 },
    { genre: 'Other', sold: 150 },
  ])
  .encode('x', 'genre')
  .encode('y', 'sold')
  .encode('color', 'genre')
  .interaction('tooltip', {
    showContent: false,
  });

  chart.on('tooltip:show', ({ data }) => {
    p.innerText = JSON.stringify(data);
  });

  chart.on('tooltip:hide', () => {
    console.log('hide');
  };);

chart.render();
```

<img width="702" alt="image" src="https://github.com/antvis/G2/assets/109653633/b7d56554-8e75-4240-b6dc-992e3cf2a6e5">
