### PR TITLE
fix: projection null

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "test:unit": "node --expose-gc --max-old-space-size=4096 --unhandled-rejections=strict node_modules/jest/bin/jest __tests__/unit/ --coverage -i  --logHeapUsage",
     "test:integration": "node --expose-gc --max-old-space-size=4096 --unhandled-rejections=strict node_modules/jest/bin/jest __tests__/integration/ --coverage -i  --logHeapUsage",
     "test:treeshaking": "vite build -c ./__tests__/treeshaking/vite.config.js",
-    "test-live": "cross-env DEBUG_MODE=1 jest --watch",
     "build:umd": "rimraf ./dist && rollup -c && npm run size",
     "build:cjs": "rimraf ./lib && tsc --module commonjs --outDir lib",
     "build:esm": "rimraf ./esm && tsc --module ESNext --outDir esm",

--- a/src/geo/geoView.ts
+++ b/src/geo/geoView.ts
@@ -184,7 +184,7 @@ export const GeoView: CC<GeoViewOptions> = () => {
             });
             const normalize = (point) => {
               const visualPoint = visual(point);
-              if (!visualPoint) return null;
+              if (!visualPoint) return [null, null];
               const [vx, vy] = visualPoint;
               return [scaleX.map(vx), scaleY.map(vy)];
             };

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,16 +1,24 @@
 import { defineConfig } from 'vite';
 import { deepMix } from '@antv/util';
 
+const { LINK, MODULE } = process.env;
+
+if (LINK === '1' && !MODULE) {
+  throw new Error(
+    `Please specify MODULE, for example: $ MODULE=@antv/gui npm run dev:link.`,
+  );
+}
+
 const linkOptions =
-  process.env.LINK === '1'
+  LINK === '1'
     ? {
         server: {
           watch: {
-            ignored: ['!**/node_modules/@antv/gui/**'],
+            ignored: [`!**/node_modules/${MODULE}/**`],
           },
         },
         optimizeDeps: {
-          exclude: ['@antv/gui'],
+          exclude: [`${MODULE}`],
         },
       }
     : {};


### PR DESCRIPTION
- 修复 coordinate.map 传入 null 的情况报错：

```js
// 之前如下是可以的
// 现在会报错
// 应该是 tslib 生成的构建代码有关系
coordinate.map(null);
```

- 添加 link node_modules 的命令：

```bash
$ MODULE=@antv/coord tnpm run dev:link
```

基于此添加了 `dev:link-gui` 的命令作为一个示例。