### PR TITLE
fix: label dom leak when chart re-render

### DIFF
--- a/__tests__/integration/snapshots/tooltip/flare-treemap-poptip-custom/step0.html
+++ b/__tests__/integration/snapshots/tooltip/flare-treemap-poptip-custom/step0.html
@@ -1,4 +1,4 @@
-<foreignObject xmlns="http://www.w3.org/2000/svg" fill="none" class="poptip">
+<foreignObject xmlns="http://www.w3.org/2000/svg" class="poptip">
   <div xmlns="http://www.w3.org/1999/xhtml">
     <div style="background-color:red;color:#fff;width:max-content;padding:1px 4px;font-size:12px;border-radius:2.5px;box-shadow:0 3px 6px -4px rgba(0,0,0,0.12), 0 6px 16px 0 rgba(0,0,0,0.08), 0 9px 28px 8px rgba(0,0,0,0.05)">
       Rectangle

--- a/__tests__/integration/snapshots/tooltip/flare-treemap-poptip/step1.html
+++ b/__tests__/integration/snapshots/tooltip/flare-treemap-poptip/step1.html
@@ -1,4 +1,4 @@
-<foreignObject xmlns="http://www.w3.org/2000/svg" fill="none" class="poptip">
+<foreignObject xmlns="http://www.w3.org/2000/svg" class="poptip">
   <div xmlns="http://www.w3.org/1999/xhtml">
     <div style="background-color:rgba(0,0,0,0.75);color:#fff;width:max-content;padding:1px 4px;font-size:12px;border-radius:2.5px;box-shadow:0 3px 6px -4px rgba(0,0,0,0.12), 0 6px 16px 0 rgba(0,0,0,0.08), 0 9px 28px 8px rgba(0,0,0,0.05)">
       Rectangle

--- a/__tests__/integration/snapshots/tooltip/flare-treemap-poptip/step3.html
+++ b/__tests__/integration/snapshots/tooltip/flare-treemap-poptip/step3.html
@@ -1,4 +1,4 @@
-<foreignObject xmlns="http://www.w3.org/2000/svg" fill="none" class="poptip">
+<foreignObject xmlns="http://www.w3.org/2000/svg" class="poptip">
   <div xmlns="http://www.w3.org/1999/xhtml">
     <div style="background-color:rgba(0,0,0,0.75);color:#fff;width:max-content;padding:1px 4px;font-size:12px;border-radius:2.5px;box-shadow:0 3px 6px -4px rgba(0,0,0,0.12), 0 6px 16px 0 rgba(0,0,0,0.08), 0 9px 28px 8px rgba(0,0,0,0.05)">
       Rectangle

--- a/__tests__/plots/static/alphabet-interval-html-label.ts
+++ b/__tests__/plots/static/alphabet-interval-html-label.ts
@@ -19,11 +19,6 @@ export function alphabetIntervalHtmlLabel(): G2Spec {
     labels: [
       {
         text: 'frequency',
-        transform: [
-          {
-            type: 'overlapHide',
-          },
-        ],
         className: 'alphabet-labels',
         render: (
           _,

--- a/src/shape/text/advance.ts
+++ b/src/shape/text/advance.ts
@@ -130,7 +130,6 @@ function inferConnectorPath(
 
 export const Advance = createElement((g) => {
   const {
-    id,
     className,
     // Do not pass className
     class: _c,
@@ -170,7 +169,7 @@ export const Advance = createElement((g) => {
   // Use html to customize advance text.
   if (innerHTML) {
     textShape = select(g)
-      .maybeAppend(id, 'html', className)
+      .maybeAppend('html', 'html', className)
       .style('zIndex', 0)
       .style('innerHTML', innerHTML)
       .call(applyStyle, {


### PR DESCRIPTION
- fixed https://github.com/antvis/G2/issues/5390
- https://github.com/antvis/G/issues/1475 G 底层 HTML 组件通过 id 查找的 bug


等待 G 发布版本解决。