### PR TITLE
refactor(api): remove coordinate for label transform

### DIFF
--- a/src/label-transform/contrastReverse.ts
+++ b/src/label-transform/contrastReverse.ts
@@ -47,7 +47,7 @@ function mostContrast(color, palette: string[]): string {
  */
 export const ContrastReverse: LLC<ContrastReverseOptions> = (options) => {
   const { threshold = 4.5, palette = ['#000', '#fff'] } = options;
-  return (labels: DisplayObject[], coordinate) => {
+  return (labels: DisplayObject[]) => {
     labels.forEach((l) => {
       const background = l.attr('dependentElement').parsedStyle.fill;
       const foreground = l.parsedStyle.fill;

--- a/src/label-transform/overflowHide.ts
+++ b/src/label-transform/overflowHide.ts
@@ -9,8 +9,8 @@ export type OverflowHideOptions = Omit<OverflowHideLabelTransform, 'type'>;
 /**
  * Hide the label when the label is overflowed from the element.
  */
-export const OverflowHide: LLC<OverflowHideOptions> = (options) => {
-  return (labels: DisplayObject[], coordinate) => {
+export const OverflowHide: LLC<OverflowHideOptions> = () => {
+  return (labels: DisplayObject[]) => {
     labels.forEach((l) => {
       show(l);
       const bounds = l.attr('bounds');

--- a/src/label-transform/overlapHide.ts
+++ b/src/label-transform/overlapHide.ts
@@ -11,7 +11,7 @@ export type OverlapHideOptions = Omit<OverlapHideLabelTransform, 'type'>;
  */
 export const OverlapHide: LLC<OverlapHideOptions> = (options) => {
   const { priority } = options;
-  return (labels: DisplayObject[], coordinate) => {
+  return (labels: DisplayObject[]) => {
     const displayLabels = [];
     // When overlap, will hide the next label.
     if (priority) labels.sort(priority);

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -7,6 +7,7 @@ import { mapObject } from '../utils/array';
 import { ChartEvent } from '../utils/event';
 import {
   appendTransform,
+  compose,
   copyAttributes,
   defined,
   error,
@@ -58,7 +59,7 @@ import {
   Theme,
   ThemeComponent,
 } from './types/component';
-import { CompositeMark, Mark, MarkComponent, SingleMark } from './types/mark';
+import { Mark, MarkComponent, SingleMark } from './types/mark';
 import {
   G2AnimationOptions,
   G2CompositionOptions,
@@ -666,9 +667,7 @@ function initializeState(
     clip,
     scale: scaleInstance,
     style: framedStyle,
-    labelTransform: composeLabelTransform(
-      labelTransform.map(useLabelTransform),
-    ),
+    labelTransform: compose(labelTransform.map(useLabelTransform)),
   };
 
   return [view, children];
@@ -998,9 +997,7 @@ function plotLabel(
   const { coordinate } = view;
   for (const [label, shapes] of labelGroups) {
     const { transform = [] } = label;
-    const transformFunction = composeLabelTransform(
-      transform.map(useLabelTransform),
-    );
+    const transformFunction = compose(transform.map(useLabelTransform));
     transformFunction(shapes, coordinate);
   }
 
@@ -1008,15 +1005,6 @@ function plotLabel(
   if (labelTransform) {
     labelTransform(labelShapes, coordinate);
   }
-}
-
-function composeLabelTransform(transform: LabelTransform[]): LabelTransform {
-  return (labels, coordinate) => {
-    for (const t of transform) {
-      labels = t(labels, coordinate);
-    }
-    return labels;
-  };
 }
 
 function getLabels(


### PR DESCRIPTION
# Label Transform

去掉了 coordinate 参数（目前都没有使用到），如果之后，通过 context 获得：和 shape 以及 animation 等保持一致。

## 开始使用

```js
// 之前
function Hide(options) {
  return (labels, coordinate) => {};
}
```

```js
// 当前
function Hide(options) {
  return (labels) => {};
}
```