### PR TITLE
refactor(shape): api

### DIFF
--- a/__tests__/plots/api/register-shape.ts
+++ b/__tests__/plots/api/register-shape.ts
@@ -4,8 +4,8 @@ import { register, Chart } from '../../../src/api';
 export function registerShape(context) {
   const { container, canvas } = context;
   register('shape.interval.triangle', (style) => {
-    return (P, value, coordinate, theme) => {
-      const { defaultColor } = theme;
+    return (P, value, defaults) => {
+      const { color: defaultColor } = defaults;
       const [p0, p1, p2, p3] = P;
       const pm = [(p0[0] + p1[0]) / 2, p0[1]];
       const { color = defaultColor } = value;

--- a/src/interaction/elementHighlight.ts
+++ b/src/interaction/elementHighlight.ts
@@ -45,6 +45,7 @@ export function elementHighlight(
     ...subObject(state.active, 'link'),
   });
   const [appendBackground, removeBackground, isBackground] = renderBackground({
+    document: root.ownerDocument,
     scale,
     coordinate,
     background,

--- a/src/interaction/elementSelect.ts
+++ b/src/interaction/elementSelect.ts
@@ -46,6 +46,7 @@ export function elementSelect(
   });
 
   const [appendBackground, removeBackground] = renderBackground({
+    document: root.ownerDocument,
     background,
     coordinate,
     scale,

--- a/src/interaction/utils.ts
+++ b/src/interaction/utils.ts
@@ -335,6 +335,7 @@ export function offsetTransform(element, offset, coordinate) {
 }
 
 export function renderBackground({
+  document,
   background,
   scale,
   coordinate,
@@ -384,7 +385,7 @@ export function renderBackground({
     ].map((d) => coordinate.map(d));
     const { __data__: data } = element;
     const { y: dy, y1: dy1 } = data;
-    return rect(points, { y: dy, y1: dy1 }, coordinate, style);
+    return rect(document, points, { y: dy, y1: dy1 }, coordinate, style);
   };
 
   // Shape without ordinal style.

--- a/src/mark/gauge.ts
+++ b/src/mark/gauge.ts
@@ -60,13 +60,14 @@ function getTextContent(textStyle, { target, total }) {
   return content ? content(target, total) : target.toString();
 }
 
-const indicatorShape: SC<ColorOptions> = (options) => {
+const indicatorShape: SC<ColorOptions> = (options, context) => {
   const { shape, radius, ...style } = options;
   const pointerStyle = subObject(style, 'pointer');
   const pinStyle = subObject(style, 'pin');
   const { shape: pointerShape, ...resPointerStyle } = pointerStyle;
   const { shape: pinShape, ...resPinStyle } = pinStyle;
-  return (points, value, coordinate, theme) => {
+  const { coordinate, theme } = context;
+  return (points, value) => {
     // Invert points.
     const invertedPoints = points.map((p) => coordinate.invert(p));
     // Get new coordinate.

--- a/src/runtime/library.ts
+++ b/src/runtime/library.ts
@@ -1,5 +1,6 @@
+import { IDocument } from '@antv/g';
 import { error } from '../utils/helper';
-import { G2ComponentOptions, G2Library } from './types/options';
+import { G2ComponentOptions, G2Context, G2Library } from './types/options';
 import {
   G2Component,
   G2ComponentNamespaces,
@@ -13,15 +14,21 @@ export function useLibrary<
 >(
   namespace: G2ComponentNamespaces,
   library: G2Library,
-): [(options: O) => V, (type: O['type']) => C] {
+): [(options: O, context?) => V, (type: O['type']) => C] {
   const create = (type: O['type']) => {
     if (typeof type !== 'string') return type;
     const key = `${namespace}.${type}`;
     return library[key] || error(`Unknown Component: ${key}`);
   };
-  const use = (options: O) => {
+  const use = (options: O, context?) => {
     const { type, ...rest } = options;
-    return create(type)({ ...rest });
+    return create(type)(rest, context);
   };
   return [use, create];
+}
+
+export function documentOf(library: G2Context): IDocument {
+  const { canvas, group } = library;
+  if (group) return group.ownerDocument;
+  return canvas.document;
 }

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -28,7 +28,7 @@ import {
 } from './constant';
 import { coordinate2Transform, createCoordinate } from './coordinate';
 import { computeLayout, placeComponents } from './layout';
-import { useLibrary } from './library';
+import { documentOf, useLibrary } from './library';
 import { initializeMark } from './mark';
 import {
   applyScale,
@@ -39,6 +39,7 @@ import {
 import { applyDataTransform } from './transform';
 import {
   G2MarkState,
+  G2Theme,
   G2ViewDescriptor,
   G2ViewInstance,
   Primitive,
@@ -914,7 +915,7 @@ async function plotView(
   }
 
   // Plot label for this view.
-  plotLabel(view, selection, transitions, library);
+  plotLabel(view, selection, transitions, library, context);
 }
 
 /**
@@ -925,6 +926,7 @@ function plotLabel(
   selection: Selection,
   transitions: GAnimation[],
   library: G2Library,
+  context: G2Context,
 ) {
   const [useLabelTransform] = useLibrary<
     G2LabelTransformOptions,
@@ -943,7 +945,13 @@ function plotLabel(
   // Get all labels for this view.
   const labels = Array.from(markState.entries()).flatMap(([mark, state]) => {
     const { labels: labelOptions = [], key } = mark;
-    const shapeFunction = createLabelShapeFunction(mark, state, view, library);
+    const shapeFunction = createLabelShapeFunction(
+      mark,
+      state,
+      view,
+      library,
+      context,
+    );
     const elements = selection
       .select(`#${key}`)
       .selectAll(className(ELEMENT_CLASS_NAME))
@@ -1100,6 +1108,7 @@ function createLabelShapeFunction(
   state: G2MarkState,
   view: G2ViewDescriptor,
   library: G2Library,
+  context: G2Context,
 ): (options: Record<string, any>) => DisplayObject {
   const [useShape] = useLibrary<G2ShapeOptions, ShapeComponent, Shape>(
     'shape',
@@ -1108,8 +1117,18 @@ function createLabelShapeFunction(
   const { data: abstractData } = mark;
   const { data: visualData, defaultLabelShape } = state;
   const point2d = visualData.map((d) => d.points);
+
+  // Assemble Context.
   const { theme, coordinate } = view;
+  const shapeContext = {
+    ...context,
+    document: documentOf(context),
+    theme,
+    coordinate,
+  };
+
   return (options) => {
+    // Computed values from data and styles.
     const { index, points } = options;
     const datum = abstractData[index];
     const {
@@ -1125,8 +1144,13 @@ function createLabelShapeFunction(
     const { shape = defaultLabelShape, text, ...style } = visualOptions;
     const f = typeof formatter === 'string' ? format(formatter) : formatter;
     const value = { ...style, text: f(text, datum, index, abstractData) };
-    const shapeFunction = useShape({ type: `label.${shape}`, ...style });
-    return shapeFunction(points, value, coordinate, theme, point2d);
+
+    // Params for create shape.
+    const shapeOptions = { type: `label.${shape}`, ...style };
+    const shapeFunction = useShape(shapeOptions, shapeContext);
+    const defaults = getDefaultsStyle(theme, 'label', shape, 'label');
+
+    return shapeFunction(points, value, defaults, point2d);
   };
 }
 
@@ -1256,10 +1280,16 @@ function createMarkShapeFunction(
   const point2d = data.map((d) => d.points);
   const { theme, coordinate } = view;
   const { type: markType, style = {} } = mark;
+  const shapeContext = {
+    ...context,
+    document: documentOf(context),
+    coordinate,
+    theme,
+  };
   return (data) => {
     const { shape: styleShape = defaultShape } = style;
     const { shape = styleShape, points, seriesIndex, index: i, ...v } = data;
-    const value = { ...v, shape, mark: markType, defaultShape, index: i };
+    const value = { ...v, index: i };
 
     // Get data-driven style.
     // If it is a series shape, such as area and line,
@@ -1275,12 +1305,28 @@ function createMarkShapeFunction(
       valueOf(d, abstractDatum, I, abstractData),
     );
 
-    const shapeFunction = useShape({
+    const shapeOptions = {
       ...visualStyle,
       type: shapeName(mark, shape),
-    });
-    return shapeFunction(points, value, coordinate, theme, point2d, context);
+    };
+    const shapeFunction = useShape(shapeOptions, shapeContext);
+
+    const defaults = getDefaultsStyle(theme, markType, shape, defaultShape);
+    return shapeFunction(points, value, defaults, point2d);
   };
+}
+
+function getDefaultsStyle(
+  theme: G2Theme,
+  mark: string | MarkComponent,
+  shape: string,
+  defaultShape: string,
+) {
+  if (typeof mark !== 'string') return;
+  const { defaultColor } = theme;
+  const markTheme = theme[mark] || {};
+  const shapeTheme = markTheme[shape] || markTheme[defaultShape];
+  return Object.assign({ color: defaultColor }, shapeTheme);
 }
 
 function createAnimationFunction(

--- a/src/runtime/types/component.ts
+++ b/src/runtime/types/component.ts
@@ -1,6 +1,6 @@
 import { Coordinate, Transformation } from '@antv/coord';
 import EventEmitter from '@antv/event-emitter';
-import { DisplayObject, IAnimation as GAnimation } from '@antv/g';
+import { DisplayObject, IAnimation as GAnimation, IDocument } from '@antv/g';
 import {
   G2Theme,
   G2ViewInstance,
@@ -78,8 +78,9 @@ export type G2BaseComponent<
   R = any,
   O = Record<string, unknown> | void,
   P = Record<string, unknown>,
+  C = Record<string, unknown>,
 > = {
-  (options?: O): R;
+  (options?: O, context?: C): R;
   props?: P;
 };
 
@@ -142,10 +143,8 @@ export type Shape = (
     index?: number;
     [key: string]: any;
   },
-  coordinate: Coordinate,
-  theme: G2Theme,
+  defaults?: Record<string, any>,
   point2d?: Vector2[][],
-  context?: G2Context,
 ) => DisplayObject;
 export type ShapeProps = {
   defaultMarker?: string;
@@ -153,10 +152,16 @@ export type ShapeProps = {
   defaultUpdateAnimation?: string;
   defaultExitAnimation?: string;
 };
+export type ShapeContext = {
+  document: IDocument;
+  coordinate: Coordinate;
+  [key: string]: any; // TODO
+};
 export type ShapeComponent<O = Record<string, unknown>> = G2BaseComponent<
   Shape,
   O,
-  ShapeProps
+  ShapeProps,
+  ShapeContext
 >;
 
 export type Theme = G2Theme;

--- a/src/shape/area/area.ts
+++ b/src/shape/area/area.ts
@@ -5,10 +5,11 @@ import { Curve } from './curve';
 
 export type AreaOptions = Record<string, any>;
 
-export const Area: SC<AreaOptions> = (options) => {
-  return (P, value, coordinate, theme) => {
+export const Area: SC<AreaOptions> = (options, context) => {
+  const { coordinate } = context;
+  return (...params) => {
     const curve = isPolar(coordinate) ? curveLinearClosed : curveLinear;
-    return Curve({ curve: curve, ...options })(P, value, coordinate, theme);
+    return Curve({ curve: curve, ...options }, context)(...params);
   };
 };
 

--- a/src/shape/area/hv.ts
+++ b/src/shape/area/hv.ts
@@ -4,14 +4,9 @@ import { Curve } from './curve';
 
 export type HVOptions = Record<string, any>;
 
-export const HV: SC<HVOptions> = (options) => {
-  return (P, value, coordinate, theme) => {
-    return Curve({ curve: curveStepAfter, ...options })(
-      P,
-      value,
-      coordinate,
-      theme,
-    );
+export const HV: SC<HVOptions> = (options, context) => {
+  return (...params) => {
+    return Curve({ curve: curveStepAfter, ...options }, context)(...params);
   };
 };
 

--- a/src/shape/area/hvh.ts
+++ b/src/shape/area/hvh.ts
@@ -4,9 +4,9 @@ import { Curve } from './curve';
 
 export type HVHOptions = Record<string, any>;
 
-export const HVH: SC<HVHOptions> = (options) => {
-  return (P, value, coordinate, theme) => {
-    return Curve({ curve: curveStep, ...options })(P, value, coordinate, theme);
+export const HVH: SC<HVHOptions> = (options, context) => {
+  return (...params) => {
+    return Curve({ curve: curveStep, ...options }, context)(...params);
   };
 };
 

--- a/src/shape/area/smooth.ts
+++ b/src/shape/area/smooth.ts
@@ -7,16 +7,12 @@ export type SmoothOptions = {
   alpha?: number;
 };
 
-export const Smooth: SC<SmoothOptions> = (options) => {
+export const Smooth: SC<SmoothOptions> = (options, context) => {
   const { alpha = 0.5, ...rest } = options;
-  return (P, value, coordinate, theme) => {
+  const { coordinate } = context;
+  return (...params) => {
     const curve = isPolar(coordinate) ? curveCatmullRomClosed : curveCatmullRom;
-    return Curve({ curve: curve.alpha(alpha), ...rest })(
-      P,
-      value,
-      coordinate,
-      theme,
-    );
+    return Curve({ curve: curve.alpha(alpha), ...rest }, context)(...params);
   };
 };
 

--- a/src/shape/area/vh.ts
+++ b/src/shape/area/vh.ts
@@ -4,14 +4,9 @@ import { Curve } from './curve';
 
 export type VHOptions = Record<string, any>;
 
-export const VH: SC<VHOptions> = (options) => {
-  return (P, value, coordinate, theme) => {
-    return Curve({ curve: curveStepBefore, ...options })(
-      P,
-      value,
-      coordinate,
-      theme,
-    );
+export const VH: SC<VHOptions> = (options, context) => {
+  return (...params) => {
+    return Curve({ curve: curveStepBefore, ...options }, context)(...params);
   };
 };
 

--- a/src/shape/box/box.ts
+++ b/src/shape/box/box.ts
@@ -1,7 +1,6 @@
-import { Path as GPath } from '@antv/g';
 import { path as d3path } from 'd3-path';
 import { Coordinate } from '@antv/coord';
-import { applyStyle, getShapeTheme } from '../utils';
+import { applyStyle } from '../utils';
 import { select } from '../../utils/selection';
 import { ShapeComponent as SC, Vector2 } from '../../runtime';
 import { isPolar } from '../../utils/coordinate';
@@ -73,26 +72,26 @@ function getPath(points: Vector2[], coordinate: Coordinate) {
   return path;
 }
 
-export const Box: SC<BoxOptions> = (options) => {
-  const { ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape, color, transform } = value;
+export const Box: SC<BoxOptions> = (options, context) => {
+  const { coordinate, document } = context;
+  return (points, value, defaults) => {
+    const { color, transform } = value;
     const {
-      defaultColor,
+      color: defaultColor,
       fill = defaultColor,
       stroke = defaultColor,
-      ...shapeTheme
-    } = getShapeTheme(theme, mark, shape, defaultShape);
+      ...rest
+    } = defaults;
 
     const path = getPath(points, coordinate);
 
-    return select(new GPath())
-      .call(applyStyle, shapeTheme)
+    return select(document.createElement('path', {}))
+      .call(applyStyle, rest)
       .style('d', path.toString())
       .style('stroke', stroke)
       .style('fill', color || fill)
       .style('transform', transform)
-      .call(applyStyle, style)
+      .call(applyStyle, options)
       .node();
   };
 };

--- a/src/shape/box/violin.ts
+++ b/src/shape/box/violin.ts
@@ -1,7 +1,6 @@
-import { Path as GPath } from '@antv/g';
 import { path as d3path } from 'd3-path';
 import { Coordinate } from '@antv/coord';
-import { applyStyle, getShapeTheme } from '../utils';
+import { applyStyle } from '../utils';
 import { select } from '../../utils/selection';
 import { ShapeComponent as SC, Vector2 } from '../../runtime';
 import { isPolar } from '../../utils/coordinate';
@@ -85,28 +84,26 @@ function getPath(p: Vector2[], coordinate: Coordinate, size = 4) {
   return path;
 }
 
-export const Violin: SC<ViolinOptions> = (options) => {
-  const { ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape, color, transform } = value;
+export const Violin: SC<ViolinOptions> = (options, context) => {
+  const { coordinate, document } = context;
+  return (points, value, defaults) => {
+    const { color, transform } = value;
     // TODO: how to setting it by size channel.
     const size = 4;
     const {
-      defaultColor,
+      color: defaultColor,
       fill = defaultColor,
       stroke = defaultColor,
-      ...shapeTheme
-    } = getShapeTheme(theme, mark, shape, defaultShape);
-
+      ...rest
+    } = defaults;
     const path = getPath(points, coordinate, size);
-
-    return select(new GPath())
-      .call(applyStyle, shapeTheme)
+    return select(document.createElement('path', {}))
+      .call(applyStyle, rest)
       .style('d', path.toString())
       .style('stroke', stroke)
       .style('fill', color || fill)
       .style('transform', transform)
-      .call(applyStyle, style)
+      .call(applyStyle, options)
       .node();
   };
 };

--- a/src/shape/connector/connector.ts
+++ b/src/shape/connector/connector.ts
@@ -8,7 +8,7 @@ import { createElement } from '../../utils/createElement';
 import { isTranspose } from '../../utils/coordinate';
 import { subObject } from '../../utils/helper';
 import { select } from '../../utils/selection';
-import { applyStyle, getShapeTheme } from '../utils';
+import { applyStyle } from '../utils';
 
 export type ConnectorOptions = ConnectorPathStyleProps & Record<string, any>;
 
@@ -98,21 +98,15 @@ function getPoints(
   ];
 }
 
-export const Connector: SC<ConnectorOptions> = (options) => {
+export const Connector: SC<ConnectorOptions> = (options, context) => {
   const { offset = 0, connectLength1: length1, ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape } = value;
-    const {
-      defaultColor,
-      connectLength1 = length1,
-      ...shapeTheme
-    } = getShapeTheme(theme, mark, shape, defaultShape);
+  const { coordinate } = context;
+  return (points, value, defaults) => {
+    const { color: defaultColor, connectLength1 = length1, ...rest } = defaults;
     const { color, transform } = value;
-
     const P = getPoints(coordinate, points, offset, connectLength1);
-
     return select(new ConnectorPath())
-      .call(applyStyle, shapeTheme)
+      .call(applyStyle, rest)
       .style('points', P)
       .style('stroke', color || defaultColor)
       .style('transform', transform)

--- a/src/shape/density/density.ts
+++ b/src/shape/density/density.ts
@@ -1,6 +1,5 @@
 import { path as d3path } from 'd3-path';
-import { Path } from '@antv/g';
-import { applyStyle, getShapeTheme } from '../utils';
+import { applyStyle } from '../utils';
 import { select } from '../../utils/selection';
 import { ShapeComponent as SC } from '../../runtime';
 
@@ -11,16 +10,11 @@ export type DensityOptions = {
 /**
  * Draw density shape.
  */
-export const Density: SC<DensityOptions> = (options) => {
-  const { ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape, transform } = value;
-    const { defaultColor, ...shapeTheme } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
+export const Density: SC<DensityOptions> = (options, context) => {
+  const { document } = context;
+  return (points, value, defaults) => {
+    const { transform } = value;
+    const { color: defaultColor, ...rest } = defaults;
     const { color = defaultColor } = value;
     const [first, ...p] = points;
 
@@ -32,14 +26,14 @@ export const Density: SC<DensityOptions> = (options) => {
     });
     path.closePath();
 
-    return select(new Path())
-      .call(applyStyle, shapeTheme)
+    return select(document.createElement('path', {}))
+      .call(applyStyle, rest)
       .style('d', path.toString())
       .style('stroke', color || defaultColor) // Always has stroke color.
       .style('fill', color || defaultColor)
       .style('fillOpacity', 0.4)
       .style('transform', transform)
-      .call(applyStyle, style)
+      .call(applyStyle, options)
       .node();
   };
 };

--- a/src/shape/heatmap/heatmap.ts
+++ b/src/shape/heatmap/heatmap.ts
@@ -1,6 +1,5 @@
 import { max as d3max, min as d3min } from 'd3-array';
-import { Image as GImage } from '@antv/g';
-import { applyStyle, getShapeTheme } from '../utils';
+import { applyStyle } from '../utils';
 import { select } from '../../utils/selection';
 import { ShapeComponent as SC } from '../../runtime';
 import { HeatmapRenderer } from './renderer';
@@ -9,7 +8,6 @@ import type { HeatmapRendererOptions } from './renderer/types';
 export type HeatmapOptions = HeatmapRendererOptions;
 
 function deleteKey(obj: any, fn: (v, k) => boolean) {
-  const r = { ...obj };
   return Object.keys(obj).reduce((r, k) => {
     const v = obj[k];
     if (!fn(v, k)) r[k] = v;
@@ -17,7 +15,7 @@ function deleteKey(obj: any, fn: (v, k) => boolean) {
   }, {});
 }
 
-export const Heatmap: SC<HeatmapOptions> = (options) => {
+export const Heatmap: SC<HeatmapOptions> = (options, context) => {
   const {
     gradient,
     opacity,
@@ -27,11 +25,9 @@ export const Heatmap: SC<HeatmapOptions> = (options) => {
     useGradientOpacity,
     ...style
   } = options;
-  return (points: number[][], value, coordinate, theme, _, context) => {
-    const { mark, shape, defaultShape, transform } = value;
-    const { ...shapeTheme } = getShapeTheme(theme, mark, shape, defaultShape);
-    const { createCanvas } = context;
-
+  const { coordinate, createCanvas, document } = context;
+  return (points: number[][], value, defaults) => {
+    const { transform } = value;
     const [width, height] = coordinate.getSize();
     const data = points.map((p: number[]) => ({
       x: p[0],
@@ -64,8 +60,8 @@ export const Heatmap: SC<HeatmapOptions> = (options) => {
           )
         : { canvas: null };
 
-    return select(new GImage())
-      .call(applyStyle, shapeTheme)
+    return select(document.createElement('image', {}))
+      .call(applyStyle, defaults)
       .style('x', 0)
       .style('y', 0)
       .style('width', width)

--- a/src/shape/image/image.ts
+++ b/src/shape/image/image.ts
@@ -1,23 +1,16 @@
-import { Image as GImage } from '@antv/g';
 import { ShapeComponent as SC } from '../../runtime';
-import { applyStyle, getShapeTheme } from '../utils';
+import { applyStyle } from '../utils';
 import { select } from '../../utils/selection';
 import { p } from '../../mark/utils';
 
 export type ImageOptions = Record<string, any>;
 
-export const Image: SC<ImageOptions> = (options) => {
-  const { ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape } = value;
-    const { defaultColor, ...shapeTheme } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
+export const Image: SC<ImageOptions> = (options, context) => {
+  const { coordinate, document } = context;
+  return (points, value, defaults) => {
+    const { color: defaultColor, ...rest } = defaults;
     const { color = defaultColor, src = '', size = 32, transform = '' } = value;
-    let { width = size, height = size } = style;
+    let { width = size, height = size } = options;
     const [[x0, y0]] = points;
 
     // Support percentage width, height.
@@ -28,14 +21,14 @@ export const Image: SC<ImageOptions> = (options) => {
     const x = x0 - Number(width) / 2;
     const y = y0 - Number(height) / 2;
 
-    return select(new GImage())
-      .call(applyStyle, shapeTheme)
+    return select(document.createElement('image', {}))
+      .call(applyStyle, rest)
       .style('x', x)
       .style('y', y)
       .style('img', src)
       .style('stroke', color)
       .style('transform', transform)
-      .call(applyStyle, style)
+      .call(applyStyle, options)
       .style('width', width)
       .style('height', height)
       .node();

--- a/src/shape/interval/funnel.ts
+++ b/src/shape/interval/funnel.ts
@@ -1,10 +1,9 @@
-import { Path } from '@antv/g';
 import { line, curveLinearClosed } from 'd3-shape';
 import { Coordinate } from '@antv/coord';
 import { isTranspose } from '../../utils/coordinate';
 import { ShapeComponent as SC, Vector2 } from '../../runtime';
 import { select } from '../../utils/selection';
-import { applyStyle, getShapeTheme, reorder, toOpacityKey } from '../utils';
+import { applyStyle, reorder } from '../utils';
 
 export type FunnelOptions = {
   adjustPoints?: (
@@ -38,25 +37,20 @@ function getFunnelPoints(
 /**
  * Render funnel in different coordinate and using color channel for stroke and fill attribute.
  */
-export const Funnel: SC<FunnelOptions> = (options) => {
+export const Funnel: SC<FunnelOptions> = (options, context) => {
   const { adjustPoints = getFunnelPoints, ...style } = options;
-  return (points, value, coordinate, theme, point2d, ...args) => {
-    const { index, mark, shape, defaultShape } = value;
-    const { defaultColor, ...defaults } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
+  const { coordinate, document } = context;
+  return (points, value, defaults, point2d) => {
+    const { index } = value;
+    const { color: defaultColor, ...rest } = defaults;
     const nextPoints = point2d[index + 1];
     const funnelPoints = adjustPoints(points, nextPoints, coordinate);
     const tpShape = !!isTranspose(coordinate);
-
     const [p0, p1, p2, p3] = tpShape ? reorder(funnelPoints) : funnelPoints;
     const { color = defaultColor, opacity } = value;
     const b = line().curve(curveLinearClosed)([p0, p1, p2, p3]);
-    return select(new Path({}))
-      .call(applyStyle, defaults)
+    return select(document.createElement('path', {}))
+      .call(applyStyle, rest)
       .style('path', b)
       .style('fill', color)
       .style('fillOpacity', opacity)

--- a/src/shape/interval/hollow.ts
+++ b/src/shape/interval/hollow.ts
@@ -6,8 +6,8 @@ export type HollowOptions = Record<string, any>;
 /**
  * Render rect in different coordinate and using color channel for stroke attribute.
  */
-export const Hollow: SC<HollowOptions> = (options) => {
-  return Color({ colorAttribute: 'stroke', ...options });
+export const Hollow: SC<HollowOptions> = (options, context) => {
+  return Color({ colorAttribute: 'stroke', ...options }, context);
 };
 
 Hollow.props = {

--- a/src/shape/interval/pyramid.ts
+++ b/src/shape/interval/pyramid.ts
@@ -40,8 +40,8 @@ function getPyramidPoints(
 /**
  * Render pyramid in different coordinate and using color channel for stroke and fill attribute.
  */
-export const Pyramid: SC<PyramidOptions> = (options) => {
-  return Funnel({ adjustPoints: getPyramidPoints, ...options });
+export const Pyramid: SC<PyramidOptions> = (options, context) => {
+  return Funnel({ adjustPoints: getPyramidPoints, ...options }, context);
 };
 
 Pyramid.props = {

--- a/src/shape/interval/rect.ts
+++ b/src/shape/interval/rect.ts
@@ -16,8 +16,8 @@ export type RectOptions = {
  * Render rect in different coordinate and using color channel for stroke and fill attribute.
  * The stroke attribute is valid with specified lineWidth attribute which defaults to zero.
  */
-export const Rect: SC<RectOptions> = (options) => {
-  return Color({ colorAttribute: 'fill', ...options });
+export const Rect: SC<RectOptions> = (options, context) => {
+  return Color({ colorAttribute: 'fill', ...options }, context);
 };
 
 Rect.props = {

--- a/src/shape/label/label.ts
+++ b/src/shape/label/label.ts
@@ -44,8 +44,9 @@ function getDefaultStyle(
  * Render normal label for each mark.
  * @todo Support position option: middle...
  */
-export const Label: SC<LabelOptions> = (options) => {
-  return (points, value, coordinate, theme) => {
+export const Label: SC<LabelOptions> = (options, context) => {
+  const { coordinate, theme } = context;
+  return (points, value) => {
     const {
       text,
       x,

--- a/src/shape/line/hv.ts
+++ b/src/shape/line/hv.ts
@@ -4,8 +4,8 @@ import { Curve } from './curve';
 
 export type HVOptions = Record<string, any>;
 
-export const HV: SC<HVOptions> = (options) => {
-  return Curve({ curve: curveStepAfter, ...options });
+export const HV: SC<HVOptions> = (options, context) => {
+  return Curve({ curve: curveStepAfter, ...options }, context);
 };
 
 HV.props = {

--- a/src/shape/line/hvh.ts
+++ b/src/shape/line/hvh.ts
@@ -4,8 +4,8 @@ import { Curve } from './curve';
 
 export type HVHOptions = Record<string, any>;
 
-export const HVH: SC<HVHOptions> = (options) => {
-  return Curve({ curve: curveStep, ...options });
+export const HVH: SC<HVHOptions> = (options, context) => {
+  return Curve({ curve: curveStep, ...options }, context);
 };
 
 HVH.props = {

--- a/src/shape/line/line.ts
+++ b/src/shape/line/line.ts
@@ -5,10 +5,11 @@ import { Curve } from './curve';
 
 export type LineOptions = Record<string, any>;
 
-export const Line: SC<LineOptions> = (options) => {
-  return (P, value, coordinate, theme) => {
+export const Line: SC<LineOptions> = (options, context) => {
+  const { coordinate } = context;
+  return (...params) => {
     const curve = isPolar(coordinate) ? curveLinearClosed : curveLinear;
-    return Curve({ curve, ...options })(P, value, coordinate, theme);
+    return Curve({ curve, ...options }, context)(...params);
   };
 };
 

--- a/src/shape/line/smooth.ts
+++ b/src/shape/line/smooth.ts
@@ -7,16 +7,12 @@ export type SmoothOptions = {
   alpha?: number;
 };
 
-export const Smooth: SC<SmoothOptions> = (options) => {
+export const Smooth: SC<SmoothOptions> = (options, context) => {
   const { alpha = 0.5, ...rest } = options;
-  return (P, value, coordinate, theme) => {
+  const { coordinate } = context;
+  return (...params) => {
     const curve = isPolar(coordinate) ? curveCatmullRomClosed : curveCatmullRom;
-    return Curve({ curve: curve.alpha(alpha), ...rest })(
-      P,
-      value,
-      coordinate,
-      theme,
-    );
+    return Curve({ curve: curve.alpha(alpha), ...rest }, context)(...params);
   };
 };
 

--- a/src/shape/line/trail.ts
+++ b/src/shape/line/trail.ts
@@ -1,9 +1,8 @@
 import { path as d3path } from 'd3-path';
-import { Path } from '@antv/g';
 import { ShapeComponent as SC } from '../../runtime';
 import { select } from '../../utils/selection';
-import { applyStyle, getShapeTheme } from '../utils';
-import { angle, dist, sub, add, Vector2 } from '../../utils/vector';
+import { applyStyle } from '../utils';
+import { angle, sub, add, Vector2 } from '../../utils/vector';
 import { Curve } from './curve';
 
 /**
@@ -45,18 +44,12 @@ function stroke(path, p0, p1, s0, s1) {
 
 export type TrailOptions = Record<string, any>;
 
-export const Trail: SC<TrailOptions> = (options) => {
-  return (P, value, coordinate, theme) => {
-    const { mark, shape, defaultShape, seriesSize, color } = value;
-    const { defaultColor, ...defaults } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
-
+export const Trail: SC<TrailOptions> = (options, context) => {
+  const { document } = context;
+  return (P, value, defaults) => {
+    const { seriesSize, color } = value;
+    const { color: defaultColor, ...rest } = defaults;
     const path = d3path();
-
     for (let i = 0; i < P.length - 1; i++) {
       const p0 = P[i];
       const p1 = P[i + 1];
@@ -64,9 +57,8 @@ export const Trail: SC<TrailOptions> = (options) => {
       const s1 = seriesSize[i + 1];
       stroke(path, p0, p1, s0, s1);
     }
-
-    return select(new Path({}))
-      .call(applyStyle, defaults)
+    return select(document.createElement('path', {}))
+      .call(applyStyle, rest)
       .style('fill', color || defaultColor)
       .style('d', path.toString())
       .call(applyStyle, options)

--- a/src/shape/line/vh.ts
+++ b/src/shape/line/vh.ts
@@ -4,8 +4,8 @@ import { Curve } from './curve';
 
 export type VHOptions = Record<string, any>;
 
-export const VH: SC<VHOptions> = (options) => {
-  return Curve({ curve: curveStepBefore, ...options });
+export const VH: SC<VHOptions> = (options, context) => {
+  return Curve({ curve: curveStepBefore, ...options }, context);
 };
 
 VH.props = {

--- a/src/shape/lineXY/line.ts
+++ b/src/shape/lineXY/line.ts
@@ -1,4 +1,4 @@
-import { Path } from '@antv/g';
+import { IDocument } from '@antv/g';
 import { Coordinate } from '@antv/coord';
 import { arc, line } from 'd3-shape';
 import { isPolar } from '../../utils/coordinate';
@@ -6,7 +6,7 @@ import { select } from '../../utils/selection';
 import { dist } from '../../utils/vector';
 import { subObject } from '../../utils/helper';
 import { Primitive, ShapeComponent as SC, Vector2 } from '../../runtime';
-import { applyStyle, getShapeTheme } from '../utils';
+import { applyStyle } from '../utils';
 
 export type LineOptions = {
   /**
@@ -31,8 +31,12 @@ export type LineOptions = {
   [key: string]: any;
 };
 
-function getArrowMarker(arrowSize: number, arrowStyle: any) {
-  const arrowMarker = new Path({
+function getArrowMarker(
+  document: IDocument,
+  arrowSize: number,
+  arrowStyle: any,
+) {
+  const arrowMarker = document.createElement('path', {
     style: {
       path: `M ${arrowSize},${arrowSize} L -${arrowSize},0 L ${arrowSize},-${arrowSize} L 0,0 Z`,
       anchor: '0.5 0.5',
@@ -65,20 +69,15 @@ function getTransform(coordinate: Coordinate, transform?: Primitive) {
   return `translate(${cx}, ${cy}) ${transform || ''}`;
 }
 
-export const Line: SC<LineOptions> = (options) => {
+export const Line: SC<LineOptions> = (options, context) => {
   const { arrow, arrowSize = 4, ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape } = value;
-    const { defaultColor, lineWidth, ...shapeTheme } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
+  const { coordinate, document } = context;
+  return (points, value, defaults) => {
+    const { color: defaultColor, lineWidth, ...shapeTheme } = defaults;
     const { color = defaultColor, size = lineWidth } = value;
 
     const arrowMarker = arrow
-      ? getArrowMarker(arrowSize, {
+      ? getArrowMarker(document, arrowSize, {
           fill: style.stroke || color,
           stroke: style.stroke || color,
           ...subObject(style, 'arrow'),
@@ -88,7 +87,7 @@ export const Line: SC<LineOptions> = (options) => {
     const path = getPath(points, coordinate);
     const transform = getTransform(coordinate, value.transform);
 
-    return select(new Path({}))
+    return select(document.createElement('path', {}))
       .call(applyStyle, shapeTheme)
       .style('d', path)
       .style('stroke', color)

--- a/src/shape/link/arc.ts
+++ b/src/shape/link/arc.ts
@@ -1,9 +1,8 @@
-import { Path } from '@antv/g';
 import { path as d3path } from 'd3-path';
-import { appendArc, applyStyle, getShapeTheme } from '../utils';
+import { appendArc, applyStyle } from '../utils';
 import { select } from '../../utils/selection';
 import { isPolar } from '../../utils/coordinate';
-import { angle, dist, mid, sub } from '../../utils/vector';
+import { dist, mid } from '../../utils/vector';
 import { ShapeComponent as SC } from '../../runtime';
 
 export type ArcOptions = Record<string, any>;
@@ -13,16 +12,12 @@ export type ArcOptions = Record<string, any>;
  * - In rect, draw half circle.
  * - In polar, draw quadratic curve.
  */
-export const Arc: SC<ArcOptions> = (options) => {
+export const Arc: SC<ArcOptions> = (options, context) => {
   const { ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape } = value;
-    const { defaultColor, ...shapeTheme } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
+  const { coordinate, document } = context;
+  return (points, value, defaults) => {
+    const { color: defaultColor, ...rest } = defaults;
+
     const { color = defaultColor, transform } = value;
     const [from, to] = points;
 
@@ -38,8 +33,8 @@ export const Arc: SC<ArcOptions> = (options) => {
       appendArc(path, from, to, center, raduis);
     }
 
-    return select(new Path())
-      .call(applyStyle, shapeTheme)
+    return select(document.createElement('path', {}))
+      .call(applyStyle, rest)
       .style('d', path.toString())
       .style('stroke', color)
       .style('transform', transform)

--- a/src/shape/link/link.ts
+++ b/src/shape/link/link.ts
@@ -8,10 +8,10 @@ export type LinkOptions = ArrowOptions;
  * Connect 2 points with a single line with arrow.
  * ----->
  */
-export const Link: SC<LinkOptions> = (options) => {
+export const Link: SC<LinkOptions> = (options, context) => {
   const { arrow = false } = options;
-  return (points, value, coordinate, theme) => {
-    return Vector({ ...options, arrow })(points, value, coordinate, theme);
+  return (...params) => {
+    return Vector({ ...options, arrow }, context)(...params);
   };
 };
 

--- a/src/shape/link/smooth.ts
+++ b/src/shape/link/smooth.ts
@@ -1,6 +1,5 @@
-import { Path } from '@antv/g';
 import { path as d3path } from 'd3-path';
-import { applyStyle, getShapeTheme } from '../utils';
+import { applyStyle } from '../utils';
 import { select } from '../../utils/selection';
 import { ShapeComponent as SC } from '../../runtime';
 
@@ -9,16 +8,11 @@ export type SmoothOptions = Record<string, any>;
 /**
  * Connect 2 points with a smooth line, used in tree.
  */
-export const Smooth: SC<SmoothOptions> = (options) => {
+export const Smooth: SC<SmoothOptions> = (options, context) => {
   const { ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape } = value;
-    const { defaultColor, ...shapeTheme } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
+  const { document } = context;
+  return (points, value, defaults) => {
+    const { color: defaultColor, ...rest } = defaults;
     const { color = defaultColor, transform } = value;
     const [from, to] = points;
 
@@ -33,8 +27,8 @@ export const Smooth: SC<SmoothOptions> = (options) => {
       to[1],
     );
 
-    return select(new Path())
-      .call(applyStyle, shapeTheme)
+    return select(document.createElement('path', {}))
+      .call(applyStyle, rest)
       .style('d', path.toString())
       .style('stroke', color)
       .style('transform', transform)

--- a/src/shape/link/vhv.ts
+++ b/src/shape/link/vhv.ts
@@ -1,10 +1,9 @@
-import { Path } from '@antv/g';
 import { path as d3path } from 'd3-path';
 import { Coordinate } from '@antv/coord';
-import { appendArc, applyStyle, getShapeTheme } from '../utils';
+import { appendArc, applyStyle } from '../utils';
 import { select } from '../../utils/selection';
 import { isTranspose, isPolar } from '../../utils/coordinate';
-import { Vector2, dist, angle, sub } from '../../utils/vector';
+import { Vector2, dist } from '../../utils/vector';
 import { ShapeComponent as SC } from '../../runtime';
 
 export type VHVOptions = {
@@ -62,23 +61,16 @@ function getVHVPath(
 /**
  * Connect 2 points with a VHV line, used in tree.
  */
-export const VHV: SC<VHVOptions> = (options) => {
+export const VHV: SC<VHVOptions> = (options, context) => {
   const { cornerRatio = 1 / 3, ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape } = value;
-    const { defaultColor, ...shapeTheme } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
+  const { coordinate, document } = context;
+  return (points, value, defaults) => {
+    const { defaultColor, ...rest } = defaults;
     const { color = defaultColor, transform } = value;
     const [from, to] = points;
-
     const path = getVHVPath(from, to, coordinate, cornerRatio);
-
-    return select(new Path())
-      .call(applyStyle, shapeTheme)
+    return select(document.createElement('path', {}))
+      .call(applyStyle, rest)
       .style('d', path.toString())
       .style('stroke', color)
       .style('transform', transform)

--- a/src/shape/path/color.ts
+++ b/src/shape/path/color.ts
@@ -1,5 +1,4 @@
-import { Path as GPath } from '@antv/g';
-import { applyStyle, getShapeTheme } from '../utils';
+import { applyStyle } from '../utils';
 import { select } from '../../utils/selection';
 import { ShapeComponent as SC } from '../../runtime';
 
@@ -11,21 +10,16 @@ export type ColorOptions = {
 /**
  * Draw a filled or hollow path.
  */
-export const Color: SC<ColorOptions> = (options) => {
+export const Color: SC<ColorOptions> = (options, context) => {
   const { arrow, colorAttribute, ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape } = value;
-    const { stroke, ...shapeTheme } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
-    const { d, color } = value;
+  const { coordinate, document } = context;
+  return (points, value, defaults) => {
+    const { color: defaultColor, stroke, ...rest } = defaults;
+    const { d, color = defaultColor } = value;
     const [width, height] = coordinate.getSize();
     return (
-      select(new GPath())
-        .call(applyStyle, shapeTheme)
+      select(document.createElement('path', {}))
+        .call(applyStyle, rest)
         // Path support string, function with parameter { width, height }.
         .style('d', typeof d === 'function' ? d({ width, height }) : d)
         .style(colorAttribute, color)

--- a/src/shape/path/hollow.ts
+++ b/src/shape/path/hollow.ts
@@ -9,8 +9,8 @@ export type PathOptions = {
 /**
  * A hollow path.
  */
-export const Hollow: SC<PathOptions> = (options) => {
-  return Color({ fill: 'none', colorAttribute: 'stroke', ...options });
+export const Hollow: SC<PathOptions> = (options, context) => {
+  return Color({ fill: 'none', colorAttribute: 'stroke', ...options }, context);
 };
 
 Hollow.props = {

--- a/src/shape/path/path.ts
+++ b/src/shape/path/path.ts
@@ -9,8 +9,8 @@ export type PathOptions = {
 /**
  * A filled path.
  */
-export const Path: SC<PathOptions> = (options) => {
-  return Color({ colorAttribute: 'fill', ...options });
+export const Path: SC<PathOptions> = (options, context) => {
+  return Color({ colorAttribute: 'fill', ...options }, context);
 };
 
 Path.props = {

--- a/src/shape/point/bowtie.ts
+++ b/src/shape/point/bowtie.ts
@@ -6,8 +6,11 @@ export type BowtieOptions = Record<string, any>;
 /**
  * ▶◀
  */
-export const Bowtie: SC<BowtieOptions> = (options) => {
-  return Color({ colorAttribute: 'fill', symbol: 'bowtie', ...options });
+export const Bowtie: SC<BowtieOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'fill', symbol: 'bowtie', ...options },
+    context,
+  );
 };
 
 Bowtie.props = {

--- a/src/shape/point/color.ts
+++ b/src/shape/point/color.ts
@@ -1,10 +1,9 @@
 import { Coordinate, Vector2 } from '@antv/coord';
-import { Path } from '@antv/g';
 import { ShapeComponent as SC } from '../../runtime';
 import { isFisheye } from '../../utils/coordinate';
 import { Symbols } from '../../utils/marker';
 import { select } from '../../utils/selection';
-import { applyStyle, getOrigin, getShapeTheme, toOpacityKey } from '../utils';
+import { applyStyle, getOrigin, toOpacityKey } from '../utils';
 
 export type ColorOptions = {
   colorAttribute: 'fill' | 'stroke';
@@ -34,24 +33,19 @@ function getRadius(
 /**
  * Render point in different coordinate.
  */
-export const Color: SC<ColorOptions> = (options) => {
+export const Color: SC<ColorOptions> = (options, context) => {
   // Render border only when colorAttribute is stroke.
   const { colorAttribute, symbol, mode = 'auto', ...style } = options;
   const path = Symbols.get(symbol) || Symbols.get('point');
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape } = value;
-    const { defaultColor, lineWidth, ...defaults } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
+  const { coordinate, document } = context;
+  return (points, value, defaults) => {
+    const { lineWidth, color: defaultColor } = defaults;
     const finalLineWidth = style.stroke ? lineWidth || 1 : lineWidth;
     const { color = defaultColor, transform, opacity } = value;
     const [cx, cy] = getOrigin(points);
     const r = getRadius(mode, points, value, coordinate);
     const finalRadius = r || style.r || defaults.r;
-    return select(new Path())
+    return select(document.createElement('path', {}))
       .call(applyStyle, defaults)
       .style('fill', 'transparent')
       .style('d', path(cx, cy, finalRadius))

--- a/src/shape/point/cross.ts
+++ b/src/shape/point/cross.ts
@@ -6,8 +6,11 @@ export type CrossOptions = Record<string, any>;
 /**
  * ✕
  */
-export const Cross: SC<CrossOptions> = (options) => {
-  return Color({ colorAttribute: 'stroke', symbol: 'cross', ...options });
+export const Cross: SC<CrossOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'stroke', symbol: 'cross', ...options },
+    context,
+  );
 };
 
 Cross.props = {

--- a/src/shape/point/diamond.ts
+++ b/src/shape/point/diamond.ts
@@ -6,8 +6,11 @@ export type DiamondOptions = Record<string, any>;
 /**
  * ◆
  */
-export const Diamond: SC<DiamondOptions> = (options) => {
-  return Color({ colorAttribute: 'fill', symbol: 'diamond', ...options });
+export const Diamond: SC<DiamondOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'fill', symbol: 'diamond', ...options },
+    context,
+  );
 };
 
 Diamond.props = {

--- a/src/shape/point/hexagon.ts
+++ b/src/shape/point/hexagon.ts
@@ -6,8 +6,11 @@ export type HexagonOptions = Record<string, any>;
 /**
  * ⭓
  */
-export const Hexagon: SC<HexagonOptions> = (options) => {
-  return Color({ colorAttribute: 'fill', symbol: 'hexagon', ...options });
+export const Hexagon: SC<HexagonOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'fill', symbol: 'hexagon', ...options },
+    context,
+  );
 };
 
 Hexagon.props = {

--- a/src/shape/point/hollow.ts
+++ b/src/shape/point/hollow.ts
@@ -6,8 +6,11 @@ export type HollowPointOptions = Record<string, any>;
 /**
  * ○
  */
-export const HollowPoint: SC<HollowPointOptions> = (options) => {
-  return Color({ colorAttribute: 'stroke', symbol: 'point', ...options });
+export const HollowPoint: SC<HollowPointOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'stroke', symbol: 'point', ...options },
+    context,
+  );
 };
 
 HollowPoint.props = {

--- a/src/shape/point/hollowBowtie.ts
+++ b/src/shape/point/hollowBowtie.ts
@@ -6,8 +6,11 @@ export type HollowBowtieOptions = Record<string, any>;
 /**
  * ▷◁
  */
-export const HollowBowtie: SC<HollowBowtieOptions> = (options) => {
-  return Color({ colorAttribute: 'stroke', symbol: 'bowtie', ...options });
+export const HollowBowtie: SC<HollowBowtieOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'stroke', symbol: 'bowtie', ...options },
+    context,
+  );
 };
 
 HollowBowtie.props = {

--- a/src/shape/point/hollowDiamond.ts
+++ b/src/shape/point/hollowDiamond.ts
@@ -6,12 +6,15 @@ export type HollowDiamondOptions = Record<string, any>;
 /**
  * ◇
  */
-export const HollowDiamond: SC<HollowDiamondOptions> = (options) => {
-  return Color({
-    colorAttribute: 'stroke',
-    symbol: 'diamond',
-    ...options,
-  });
+export const HollowDiamond: SC<HollowDiamondOptions> = (options, context) => {
+  return Color(
+    {
+      colorAttribute: 'stroke',
+      symbol: 'diamond',
+      ...options,
+    },
+    context,
+  );
 };
 
 HollowDiamond.props = {

--- a/src/shape/point/hollowHexagon.ts
+++ b/src/shape/point/hollowHexagon.ts
@@ -6,12 +6,15 @@ export type HollowHexagonOptions = Record<string, any>;
 /**
  * ⬡
  */
-export const HollowHexagon: SC<HollowHexagonOptions> = (options) => {
-  return Color({
-    colorAttribute: 'stroke',
-    symbol: 'hexagon',
-    ...options,
-  });
+export const HollowHexagon: SC<HollowHexagonOptions> = (options, context) => {
+  return Color(
+    {
+      colorAttribute: 'stroke',
+      symbol: 'hexagon',
+      ...options,
+    },
+    context,
+  );
 };
 
 HollowHexagon.props = {

--- a/src/shape/point/hollowSquare.ts
+++ b/src/shape/point/hollowSquare.ts
@@ -6,8 +6,11 @@ export type HollowSquareOptions = Record<string, any>;
 /**
  * □
  */
-export const HollowSquare: SC<HollowSquareOptions> = (options) => {
-  return Color({ colorAttribute: 'stroke', symbol: 'square', ...options });
+export const HollowSquare: SC<HollowSquareOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'stroke', symbol: 'square', ...options },
+    context,
+  );
 };
 
 HollowSquare.props = {

--- a/src/shape/point/hollowTriangle.ts
+++ b/src/shape/point/hollowTriangle.ts
@@ -6,12 +6,15 @@ export type HollowTriangleOptions = Record<string, any>;
 /**
  * △
  */
-export const HollowTriangle: SC<HollowTriangleOptions> = (options) => {
-  return Color({
-    colorAttribute: 'stroke',
-    symbol: 'triangle',
-    ...options,
-  });
+export const HollowTriangle: SC<HollowTriangleOptions> = (options, context) => {
+  return Color(
+    {
+      colorAttribute: 'stroke',
+      symbol: 'triangle',
+      ...options,
+    },
+    context,
+  );
 };
 
 HollowTriangle.props = {

--- a/src/shape/point/hollowTriangleDown.ts
+++ b/src/shape/point/hollowTriangleDown.ts
@@ -6,12 +6,18 @@ export type HollowTriangleDownOptions = Record<string, any>;
 /**
  * ▽
  */
-export const HollowTriangleDown: SC<HollowTriangleDownOptions> = (options) => {
-  return Color({
-    colorAttribute: 'stroke',
-    symbol: 'triangle-down',
-    ...options,
-  });
+export const HollowTriangleDown: SC<HollowTriangleDownOptions> = (
+  options,
+  context,
+) => {
+  return Color(
+    {
+      colorAttribute: 'stroke',
+      symbol: 'triangle-down',
+      ...options,
+    },
+    context,
+  );
 };
 
 HollowTriangleDown.props = {

--- a/src/shape/point/hyphen.ts
+++ b/src/shape/point/hyphen.ts
@@ -6,8 +6,11 @@ export type HyphenOptions = Record<string, any>;
 /**
  * -
  */
-export const Hyphen: SC<HyphenOptions> = (options) => {
-  return Color({ colorAttribute: 'stroke', symbol: 'hyphen', ...options });
+export const Hyphen: SC<HyphenOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'stroke', symbol: 'hyphen', ...options },
+    context,
+  );
 };
 
 Hyphen.props = {

--- a/src/shape/point/line.ts
+++ b/src/shape/point/line.ts
@@ -6,8 +6,11 @@ export type LineOptions = Record<string, any>;
 /**
  * |
  */
-export const Line: SC<LineOptions> = (options) => {
-  return Color({ colorAttribute: 'stroke', symbol: 'line', ...options });
+export const Line: SC<LineOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'stroke', symbol: 'line', ...options },
+    context,
+  );
 };
 
 Line.props = {

--- a/src/shape/point/plus.ts
+++ b/src/shape/point/plus.ts
@@ -6,8 +6,11 @@ export type PlusOptions = Record<string, any>;
 /**
  * +
  */
-export const Plus: SC<PlusOptions> = (options) => {
-  return Color({ colorAttribute: 'stroke', symbol: 'plus', ...options });
+export const Plus: SC<PlusOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'stroke', symbol: 'plus', ...options },
+    context,
+  );
 };
 
 Plus.props = {

--- a/src/shape/point/point.ts
+++ b/src/shape/point/point.ts
@@ -6,8 +6,11 @@ export type PointOptions = Record<string, any>;
 /**
  * ●
  */
-export const Point: SC<PointOptions> = (options) => {
-  return Color({ colorAttribute: 'fill', symbol: 'point', ...options });
+export const Point: SC<PointOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'fill', symbol: 'point', ...options },
+    context,
+  );
 };
 
 Point.props = {

--- a/src/shape/point/square.ts
+++ b/src/shape/point/square.ts
@@ -6,8 +6,11 @@ export type SquareOptions = Record<string, any>;
 /**
  * ■
  */
-export const Square: SC<SquareOptions> = (options) => {
-  return Color({ colorAttribute: 'fill', symbol: 'square', ...options });
+export const Square: SC<SquareOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'fill', symbol: 'square', ...options },
+    context,
+  );
 };
 
 Square.props = {

--- a/src/shape/point/tick.ts
+++ b/src/shape/point/tick.ts
@@ -6,8 +6,11 @@ export type TickOptions = Record<string, any>;
 /**
  * 工
  */
-export const Tick: SC<TickOptions> = (options) => {
-  return Color({ colorAttribute: 'stroke', symbol: 'tick', ...options });
+export const Tick: SC<TickOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'stroke', symbol: 'tick', ...options },
+    context,
+  );
 };
 
 Tick.props = {

--- a/src/shape/point/triangle.ts
+++ b/src/shape/point/triangle.ts
@@ -6,8 +6,11 @@ export type TriangleOptions = Record<string, any>;
 /**
  * ▲
  */
-export const Triangle: SC<TriangleOptions> = (options) => {
-  return Color({ colorAttribute: 'fill', symbol: 'triangle', ...options });
+export const Triangle: SC<TriangleOptions> = (options, context) => {
+  return Color(
+    { colorAttribute: 'fill', symbol: 'triangle', ...options },
+    context,
+  );
 };
 
 Triangle.props = {

--- a/src/shape/point/triangleDown.ts
+++ b/src/shape/point/triangleDown.ts
@@ -6,12 +6,15 @@ export type TriangleDownOptions = Record<string, any>;
 /**
  * ▼
  */
-export const TriangleDown: SC<TriangleDownOptions> = (options) => {
-  return Color({
-    colorAttribute: 'fill',
-    symbol: 'triangle-down',
-    ...options,
-  });
+export const TriangleDown: SC<TriangleDownOptions> = (options, context) => {
+  return Color(
+    {
+      colorAttribute: 'fill',
+      symbol: 'triangle-down',
+      ...options,
+    },
+    context,
+  );
 };
 
 TriangleDown.props = {

--- a/src/shape/polygon/polygon.ts
+++ b/src/shape/polygon/polygon.ts
@@ -1,8 +1,7 @@
-import { Path as GPath } from '@antv/g';
 import { Coordinate } from '@antv/coord';
 import { path as d3path } from 'd3-path';
 import { isPolar } from '../../utils/coordinate';
-import { applyStyle, appendPolygon, appendArc, getShapeTheme } from '../utils';
+import { applyStyle, appendPolygon, appendArc } from '../utils';
 import { select } from '../../utils/selection';
 import { dist } from '../../utils/vector';
 import { ShapeComponent as SC, Vector2 } from '../../runtime';
@@ -44,26 +43,19 @@ function getPolygonPath(points: Vector2[], coordinate: Coordinate) {
   return appendPolygon(path, points);
 }
 
-export const Polygon: SC<PolygonOptions> = (options) => {
-  const { ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape, color, transform } = value;
-    const { defaultColor, ...shapeTheme } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
-
+export const Polygon: SC<PolygonOptions> = (options, context) => {
+  const { coordinate, document } = context;
+  return (points, value, defaults) => {
+    const { color: defaultColor, ...rest } = defaults;
+    const { color = defaultColor, transform } = value;
     const path = getPolygonPath(points, coordinate);
-
-    return select(new GPath())
-      .call(applyStyle, shapeTheme)
+    return select(document.createElement('path', {}))
+      .call(applyStyle, rest)
       .style('d', path.toString())
-      .style('stroke', color || defaultColor)
-      .style('fill', color || defaultColor)
+      .style('stroke', color)
+      .style('fill', color)
       .style('transform', transform)
-      .call(applyStyle, style)
+      .call(applyStyle, options)
       .node();
   };
 };

--- a/src/shape/polygon/ribbon.ts
+++ b/src/shape/polygon/ribbon.ts
@@ -1,7 +1,6 @@
-import { Path as GPath } from '@antv/g';
 import { path as d3path } from 'd3-path';
 import { Coordinate } from '@antv/coord';
-import { appendArc, applyStyle, getShapeTheme } from '../utils';
+import { appendArc, applyStyle } from '../utils';
 import { select } from '../../utils/selection';
 import { isPolar } from '../../utils/coordinate';
 import { dist } from '../../utils/vector';
@@ -70,21 +69,15 @@ function getRibbonPath(points: Vector2[], coordinate: Coordinate) {
  * - In rect, draw ribbon used in Sankey.
  * - In polar, draw arc used in Chord.
  */
-export const Ribbon: SC<RibbonOptions> = (options) => {
+export const Ribbon: SC<RibbonOptions> = (options, context) => {
   const { ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape, color, transform } = value;
-    const { defaultColor, ...shapeTheme } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
-
+  const { coordinate, document } = context;
+  return (points, value, defaults) => {
+    const { color: defaultColor, ...rest } = defaults;
+    const { color = defaultColor, transform } = value;
     const path = getRibbonPath(points, coordinate);
-
-    return select(new GPath())
-      .call(applyStyle, shapeTheme)
+    return select(document.createElement('path', {}))
+      .call(applyStyle, rest)
       .style('d', path.toString())
       .style('fill', color || defaultColor)
       .style('stroke', color || defaultColor)

--- a/src/shape/shape/shape.ts
+++ b/src/shape/shape/shape.ts
@@ -8,7 +8,7 @@ export type ShapeOptions = Record<string, any>;
  */
 export const Shape: SC<ShapeOptions> = (options) => {
   const { render, ...rest } = options;
-  return (points, value, coordinate, theme) => {
+  return (points) => {
     const [[x0, y0]] = points;
     return render({
       ...rest,

--- a/src/shape/text/badge.ts
+++ b/src/shape/text/badge.ts
@@ -4,7 +4,7 @@ import { ShapeComponent as SC, WithPrefix } from '../../runtime';
 import { createElement } from '../../utils/createElement';
 import { subObject } from '../../utils/helper';
 import { select } from '../../utils/selection';
-import { applyStyle, getShapeTheme } from '../../shape/utils';
+import { applyStyle } from '../../shape/utils';
 
 export type BadgeOptions = BadgeShapeStyleProps & Record<string, any>;
 
@@ -56,27 +56,19 @@ const BadgeShape = createElement((g) => {
     .call(applyStyle, rest);
 });
 
-export const Badge: SC<BadgeOptions> = (options) => {
+export const Badge: SC<BadgeOptions> = (options, context) => {
   const { ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape } = value;
-    const { defaultColor, ...shapeTheme } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
-    const { color, text = '' } = value;
-
+  return (points, value, defaults) => {
+    const { color: defaultColor, ...rest } = defaults;
+    const { color = defaultColor, text = '' } = value;
     const textStyle = {
       text: String(text),
-      stroke: color || defaultColor,
-      fill: color || defaultColor,
+      stroke: color,
+      fill: color,
     };
-
     const [[x0, y0]] = points;
     return select(new BadgeShape())
-      .call(applyStyle, shapeTheme)
+      .call(applyStyle, rest)
       .style('x', x0)
       .style('y', y0)
       .call(applyStyle, textStyle)

--- a/src/shape/text/text.ts
+++ b/src/shape/text/text.ts
@@ -1,37 +1,32 @@
 import { ShapeComponent as SC } from '../../runtime';
-import { applyStyle, getShapeTheme } from '../../shape/utils';
+import { applyStyle } from '../../shape/utils';
 import { select } from '../../utils/selection';
 import { Advance } from './advance';
 
 export type TextOptions = Record<string, any>;
 
 /**
- * todo autoRotate when in polar coordinate
+ * @todo autoRotate when in polar coordinate
  */
-export const Text: SC<TextOptions> = (options) => {
-  const { ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape } = value;
-    const { ...shapeTheme } = getShapeTheme(theme, mark, shape, defaultShape);
+export const Text: SC<TextOptions> = (options, context) => {
+  const { coordinate } = context;
+  return (points, value, defaults) => {
     const { color, text = '', fontSize, rotate = 0, transform = '' } = value;
-
     const textStyle = {
       text: String(text),
       stroke: color,
       fill: color,
       fontSize,
     };
-
     const [[x0, y0]] = points;
-
     return select(new Advance())
       .style('x', x0)
       .style('y', y0)
-      .call(applyStyle, shapeTheme)
+      .call(applyStyle, defaults)
       .style('transform', `${transform}rotate(${+rotate})`)
       .style('coordCenter', coordinate.getCenter())
       .call(applyStyle, textStyle)
-      .call(applyStyle, style)
+      .call(applyStyle, options)
       .node();
   };
 };

--- a/src/shape/utils.ts
+++ b/src/shape/utils.ts
@@ -182,23 +182,6 @@ export function getArcObject(
 }
 
 /**
- * Get the mark.shape's style object.
- * @returns
- */
-export function getShapeTheme(
-  theme: G2Theme,
-  mark: string,
-  shape: string,
-  defaultShape: string,
-) {
-  const { defaultColor } = theme;
-  const markTheme = theme[mark] || {};
-  const shapeTheme = markTheme[shape] || markTheme[defaultShape];
-
-  return Object.assign({ defaultColor }, shapeTheme);
-}
-
-/**
  * Pick connectStyle from style.
  * @param style
  */

--- a/src/shape/vector/vector.ts
+++ b/src/shape/vector/vector.ts
@@ -1,6 +1,5 @@
 import { path as d3path } from 'd3-path';
-import { Path } from '@antv/g';
-import { applyStyle, arrowPoints, ArrowOptions, getShapeTheme } from '../utils';
+import { applyStyle, arrowPoints, ArrowOptions } from '../utils';
 import { select } from '../../utils/selection';
 import { ShapeComponent as SC } from '../../runtime';
 
@@ -10,17 +9,12 @@ export type VectorOptions = ArrowOptions;
  * Connect 2 points with a single line with arrow.
  * ----->
  */
-export const Vector: SC<VectorOptions> = (options) => {
+export const Vector: SC<VectorOptions> = (options, context) => {
   const { arrow = true, arrowSize = '40%', ...style } = options;
-  return (points, value, coordinate, theme) => {
-    const { mark, shape, defaultShape, transform } = value;
-    const { defaultColor, ...shapeTheme } = getShapeTheme(
-      theme,
-      mark,
-      shape,
-      defaultShape,
-    );
-    const { color = defaultColor } = value;
+  const { document } = context;
+  return (points, value, defaults) => {
+    const { defaultColor, ...rest } = defaults;
+    const { color = defaultColor, transform } = value;
     const [from, to] = points;
 
     // Draw line
@@ -38,10 +32,10 @@ export const Vector: SC<VectorOptions> = (options) => {
       path.lineTo(...arrow2);
     }
 
-    return select(new Path())
-      .call(applyStyle, shapeTheme)
+    return select(document.createElement('path', {}))
+      .call(applyStyle, rest)
       .style('d', path.toString())
-      .style('stroke', color || defaultColor)
+      .style('stroke', color)
       .style('transform', transform)
       .call(applyStyle, style)
       .node();


### PR DESCRIPTION
# Shape

重构 Shape API，使得 API 更简洁，外部依赖更少。


## 开始使用

之前的接口：

```js
import { Path } from '@antv/g';

export function Color(
  options, // 解析后的 style
) {
  return (
    P, // 控制点
    value, // 视觉数据,
    coordinate, // 坐标系
    theme, // 主题
    point2d, //所有控制点
  ) => {
    return new Path({ style: {} });
  };
}
```

现在的接口：

```js
function Color(
  options, // 解析后的 style
  context, // 上下文信息
) {
  const {
    coordinate, // 坐标系
    theme, // 主题
    document, // G 的文档对象
    createCanvas, // 创建 canvas 的函数
  } = context;
  return (
    P, // 控制点
    value, // 视觉数据,
    defaults, // 从主题获得的默认值
    point2d, // 所有控制点
  ) => {
    return document.createElement('path', {}); // 通过 document 创建元素
  };
}
```

## 主要变化

- theme 和 coordinate 从 context 里面获得。
- 默认样式在主题里面计算完成，不要通过 `getShapeTheme` 计算得到。
- 通过 `document.createElement` 去创建元素。


