### PR TITLE
refactor(api): animation api

### DIFF
--- a/src/animation/fadeIn.ts
+++ b/src/animation/fadeIn.ts
@@ -1,6 +1,5 @@
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from './types';
-import { effectTiming } from './utils';
 
 export type FadeInOptions = Animation;
 
@@ -8,10 +7,9 @@ export type FadeInOptions = Animation;
  * Transform mark from transparent to solid.
  */
 export const FadeIn: AC<FadeInOptions> = (options) => {
-  return (from, to, value, coordinate, defaults) => {
+  return (from, _, defaults) => {
     const [shape] = from;
     const { fillOpacity = 1, strokeOpacity = 1, opacity = 1 } = shape.style;
-
     const keyframes = [
       { fillOpacity: 0, strokeOpacity: 0, opacity: 0 },
       {
@@ -20,8 +18,7 @@ export const FadeIn: AC<FadeInOptions> = (options) => {
         opacity,
       },
     ];
-
-    return shape.animate(keyframes, effectTiming(defaults, value, options));
+    return shape.animate(keyframes, { ...defaults, ...options });
   };
 };
 

--- a/src/animation/fadeOut.ts
+++ b/src/animation/fadeOut.ts
@@ -1,6 +1,5 @@
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from './types';
-import { effectTiming } from './utils';
 
 export type FadeOutOptions = Animation;
 
@@ -8,7 +7,7 @@ export type FadeOutOptions = Animation;
  * Transform mark from solid to transparent.
  */
 export const FadeOut: AC<FadeOutOptions> = (options) => {
-  return (from, to, value, coordinate, defaults) => {
+  return (from, _, defaults) => {
     const [shape] = from;
     const { fillOpacity = 1, strokeOpacity = 1, opacity = 1 } = shape.style;
     const keyframes = [
@@ -19,7 +18,7 @@ export const FadeOut: AC<FadeOutOptions> = (options) => {
       },
       { fillOpacity: 0, strokeOpacity: 0, opacity: 0 },
     ];
-    return shape.animate(keyframes, effectTiming(defaults, value, options));
+    return shape.animate(keyframes, { ...defaults, ...options });
   };
 };
 

--- a/src/animation/growInX.ts
+++ b/src/animation/growInX.ts
@@ -8,8 +8,8 @@ export type GrowInXOptions = Animation;
 /**
  * Scale mark from nothing to desired shape in x direction.
  */
-export const GrowInX: AC<GrowInXOptions> = (options) => {
-  return (from, to, value, coordinate, defaults) => {
+export const GrowInX: AC<GrowInXOptions> = (options, context) => {
+  return (from, to, defaults) => {
     const [shape] = from;
     const { height, width } = shape.getBoundingClientRect();
     const clipPath = new Path({
@@ -20,13 +20,7 @@ export const GrowInX: AC<GrowInXOptions> = (options) => {
     shape.appendChild(clipPath);
     shape.style.clipPath = clipPath;
 
-    const animation = ScaleInX(options)(
-      [clipPath],
-      to,
-      value,
-      coordinate,
-      defaults,
-    );
+    const animation = ScaleInX(options, context)([clipPath], to, defaults);
 
     (animation as IAnimation).finished.then(() => {
       clipPath.remove();

--- a/src/animation/growInY.ts
+++ b/src/animation/growInY.ts
@@ -8,8 +8,8 @@ export type GrowInYOptions = Animation;
 /**
  * Scale mark from nothing to desired shape in x direction.
  */
-export const GrowInY: AC<GrowInYOptions> = (options) => {
-  return (from, to, value, coordinate, defaults) => {
+export const GrowInY: AC<GrowInYOptions> = (options, context) => {
+  return (from, to, defaults) => {
     const [shape] = from;
     const { height, width } = shape.getBoundingClientRect();
     const clipPath = new Path({
@@ -20,13 +20,7 @@ export const GrowInY: AC<GrowInYOptions> = (options) => {
     shape.appendChild(clipPath);
     shape.style.clipPath = clipPath;
 
-    const animation = ScaleInY(options)(
-      [clipPath],
-      to,
-      value,
-      coordinate,
-      defaults,
-    );
+    const animation = ScaleInY(options, context)([clipPath], to, defaults);
 
     (animation as IAnimation).finished.then(() => {
       clipPath.remove();

--- a/src/animation/morphing.ts
+++ b/src/animation/morphing.ts
@@ -7,7 +7,7 @@ import {
 import { AnimationComponent as AC } from '../runtime';
 import { copyAttributes } from '../utils/helper';
 import { Animation } from './types';
-import { attributeKeys, attributeOf, effectTiming } from './utils';
+import { attributeKeys, attributeOf } from './utils';
 
 export type MorphingOptions = Animation & { split: 'pack' | SplitFunction };
 
@@ -249,9 +249,9 @@ function multipleToOne(
  * @todo Support more split function.
  */
 export const Morphing: AC<MorphingOptions> = (options) => {
-  return (from, to, value, coordinate, defaults) => {
+  return (from, to, defaults) => {
     const split = normalizeSplit(options.split);
-    const timeEffect = effectTiming(defaults, value, options);
+    const timeEffect = { ...defaults, ...options };
     const { length: fl } = from;
     const { length: tl } = to;
     if ((fl === 1 && tl === 1) || (fl > 1 && tl > 1)) {

--- a/src/animation/pathIn.ts
+++ b/src/animation/pathIn.ts
@@ -1,7 +1,6 @@
 import { Line } from '@antv/g';
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from './types';
-import { effectTiming } from './utils';
 
 export type PathInOptions = Animation;
 
@@ -9,7 +8,7 @@ export type PathInOptions = Animation;
  * Transform mark from transparent to solid.
  */
 export const PathIn: AC<PathInOptions> = (options) => {
-  return (from, to, value, coordinate, defaults) => {
+  return (from, _, defaults) => {
     const [shape] = from;
     const length = (shape as Line).getTotalLength?.() || 0;
 
@@ -17,7 +16,7 @@ export const PathIn: AC<PathInOptions> = (options) => {
       { lineDash: [0, length] },
       { lineDash: [length, 0] },
     ] as any[];
-    return shape.animate(keyframes, effectTiming(defaults, value, options));
+    return shape.animate(keyframes, { ...defaults, ...options });
   };
 };
 

--- a/src/animation/scaleInX.ts
+++ b/src/animation/scaleInX.ts
@@ -1,19 +1,20 @@
 import { isTranspose } from '../utils/coordinate';
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from './types';
-import { effectTiming } from './utils';
 
 export type ScaleInXOptions = Animation;
 
 /**
  * Scale mark from nothing to desired shape in x direction.
  */
-export const ScaleInX: AC<ScaleInXOptions> = (options) => {
+export const ScaleInX: AC<ScaleInXOptions> = (options, context) => {
   // Small enough to hide or show very small part of mark,
   // but bigger enough to not cause bug.
   const ZERO = 0.0001;
 
-  return (from, to, value, coordinate, defaults) => {
+  const { coordinate } = context;
+
+  return (from, _, defaults) => {
     const [shape] = from;
     const { height } = shape.getBoundingClientRect();
     const {
@@ -54,10 +55,7 @@ export const ScaleInX: AC<ScaleInXOptions> = (options) => {
     // Change transform origin for correct transform.
     shape.setOrigin(transformOrigin);
 
-    const animation = shape.animate(
-      keyframes,
-      effectTiming(defaults, value, options),
-    );
+    const animation = shape.animate(keyframes, { ...defaults, ...options });
 
     // Reset transform origin to eliminate side effect for following animations.
     animation.finished.then(() => shape.setOrigin(0, 0));

--- a/src/animation/scaleInY.ts
+++ b/src/animation/scaleInY.ts
@@ -1,19 +1,20 @@
 import { isTranspose } from '../utils/coordinate';
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from './types';
-import { effectTiming } from './utils';
 
 export type ScaleInYOptions = Animation;
 
 /**
  * Scale mark from nothing to desired shape in y direction.
  */
-export const ScaleInY: AC<ScaleInYOptions> = (options) => {
+export const ScaleInY: AC<ScaleInYOptions> = (options, context) => {
   // Small enough to hide or show very small part of mark,
   // but bigger enough to not cause bug.
   const ZERO = 0.0001;
 
-  return (from, to, value, coordinate, defaults) => {
+  const { coordinate } = context;
+
+  return (from, _, defaults) => {
     const [shape] = from;
     const { height } = shape.getBoundingClientRect();
     const {
@@ -54,10 +55,7 @@ export const ScaleInY: AC<ScaleInYOptions> = (options) => {
     // Change transform origin for correct transform.
     shape.setOrigin(transformOrigin);
 
-    const animation = shape.animate(
-      keyframes,
-      effectTiming(defaults, value, options),
-    );
+    const animation = shape.animate(keyframes, { ...defaults, ...options });
 
     // Reset transform origin to eliminate side effect for following animations.
     animation.finished.then(() => shape.setOrigin(0, 0));

--- a/src/animation/scaleOutX.ts
+++ b/src/animation/scaleOutX.ts
@@ -1,19 +1,20 @@
 import { isTranspose } from '../utils/coordinate';
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from './types';
-import { effectTiming } from './utils';
 
 export type ScaleOutXOptions = Animation;
 
 /**
  * Scale mark from desired shape to nothing in x direction.
  */
-export const ScaleOutX: AC<ScaleOutXOptions> = (options) => {
+export const ScaleOutX: AC<ScaleOutXOptions> = (options, context) => {
   // Small enough to hide or show very small part of mark,
   // but bigger enough to not cause bug.
   const ZERO = 0.0001;
 
-  return (from, to, value, coordinate, defaults) => {
+  const { coordinate } = context;
+
+  return (from, _, defaults) => {
     const [shape] = from;
     const { height } = shape.getBoundingClientRect();
     const {
@@ -51,10 +52,7 @@ export const ScaleOutX: AC<ScaleOutXOptions> = (options) => {
     // Change transform origin for correct transform.
     shape.setOrigin(transformOrigin);
 
-    const animation = shape.animate(
-      keyframes,
-      effectTiming(defaults, value, options),
-    );
+    const animation = shape.animate(keyframes, { ...defaults, ...options });
 
     // Reset transform origin to eliminate side effect for following animations.
     animation.finished.then(() => shape.setOrigin(0, 0));

--- a/src/animation/scaleOutY.ts
+++ b/src/animation/scaleOutY.ts
@@ -1,19 +1,20 @@
 import { isTranspose } from '../utils/coordinate';
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from './types';
-import { effectTiming } from './utils';
 
 export type ScaleOutYOptions = Animation;
 
 /**
  * Scale mark from desired shape to nothing in y direction.
  */
-export const ScaleOutY: AC<ScaleOutYOptions> = (options) => {
+export const ScaleOutY: AC<ScaleOutYOptions> = (options, context) => {
   // Small enough to hide or show very small part of mark,
   // but bigger enough to not cause bug.
   const ZERO = 0.0001;
 
-  return (from, to, value, coordinate, defaults) => {
+  const { coordinate } = context;
+
+  return (from, _, defaults) => {
     const [shape] = from;
     const { height } = shape.getBoundingClientRect();
     const {
@@ -51,10 +52,7 @@ export const ScaleOutY: AC<ScaleOutYOptions> = (options) => {
     // Change transform origin for correct transform.
     shape.setOrigin(transformOrigin);
 
-    const animation = shape.animate(
-      keyframes,
-      effectTiming(defaults, value, options),
-    );
+    const animation = shape.animate(keyframes, { ...defaults, ...options });
 
     // Reset transform origin to eliminate side effect for following animations.
     animation.finished.then(() => shape.setOrigin(0, 0));

--- a/src/animation/utils.ts
+++ b/src/animation/utils.ts
@@ -1,30 +1,4 @@
 import { DisplayObject } from '@antv/g';
-import { Container } from '../utils/container';
-import { G2Theme } from '../runtime';
-
-export function effectTiming(
-  defaults: G2Theme['enter' | 'exit' | 'update'],
-  value: Record<string, any>,
-  options: Record<string, any>,
-): Record<string, any> {
-  return Container.of({})
-    .call(assignDefined, defaults)
-    .call(assignDefined, value)
-    .call(assignDefined, options)
-    .value();
-}
-
-function assignDefined<T>(
-  target: Record<string, T>,
-  source: Record<string, T>,
-): Record<string, T> {
-  for (const [key, value] of Object.entries(source)) {
-    if (value !== undefined) {
-      target[key] = source[key];
-    }
-  }
-  return target;
-}
 
 // TODO: Add more attributes need to be transform.
 // TODO: Opacity transform unexpectedly.

--- a/src/animation/waveIn.ts
+++ b/src/animation/waveIn.ts
@@ -5,7 +5,6 @@ import { AnimationComponent as AC } from '../runtime';
 import { getArcObject } from '../shape/utils';
 import { isPolar } from '../utils/coordinate';
 import { Animation } from './types';
-import { effectTiming } from './utils';
 import { ScaleInX } from './scaleInX';
 
 export type WaveInOptions = Animation;
@@ -13,7 +12,7 @@ export type WaveInOptions = Animation;
 /**
  * Transform mark from transparent to solid.
  */
-export const WaveIn: AC<WaveInOptions> = (options) => {
+export const WaveIn: AC<WaveInOptions> = (options, context) => {
   const ZERO = 0.0001;
 
   // @see https://g-next.antv.vision/zh/docs/api/css/css-properties-values-api#%E8%87%AA%E5%AE%9A%E4%B9%89%E5%B1%9E%E6%80%A7
@@ -25,11 +24,13 @@ export const WaveIn: AC<WaveInOptions> = (options) => {
     syntax: PropertySyntax.NUMBER,
   });
 
-  return (from, to, value, coordinate, defaults) => {
+  const { coordinate } = context;
+
+  return (from, to, defaults) => {
     const [shape] = from;
 
     if (!isPolar(coordinate)) {
-      return ScaleInX(options)(from, to, value, coordinate, defaults);
+      return ScaleInX(options, context)(from, to, defaults);
     }
 
     const center = coordinate.getCenter();
@@ -88,10 +89,7 @@ export const WaveIn: AC<WaveInOptions> = (options) => {
         opacity,
       },
     ];
-    const animation = shape.animate(
-      keyframes,
-      effectTiming(defaults, value, options),
-    );
+    const animation = shape.animate(keyframes, { ...defaults, ...options });
 
     animation.onframe = function () {
       shape.style.path = createArcPath({

--- a/src/animation/zoomIn.ts
+++ b/src/animation/zoomIn.ts
@@ -1,6 +1,5 @@
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from './types';
-import { effectTiming } from './utils';
 
 export type ZoomInOptions = Animation;
 
@@ -9,7 +8,7 @@ export const ZoomIn: AC<ZoomInOptions> = (options) => {
   // but bigger enough to not cause bug.
   const ZERO = 0.0001;
 
-  return (from, to, value, coordinate, defaults) => {
+  return (from, _, defaults) => {
     const [shape] = from;
     const {
       transform: prefix = '',
@@ -42,10 +41,7 @@ export const ZoomIn: AC<ZoomInOptions> = (options) => {
     // Change transform origin for correct transform.
     shape.setOrigin([width / 2, height / 2]);
 
-    const animation = shape.animate(
-      keyframes,
-      effectTiming(defaults, value, options),
-    );
+    const animation = shape.animate(keyframes, { ...defaults, ...options });
 
     // Reset transform origin to eliminate side effect for following animations.
     animation.finished.then(() => shape.setOrigin(0, 0));

--- a/src/animation/zoomOut.ts
+++ b/src/animation/zoomOut.ts
@@ -1,6 +1,5 @@
 import { AnimationComponent as AC } from '../runtime';
 import { Animation } from './types';
-import { effectTiming } from './utils';
 
 export type ZoomOutOptions = Animation;
 
@@ -9,7 +8,7 @@ export const ZoomOut: AC<ZoomOutOptions> = (options) => {
   // but bigger enough to not cause bug.
   const ZERO = 0.0001;
 
-  return (from, to, value, coordinate, defaults) => {
+  return (from, _, defaults) => {
     const [shape] = from;
     const {
       transform: prefix = '',
@@ -37,10 +36,7 @@ export const ZoomOut: AC<ZoomOutOptions> = (options) => {
     const { width, height } = shape.getBoundingClientRect();
     // Change transform origin for correct transform.
     shape.setOrigin([width / 2, height / 2]);
-    const animation = shape.animate(
-      keyframes,
-      effectTiming(defaults, value, options),
-    );
+    const animation = shape.animate(keyframes, { ...defaults, ...options });
 
     // Reset transform origin to eliminate side effect for following animations.
     animation.finished.then(() => shape.setOrigin(0, 0));

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -1359,6 +1359,7 @@ function createAnimationFunction(
   ).props;
   const { [type]: defaultEffectTiming = {} } = theme;
   const animate = mark.animate?.[type] || {};
+  const context = { coordinate };
   return (data, from, to) => {
     const {
       [`${type}Type`]: animation,
@@ -1371,9 +1372,9 @@ function createAnimationFunction(
       ...animate,
     };
     if (!options.type) return null;
-    const animateFunction = useAnimation(options);
+    const animateFunction = useAnimation(options, context);
     const value = { delay, duration, easing };
-    const A = animateFunction(from, to, value, coordinate, defaultEffectTiming);
+    const A = animateFunction(from, to, deepMix(defaultEffectTiming, value));
     if (!Array.isArray(A)) return [A];
     return A;
   };

--- a/src/runtime/types/component.ts
+++ b/src/runtime/types/component.ts
@@ -7,7 +7,6 @@ import {
   GuideComponentOrientation,
   GuideComponentPosition,
   IndexedValue,
-  Layout,
   Vector2,
   G2MarkState,
 } from './common';
@@ -21,26 +20,21 @@ export type G2ComponentNamespaces =
   | 'coordinate'
   | 'encode'
   | 'mark'
-  | 'infer'
   | 'palette'
   | 'scale'
   | 'shape'
-  | 'statistic'
   | 'theme'
   | 'transform'
   | 'component'
   | 'animation'
   | 'action'
   | 'interaction'
-  | 'interactor'
   | 'composition'
   | 'data'
   | 'labelTransform';
 
 export type G2Component =
   | EncodeComponent
-  | InferComponent
-  | StatisticComponent
   | ScaleComponent
   | CoordinateComponent
   | PaletteComponent
@@ -51,7 +45,6 @@ export type G2Component =
   | AnimationComponent
   | InteractionComponent
   | CompositionComponent
-  | AdjustComponent
   | TransformComponent
   | DataComponent
   | LabelTransformComponent;
@@ -59,8 +52,6 @@ export type G2Component =
 export type G2ComponentValue =
   | Transform
   | Encode
-  | Infer
-  | Statistic
   | Scale
   | CoordinateTransform
   | Palette
@@ -71,7 +62,6 @@ export type G2ComponentValue =
   | Animation
   | Interaction
   | Composition
-  | Adjust
   | LabelTransform;
 
 export type G2BaseComponent<
@@ -99,11 +89,6 @@ export type InferValue = {
     statistic: InferredStatistic[],
   ) => InferredStatistic[];
 };
-export type Infer = (encodings: InferValue) => InferValue;
-export type InferComponent<O = void> = G2BaseComponent<Infer, O>;
-
-export type Statistic = (value: IndexedValue) => IndexedValue;
-export type StatisticComponent<O = void> = G2BaseComponent<Statistic, O>;
 
 export type Scale = {
   map: (x: any) => any;
@@ -195,13 +180,21 @@ export type GuideComponentComponent<O = Record<string, unknown>> =
 export type Animation = (
   from: DisplayObject[],
   to: DisplayObject[],
-  value: Record<string, any>,
-  coordinate: Coordinate,
-  defaults: G2Theme['enter' | 'exit' | 'update'],
+  defaults: Record<string, any>,
 ) => GAnimation | GAnimation[];
+
+export type AnimationContext = {
+  coordinate: Coordinate;
+  [key: string]: any; // TODO
+};
+
+export type AnimationProps = Record<string, unknown>;
+
 export type AnimationComponent<O = Record<string, unknown>> = G2BaseComponent<
   Animation,
-  O
+  O,
+  AnimationProps,
+  AnimationContext
 >;
 
 export type Interaction = (
@@ -222,16 +215,6 @@ export type Composition = (
   | Promise<G2ViewTree[]>;
 export type CompositionComponent<O = Record<string, unknown>> = G2BaseComponent<
   Composition,
-  O
->;
-
-export type Adjust = (
-  points: Vector2[][],
-  domain: number,
-  layout: Layout,
-) => string[];
-export type AdjustComponent<O = Record<string, unknown>> = G2BaseComponent<
-  Adjust,
   O
 >;
 

--- a/src/runtime/types/options.ts
+++ b/src/runtime/types/options.ts
@@ -9,21 +9,18 @@ import {
   Primitive,
 } from './common';
 import {
-  AdjustComponent,
   AnimationComponent,
   CompositionComponent,
   CoordinateComponent,
   G2BaseComponent,
   G2ComponentNamespaces,
   GuideComponentComponent,
-  InferComponent,
   InteractionComponent,
   LabelTransformComponent,
   PaletteComponent,
   Scale,
   ScaleComponent,
   ShapeComponent,
-  StatisticComponent,
   ThemeComponent,
 } from './component';
 
@@ -149,24 +146,20 @@ export type G2BaseComponentOptions<
 
 export type G2ComponentOptions =
   | G2TransformOptions
-  | G2StatisticOptions
   | G2EncodeOptions
   | G2ThemeOptions
   | G2MarkOptions
   | G2CoordinateOptions
   | G2ScaleOptions
-  | G2InferOptions
   | G2ShapeOptions
   | G2PaletteOptions
   | G2GuideComponentOptions
   | G2AnimationOptions
   | G2InteractionOptions
   | G2CompositionOptions
-  | G2AdjustOptions
   | G2LabelTransformOptions;
 
 export type G2TransformOptions = G2BaseComponentOptions<TransformComponent>;
-export type G2StatisticOptions = G2BaseComponentOptions<StatisticComponent>;
 export type G2EncodeOptions = G2BaseComponentOptions<EncodeComponent>;
 export type G2ThemeOptions = G2BaseComponentOptions<ThemeComponent>;
 export type G2MarkOptions = G2BaseComponentOptions<MarkComponent>;
@@ -183,7 +176,6 @@ export type G2ScaleOptions = G2BaseComponentOptions<
     [key: string | symbol]: any;
   }
 >;
-export type G2InferOptions = G2BaseComponentOptions<InferComponent>;
 export type G2ShapeOptions = G2BaseComponentOptions<ShapeComponent>;
 export type G2PaletteOptions = G2BaseComponentOptions<PaletteComponent>;
 export type G2GuideComponentOptions = G2BaseComponentOptions<
@@ -200,7 +192,6 @@ export type G2GuideComponentOptions = G2BaseComponentOptions<
 export type G2AnimationOptions = G2BaseComponentOptions<AnimationComponent>;
 export type G2InteractionOptions = G2BaseComponentOptions<InteractionComponent>;
 export type G2CompositionOptions = G2BaseComponentOptions<CompositionComponent>;
-export type G2AdjustOptions = G2BaseComponentOptions<AdjustComponent>;
 export type G2LabelTransformOptions =
   G2BaseComponentOptions<LabelTransformComponent>;
 export type G2TitleOptions = G2Title;


### PR DESCRIPTION
# Animation

调整 Animation API

## 开始使用

```js
// 之前
function FadeIn(options) {
  return (from, to, value, coordinate, defaults) => {};
}
```

```js
function FadeIn(options, context) {
  const { coordinate } = context;
  return (from, to, defaults) => {};
}
```

## 变化

- coordinate 从 context 里面取。
- value 和 defaults 在 runtime 里面就合并了。