### PR TITLE
fix(types): add types for Chart interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # G2 - Changelog
 
+## [5.0.20](https://github.com/antvis/g2/compare/5.0.19...5.0.20) (2023-08-17)
+
+### Bug Fixes
+
+- **interaction:** multi interaction ([#5419](https://github.com/antvis/g2/issues/5419)) ([328aeea](https://github.com/antvis/g2/commit/328aeeac34e770ff2c28f5b1a8ad704ab00af0a5))
+- **types:** add types for Chart interface ([acd81b9](https://github.com/antvis/g2/commit/acd81b93facc110015a38922e766a1fe5d7f9069))
+
 ## [5.0.19](https://github.com/antvis/g2/compare/5.0.18...5.0.19) (2023-08-15)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2",
-  "version": "5.0.19",
+  "version": "5.0.20",
   "description": "the Grammar of Graphics in Javascript",
   "license": "MIT",
   "main": "lib/index.js",

--- a/site/package.json
+++ b/site/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.19",
+  "version": "5.0.20",
   "scripts": {
     "start": "dumi dev",
     "build": "dumi build",

--- a/src/api/chart.ts
+++ b/src/api/chart.ts
@@ -1,8 +1,8 @@
-import { extend } from './extend';
+import { G2Spec } from 'spec';
+import { extend, API } from './extend';
 import { library } from './library';
 import { Runtime } from './runtime';
 
-// Use a empty interface to mark Chart both a value and a class type.
-export interface Chart {}
+export interface Chart extends API<G2Spec, typeof library> {}
 
 export const Chart = extend(Runtime, library);

--- a/src/api/chart.ts
+++ b/src/api/chart.ts
@@ -1,4 +1,4 @@
-import { G2Spec } from 'spec';
+import { G2Spec } from '../spec';
 import { extend, API } from './extend';
 import { library } from './library';
 import { Runtime } from './runtime';

--- a/src/api/extend.ts
+++ b/src/api/extend.ts
@@ -16,15 +16,17 @@ type CompositionOf<Library> = Of<
     CompositionOf<Library>
 >;
 
+export type API<Spec, Library> = Runtime<Spec> &
+  MarkOf<Library, (composite?) => MarkNode> &
+  CompositionOf<Library>;
+
 export function extend<
   Spec extends G2Spec = G2Spec,
   Library extends G2Library = G2Library,
 >(
   Runtime: new (options: RuntimeOptions) => Runtime<Spec>,
   library: Library,
-): new (options?: RuntimeOptions) => Runtime<Spec> &
-  MarkOf<Library, (composite?) => MarkNode> &
-  CompositionOf<Library> {
+): new (options?: RuntimeOptions) => API<Spec, Library> {
   class Chart extends Runtime {
     constructor(options: Omit<RuntimeOptions, 'lib'>) {
       super({ ...options, lib: library });


### PR DESCRIPTION
# Chart 类型定义

之前的 Chart 会有问题：

```ts
import { Chart } from '@antv/g2';

const chart = new Chart();

chart.interval() // 有提示！
```

```ts
import { Chart } from '@antv/g2';

const chart: Chart = new Chart();

chart.interval() // 报错，没有提示！
```

## 存在问题

Chart 不是通过 class 声明的：

```ts
const Chart = extend(Runtime, library);
```

所以 Chart 不能作为类型，为了使得它可以作为类型，之前声明了一个空的 interface：

```ts
interface Chart {};
const Chart = extend(Runtime, library);
```

两者的类型理论上会合并，但是 `typeof Chart` 其实是 `new() => Runtime` 一个构造函数，并不是 `Runtime`，也没有 interval 方法。

## 解决办法

所以不能用空的 interface，还是得生成类型。

```ts
export interface Chart extends API<G2Spec, typeof library> {}

export const Chart = extend(Runtime, library);
```