### PR TITLE
docs: fix broken link

### DIFF
--- a/site/.dumirc.ts
+++ b/site/.dumirc.ts
@@ -405,7 +405,7 @@ export default defineConfig({
             zh: '开始使用',
             en: 'Getting Started',
           },
-          link: `/manual/getting-started`,
+          link: `/manual/introduction/getting-started`,
         },
       ],
     },


### PR DESCRIPTION
修复下图中开始使用链接失效：

![image](https://github.com/antvis/G2/assets/49330279/6ada52f0-37b6-4e2f-a3b8-16e6abf1249b)
