### PR TITLE
refactor(theme): change some theme attributes

### DIFF
--- a/__tests__/plots/static/github-star-interval-palette.ts
+++ b/__tests__/plots/static/github-star-interval-palette.ts
@@ -17,8 +17,8 @@ export function githubStarIntervalPalette(): G2Spec {
       color: 'name',
     },
     theme: {
-      defaultCategory10: 'category10',
-      defaultCategory20: 'category20',
+      category10: 'category10',
+      category20: 'category20',
     },
   };
 }

--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -122,7 +122,7 @@ describe('Chart', () => {
       .coordinate({ type: 'polar' })
       .interaction('elementHighlight')
       .transform({ type: 'stackY' })
-      .theme({ defaultColor: 'red' });
+      .theme({ color: 'red' });
 
     expect(chart.options()).toEqual({
       type: 'view',
@@ -131,7 +131,7 @@ describe('Chart', () => {
       labelTransform: [{ type: 'overlapDodgeY' }],
       coordinate: { type: 'polar' },
       transform: [{ type: 'stackY' }],
-      theme: { defaultColor: 'red' },
+      theme: { color: 'red' },
       interaction: {
         elementHighlight: true,
       },

--- a/src/component/legendContinuous.ts
+++ b/src/component/legendContinuous.ts
@@ -150,7 +150,7 @@ function getLinearConfig(
   // in this view.
   const defaultColor = scales.color
     ? theme.legendContinuous.ribbonFill || 'black'
-    : theme.defaultColor;
+    : theme.color;
 
   const scale = colorScale || createColorScale(definedScale, defaultColor);
   const [min, max] = rangeOf(scale);

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -741,7 +741,7 @@ async function plotView(
   const I = areaKeys.map((_, i) => i);
   const sizeKeys = ['a', 'margin', 'padding', 'inset'];
   const areaStyles = areaKeys.map((d) =>
-    maybeSubObject(Object.assign({}, theme, style), d),
+    maybeSubObject(Object.assign({}, theme.view, style), d),
   );
   const areaSizes = sizeKeys.map((d) => subObject(rest, d));
   const styleArea = (selection) =>
@@ -1375,10 +1375,10 @@ function getDefaultsStyle(
   defaultShape: string,
 ) {
   if (typeof mark !== 'string') return;
-  const { defaultColor } = theme;
+  const { color } = theme;
   const markTheme = theme[mark] || {};
   const shapeTheme = markTheme[shape] || markTheme[defaultShape];
-  return Object.assign({ color: defaultColor }, shapeTheme);
+  return Object.assign({ color }, shapeTheme);
 }
 
 function createAnimationFunction(

--- a/src/runtime/scale.ts
+++ b/src/runtime/scale.ts
@@ -410,7 +410,7 @@ function categoricalColors(
     'palette',
     library,
   );
-  const { defaultCategory10: c10, defaultCategory20: c20 } = theme;
+  const { category10: c10, category20: c20 } = theme;
   const defaultPalette = unique(values.flat()).length <= c10.length ? c10 : c20;
   const { palette = defaultPalette, offset } = options;
   // Built-in palettes have higher priority.

--- a/src/runtime/types/theme.ts
+++ b/src/runtime/types/theme.ts
@@ -59,13 +59,11 @@ type MarkTheme = NestUnion<'interval', ['rect', 'hollowRect'], ElementStyle> &
     }
   >;
 
+// @todo
 type InteractionTheme = {
-  interaction?: {
-    active: MarkTheme;
-    inactive: MarkTheme;
-    selected: MarkTheme;
-    disabled: MarkTheme;
-  };
+  tooltip?: Record<string, unknown>;
+  elementHighlight?: Record<string, unknown>;
+  elementSelect?: Record<string, unknown>;
 };
 
 type ComponentTheme = {
@@ -113,17 +111,15 @@ type AreaTheme = {
 };
 
 export type G2Theme = {
-  backgroundColor?: string;
-  defaultColor?: string;
-  defaultCategory10?: string;
-  defaultCategory20?: string;
-  defaultSize?: number;
-  elementActiveStroke?: string;
+  color?: string;
+  category10?: string;
+  category20?: string;
+  size?: number;
+  view?: WithPrefix<AreaTheme, 'view'> &
+    WithPrefix<AreaTheme, 'plot'> &
+    WithPrefix<AreaTheme, 'main'> &
+    WithPrefix<AreaTheme, 'content'>;
 } & MarkTheme &
   ComponentTheme &
   AnimationTheme &
-  InteractionTheme &
-  WithPrefix<AreaTheme, 'view'> &
-  WithPrefix<AreaTheme, 'plot'> &
-  WithPrefix<AreaTheme, 'main'> &
-  WithPrefix<AreaTheme, 'content'>;
+  InteractionTheme;

--- a/src/theme/academy.ts
+++ b/src/theme/academy.ts
@@ -10,14 +10,14 @@ const COLORS = {
 
 const BACKGROUND_COLOR = 'transparent';
 
+const DEFAULT_COLOR = '#4e79a7';
+
 export const Academy: TC<AcademyOptions> = (options) => {
-  const DEFAULT_COLOR = '#4e79a7';
   const defaultOptions: Theme = {
-    defaultColor: DEFAULT_COLOR,
-    defaultCategory10: 'tableau10',
-    defaultCategory20: 'tableau10',
-    defaultSize: 1,
-    elementActiveStroke: COLORS.BLACK,
+    color: DEFAULT_COLOR,
+    size: 1,
+    category10: 'tableau10',
+    category20: 'tableau10',
     enter: {
       duration: 300,
       fill: 'both',
@@ -33,12 +33,12 @@ export const Academy: TC<AcademyOptions> = (options) => {
       fill: 'both',
       delay: 0,
     },
-    // --- Theme of area style
-    viewFill: BACKGROUND_COLOR,
-    plotFill: 'transparent',
-    mainFill: 'transparent',
-    contentFill: 'transparent',
-    // --- Theme of mark shape
+    view: {
+      viewFill: BACKGROUND_COLOR,
+      plotFill: 'transparent',
+      mainFill: 'transparent',
+      contentFill: 'transparent',
+    },
     line: {
       line: {
         fill: '',
@@ -197,26 +197,6 @@ export const Academy: TC<AcademyOptions> = (options) => {
         endMarkerFill: COLORS.STROKE,
         endMarkerFillOpacity: 0.95,
       },
-    },
-    interaction: {
-      active: {
-        line: {
-          line: { lineWidth: 3 },
-        },
-        interval: {
-          rect: { stroke: COLORS.BLACK },
-        },
-        area: {
-          area: { fillOpacity: 0.5 },
-        },
-      },
-      inactive: {
-        area: {
-          area: { fillOpacity: 0.3 },
-        },
-      },
-      selected: {},
-      disabled: {},
     },
     axis: {
       arrow: false,

--- a/src/theme/classic.ts
+++ b/src/theme/classic.ts
@@ -10,17 +10,17 @@ const COLORS = {
 
 const BACKGROUND_COLOR = 'transparent';
 
+const DEFAULT_COLOR = '#5B8FF9';
+
 /**
  * Default theme.
  */
 export const Classic: TC<ClassicOptions> = (options) => {
-  const DEFAULT_COLOR = '#5B8FF9';
   const defaultOptions: Theme = {
-    defaultColor: DEFAULT_COLOR,
-    defaultCategory10: 'category10',
-    defaultCategory20: 'category20',
-    defaultSize: 1,
-    elementActiveStroke: COLORS.BLACK,
+    color: DEFAULT_COLOR,
+    size: 1,
+    category10: 'category10',
+    category20: 'category20',
     enter: {
       duration: 300,
       fill: 'both',
@@ -36,12 +36,12 @@ export const Classic: TC<ClassicOptions> = (options) => {
       fill: 'both',
       delay: 0,
     },
-    // --- Theme of area style
-    viewFill: BACKGROUND_COLOR,
-    plotFill: 'transparent',
-    mainFill: 'transparent',
-    contentFill: 'transparent',
-    // --- Theme of mark shape
+    view: {
+      viewFill: BACKGROUND_COLOR,
+      plotFill: 'transparent',
+      mainFill: 'transparent',
+      contentFill: 'transparent',
+    },
     line: {
       line: {
         fill: '',
@@ -132,7 +132,6 @@ export const Classic: TC<ClassicOptions> = (options) => {
     },
     text: {
       text: {
-        // fill: COLORS.BLACK,fillOpacity: 0.65,
         fill: '#1D2129',
         fontSize: 12,
         strokeWidth: 0,
@@ -198,26 +197,6 @@ export const Classic: TC<ClassicOptions> = (options) => {
         endMarkerFill: COLORS.STROKE,
         endMarkerFillOpacity: 0.95,
       },
-    },
-    interaction: {
-      active: {
-        line: {
-          line: { lineWidth: 3 },
-        },
-        interval: {
-          rect: { stroke: COLORS.BLACK },
-        },
-        area: {
-          area: { fillOpacity: 0.5 },
-        },
-      },
-      inactive: {
-        area: {
-          area: { fillOpacity: 0.3 },
-        },
-      },
-      selected: {},
-      disabled: {},
     },
     axis: {
       arrow: false,

--- a/src/theme/classicDark.ts
+++ b/src/theme/classicDark.ts
@@ -10,17 +10,17 @@ const COLORS = {
 
 const BACKGROUND_COLOR = '#141414';
 
+const DEFAULT_COLOR = '#5B8FF9';
+
 /**
  * Dark theme.
  */
 export const ClassicDark: TC<ClassicDarkOptions> = (options) => {
-  const DEFAULT_COLOR = '#5B8FF9';
   const defaultOptions: Theme = {
-    defaultColor: DEFAULT_COLOR,
-    defaultCategory10: 'category10',
-    defaultCategory20: 'category20',
-    defaultSize: 1,
-    elementActiveStroke: COLORS.BLACK,
+    color: DEFAULT_COLOR,
+    category10: 'category10',
+    category20: 'category20',
+    size: 1,
     enter: {
       duration: 300,
       fill: 'both',
@@ -36,12 +36,12 @@ export const ClassicDark: TC<ClassicDarkOptions> = (options) => {
       fill: 'both',
       delay: 0,
     },
-    // --- Theme of area style
-    viewFill: BACKGROUND_COLOR,
-    plotFill: 'transparent',
-    mainFill: 'transparent',
-    contentFill: 'transparent',
-    // --- Theme of mark shape
+    view: {
+      viewFill: BACKGROUND_COLOR,
+      plotFill: 'transparent',
+      mainFill: 'transparent',
+      contentFill: 'transparent',
+    },
     line: {
       line: {
         fill: '',
@@ -198,26 +198,6 @@ export const ClassicDark: TC<ClassicDarkOptions> = (options) => {
         endMarkerFill: COLORS.STROKE,
         endMarkerFillOpacity: 0.95,
       },
-    },
-    interaction: {
-      active: {
-        line: {
-          line: { lineWidth: 3 },
-        },
-        interval: {
-          rect: { stroke: COLORS.BLACK },
-        },
-        area: {
-          area: { fillOpacity: 0.5 },
-        },
-      },
-      inactive: {
-        area: {
-          area: { fillOpacity: 0.3 },
-        },
-      },
-      selected: {},
-      disabled: {},
     },
     axis: {
       arrow: false,


### PR DESCRIPTION
# Theme 

简单调整一下 Theme 的结构。

## 思路

Theme 的本质是**默认值**，而 G2 是由一系列可视化组件构成的，所以 Theme 应该是所有组件的默认值。那么结构就应该是 key 为组件名（不用加 namespace），value 为该组件对应的默认值。用 ts 表示如下：

```ts
type ComponentName = 'interval' | 'axis' | 'binX'; // ....
type Theme = Record<ComponentName, Record<string, any>>;
```
一个简单的例子如下：

```js
const theme = {
  binX: {}, // Transform
  axis: {}, // Static Mark
  tooltip: {},  // Interaction
  interval: {}, // Mark
}
```

当然除了组件的默认值，还有一些全局属性，比如：默认颜色，色板等，这些直接作为顶层的属性。

```js
const theme = {
  color: 'red',
  size: 1,
  category: 'category10'
}
```

或者说都放在 globals 下？

```js
const theme = {
  globals: {
    color: 'red',
    size: 1,
    category: 'category10'
  }
}
```

## 变化

- view 相关的属性都收口到 view 下: 按照上面的思路，view 是一个单独可视化组件，属性应该放在一起。

```js
// Before
const theme = {
  viewFill: 'red',
  contentFill: 'red', 
}

// After
const theme = {
  view: { viewFill: 'red', contentFill: 'red' }
}
```

-  全局属性去掉 default 前缀：因为本来就是默认值，不需要加 default。

```js
// Before
const theme = {
   defaultColor: 'red',
}

// After
const theme = {
  color: 'red'
}
```

- 去掉目前的 interaction，将 state 放入每个 shape 下面。

```js
// Before
const theme = {
  interaction: { active: {} }
}

// After 
const theme = {
  active: {}, // global level for all marks
  interval: {
    active: {}, // mark level for this mark.
  }
}
```

