### PR TITLE
fix: clear transform when animation finished

### DIFF
--- a/src/animation/morphing.ts
+++ b/src/animation/morphing.ts
@@ -183,13 +183,12 @@ function oneToOne(
   const animation = pathShape.animate(keyframes, timeEffect);
 
   animation.onfinish = () => {
+    pathShape.style.transform = 'none';
     copyAttributes(pathShape, to);
   };
 
   // Remove transform because it already applied in path
   // converted by convertToPath.
-  // @todo Remove this scale(1, 1)
-  pathShape.style.transform = 'scale(1, 1)';
   pathShape.style.transform = 'none';
   return animation;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] benchmarks are included
- [ ] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change

* 当 morphing 动画结束时，需要清除原始 Path 上的 transform。原因是在 convertToPath 时已经考虑了 transform，如果不清除会出现动画结束后 Path 位置偏移的现象。https://github.com/antvis/G/pull/1406/commits/0eb5142d929feb3b90ad18fe1b1298d4c606c231
<img width="412" alt="截屏2023-07-06 下午4 11 47" src="https://github.com/antvis/G2/assets/3608471/0ae8766e-dd73-4880-a434-133492c4dd07">

* 移除多余的 `scale(1, 1)`，现在可以直接通过设置 `transform: 'none'` 清空。
