### PR TITLE
docs(interval): log scale with zero value

### DIFF
--- a/site/examples/general/interval/demo/column-log.ts
+++ b/site/examples/general/interval/demo/column-log.ts
@@ -1,0 +1,25 @@
+import { Chart } from '@antv/g2';
+
+const EPSILON = 1e-6;
+
+const chart = new Chart({
+  container: 'container',
+  theme: 'classic',
+  padding: 'auto',
+  autoFit: true,
+});
+
+chart
+  .interval()
+  .data({
+    type: 'fetch',
+    value:
+      'https://gw.alipayobjects.com/os/bmw-prod/fb9db6b7-23a5-4c23-bbef-c54a55fee580.csv',
+  })
+  .encode('x', 'letter')
+  .encode('y', 'frequency')
+  .encode('y1', EPSILON) // Log scale cant' map zero, set a value close to zero.
+  .scale('y', { type: 'log' })
+  .axis('y', { labelFormatter: (d) => (d === EPSILON ? 0 : d) });
+
+chart.render();

--- a/site/examples/general/interval/demo/meta.json
+++ b/site/examples/general/interval/demo/meta.json
@@ -21,6 +21,14 @@
       "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*fu-BSYg7U_kAAAAAAAAAAAAADmJ7AQ/original"
     },
     {
+      "filename": "column-log.ts",
+      "title": {
+        "zh": "对数柱形图",
+        "en": "Log Column Chart"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*cRE5TqJGnVUAAAAAAAAAAAAADmJ7AQ/original"
+    },
+    {
       "filename": "bar.ts",
       "title": {
         "zh": "水平条形图",

--- a/src/spec/mark.ts
+++ b/src/spec/mark.ts
@@ -153,6 +153,7 @@ export type BaseMark<T extends MarkTypes, C extends string = ChannelTypes> = {
   scale?: Partial<Record<C, Scale>>;
   coordinate?: Coordinate;
   style?: Record<string, any>;
+  viewStyle?: Record<string, any>;
   state?: Partial<
     Record<
       'active' | 'selected' | 'inactive' | 'unselected',

--- a/src/transform/maybeGradient.ts
+++ b/src/transform/maybeGradient.ts
@@ -1,6 +1,6 @@
 import { deepMix } from '@antv/util';
 import { TransformComponent as TC } from '../runtime';
-import { column, columnOf, constant, visualColumn } from './utils/helper';
+import { constant, visualColumn } from './utils/helper';
 
 export type MaybeGradientOptions = Record<string, never>;
 


### PR DESCRIPTION
# Log Scale

close: https://github.com/antvis/G2/issues/5185

添加一个 example 解决当 Log Scale 不能映射 0 值的问题。

## 解释

经过排查，上面 issue 中的问题不是 bug。其中 y1 为 `[0, 0, 0, ..., 0]`，而 log 比例尺无法映射 0。如果真的希望使用 log 比例尺，可以修改 y1 为接近 0 的值，同时设置 labelFormatter。

<img src="https://github.com/antvis/G2/assets/49330279/c2a6ded9-6d3b-49b3-88a2-570fdd91625e" width=640 />


```js
import { Chart } from '@antv/g2';

const EPSILON = 1e-6;

const chart = new Chart({
  container: 'container',
  theme: 'classic',
  padding: 'auto',
  autoFit: true,
});

chart
  .interval()
  .data({
    type: 'fetch',
    value:
      'https://gw.alipayobjects.com/os/bmw-prod/fb9db6b7-23a5-4c23-bbef-c54a55fee580.csv',
  })
  .encode('x', 'letter')
  .encode('y', 'frequency')
  .encode('y1', EPSILON) // Log scale cant' map zero, set a value close to zero.
  .scale('y', { type: 'log' })
  .axis('y', { labelFormatter: (d) => (d === EPSILON ? 0 : d) });

chart.render();
```