### PR TITLE
fix: broken link for wordcloud

### DIFF
--- a/site/docs/spec/mark/wordcloud.en.md
+++ b/site/docs/spec/mark/wordcloud.en.md
@@ -3,4 +3,4 @@ title: wordCloud
 order: 1
 ---
 
-<embed src="@/docs/spec/mark/wordCloud.zh.md"></embed>
+<embed src="@/docs/spec/mark/wordcloud.zh.md"></embed>


### PR DESCRIPTION
修复这个 https://github.com/antvis/G2/pull/5352 带来的 site 构建问题。