### PR TITLE
chore: add camera animation example

### DIFF
--- a/site/docs/manual/extra-topics/3d-charts.zh.md
+++ b/site/docs/manual/extra-topics/3d-charts.zh.md
@@ -10,10 +10,8 @@ order: 11
 - 设置 z 通道、比例尺和坐标轴
 - 在场景中设置相机
 - 添加光源
-- 使用相机交互
-- 添加图例
-
-我们暂不支持图例。
+- 添加自定义图例
+- 使用相机交互与动画
 
 ## 创建 WebGL 渲染器和插件
 
@@ -301,12 +299,6 @@ canvas.appendChild(light);
 })();
 ```
 
-## 使用相机交互
-
-3D 场景下的交互和 2D 场景有很大的不同，[g-plugin-control](https://g.antv.antgroup.com/plugins/control) 提供了 3D 场景下基于相机的交互。当我们拖拽画布时，会控制相机绕视点进行旋转操作，而鼠标滚轮的缩放会让相机进行 dolly 操作。
-
-需要注意的是缩放操作在正交投影下是没有效果的，但旋转操作依然有效。
-
 ## 添加自定义图例
 
 你可能注意到在上面的例子中我们刻意关闭了图例：
@@ -417,6 +409,171 @@ chart.legend(false);
 
   chart.render().then(() => {
     legendColor(chart);
+
+    const { canvas } = chart.getContext();
+    const camera = canvas.getCamera();
+    camera.setPerspective(0.1, 5000, 45, 500 / 500);
+    camera.setType(g.CameraType.ORBITING);
+
+    // Add a directional light into scene.
+    const light = new gPlugin3d.DirectionalLight({
+      style: {
+        intensity: 3,
+        fill: 'white',
+        direction: [-1, 0, 1],
+      },
+    });
+    canvas.appendChild(light);
+  });
+
+  return chart.getContainer();
+})();
+```
+
+## 使用相机交互与动画
+
+3D 场景下的交互和 2D 场景有很大的不同，[g-plugin-control](https://g.antv.antgroup.com/plugins/control) 提供了 3D 场景下基于相机的交互。当我们拖拽画布时，会控制相机绕视点进行旋转操作，而鼠标滚轮的缩放会让相机进行 dolly 操作。需要注意的是缩放操作在正交投影下是没有效果的，但旋转操作依然有效。
+
+当用户经过了一番相机操作，有时想回到初始状态，例如 [plot.ly](https://plotly.com/javascript/3d-line-plots/) 在操作工具栏中就提供了 “Reset camera to default” 按钮。使用 G 提供的[相机动画 API](https://g.antv.antgroup.com/api/camera/animation)，我们可以实现在任意相机位置间平滑过渡：
+
+```ts
+const camera = canvas.getCamera();
+camera.createLandmark('default', {
+  position: [250, 250, 500],
+  focalPoint: [250, 250, 0],
+  zoom: 1,
+});
+
+button.onclick = () => {
+  camera.gotoLandmark('default', {
+    duration: 300,
+    easing: 'linear',
+  });
+};
+```
+
+```js | ob { pin: false }
+(() => {
+  function cameraButton(chart) {
+    const node = chart.getContainer();
+    const button = document.createElement('button');
+    button.textContent = 'Reset camera to default';
+    node.insertBefore(button, node.childNodes[0]);
+
+    const { canvas } = chart.getContext();
+    const camera = canvas.getCamera();
+    camera.createLandmark('default', {
+      position: [250, 250, 500],
+      focalPoint: [250, 250, 0],
+      zoom: 1,
+    });
+
+    button.onclick = () => {
+      camera.gotoLandmark('default', {
+        duration: 300,
+        easing: 'linear',
+      });
+    };
+  }
+  // 添加图例
+  function legendColor(chart) {
+    // 创建 Legend 并且挂在图例
+    const node = chart.getContainer();
+    const legend = document.createElement('div');
+    legend.style.display = 'flex';
+    node.insertBefore(legend, node.childNodes[0]);
+
+    // 创建并挂载 Items
+    const { color: scale } = chart.getScale();
+    const { domain } = scale.getOptions();
+    const items = domain.map((value) => {
+      const item = document.createElement('div');
+      const color = scale.map(value);
+      item.style.marginLeft = '1em';
+      item.innerHTML = `
+    <span style="
+      background-color:${color};
+      display:inline-block;
+      width:10px;
+      height:10px;"
+    ></span>
+    <span>${value}</span>
+    `;
+      return item;
+    });
+    items.forEach((d) => legend.append(d));
+
+    // 监听事件
+    const selectedValues = [...domain];
+    const options = chart.options();
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      const value = domain[i];
+      item.style.cursor = 'pointer';
+      item.onclick = () => {
+        const index = selectedValues.indexOf(value);
+        if (index !== -1) {
+          selectedValues.splice(index, 1);
+          item.style.opacity = 0.5;
+        } else {
+          selectedValues.push(value);
+          item.style.opacity = 1;
+        }
+        changeColor(selectedValues);
+      };
+    }
+
+    // 重新渲染视图
+    function changeColor(value) {
+      const { transform = [] } = options;
+      const newTransform = [{ type: 'filter', color: { value } }, ...transform];
+      chart.options({
+        ...options,
+        transform: newTransform, // 指定新的 transform
+        scale: { color: { domain } },
+      });
+      chart.render(); // 重新渲染图表
+    }
+  }
+
+  const renderer = new gWebgl.Renderer();
+  renderer.registerPlugin(new gPluginControl.Plugin());
+  renderer.registerPlugin(new gPlugin3d.Plugin());
+
+  const Chart = G2.extend(G2.Runtime, { ...G2.corelib(), ...G2.threedlib() });
+
+  // 初始化图表实例
+  const chart = new Chart({
+    theme: 'classic',
+    renderer,
+    width: 500,
+    height: 500,
+    depth: 400,
+  });
+
+  chart
+    .point3D()
+    .data({
+      type: 'fetch',
+      value:
+        'https://gw.alipayobjects.com/os/bmw-prod/2c813e2d-2276-40b9-a9af-cf0a0fb7e942.csv',
+    })
+    .encode('x', 'Horsepower')
+    .encode('y', 'Miles_per_Gallon')
+    .encode('z', 'Weight_in_lbs')
+    .encode('color', 'Origin')
+    .coordinate({ type: 'cartesian3D' })
+    .scale('x', { nice: true })
+    .scale('y', { nice: true })
+    .scale('z', { nice: true })
+    .legend(false)
+    .axis('x', { gridLineWidth: 2 })
+    .axis('y', { gridLineWidth: 2, titleBillboardRotation: -Math.PI / 2 })
+    .axis('z', { gridLineWidth: 2 });
+
+  chart.render().then(() => {
+    legendColor(chart);
+    cameraButton(chart);
 
     const { canvas } = chart.getContext();
     const camera = canvas.getCamera();

--- a/site/examples/threed/scatter/demo/camera-animation.ts
+++ b/site/examples/threed/scatter/demo/camera-animation.ts
@@ -1,0 +1,143 @@
+import { CameraType } from '@antv/g';
+import { Renderer as WebGLRenderer } from '@antv/g-webgl';
+import { Plugin as ThreeDPlugin, DirectionalLight } from '@antv/g-plugin-3d';
+import { Plugin as ControlPlugin } from '@antv/g-plugin-control';
+import { Runtime, corelib, threedlib, extend } from '@antv/g2';
+
+function cameraButton(chart) {
+  const node = chart.getContainer();
+  const button = document.createElement('button');
+  button.textContent = 'Reset camera to default';
+  node.insertBefore(button, node.childNodes[0]);
+
+  const { canvas } = chart.getContext();
+  const camera = canvas.getCamera();
+  camera.createLandmark('default', {
+    position: [320, 240, 500],
+    focalPoint: [320, 240, 0],
+    zoom: 1,
+  });
+
+  button.onclick = () => {
+    camera.gotoLandmark('default', {
+      duration: 300,
+      easing: 'linear',
+    });
+  };
+}
+
+// 添加图例
+function legendColor(chart) {
+  // 创建 Legend 并且挂在图例
+  const node = chart.getContainer();
+  const legend = document.createElement('div');
+  legend.style.display = 'flex';
+  node.insertBefore(legend, node.childNodes[0]);
+
+  // 创建并挂载 Items
+  const { color: scale } = chart.getScale();
+  const { domain } = scale.getOptions();
+  const items = domain.map((value) => {
+    const item = document.createElement('div');
+    const color = scale.map(value);
+    item.style.marginLeft = '1em';
+    item.innerHTML = `
+    <span style="
+      background-color:${color};
+      display:inline-block;
+      width:10px;
+      height:10px;"
+    ></span>
+    <span>${value}</span>
+    `;
+    return item;
+  });
+  items.forEach((d) => legend.append(d));
+
+  // 监听事件
+  const selectedValues = [...domain];
+  const options = chart.options();
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const value = domain[i];
+    item.style.cursor = 'pointer';
+    item.onclick = () => {
+      const index = selectedValues.indexOf(value);
+      if (index !== -1) {
+        selectedValues.splice(index, 1);
+        item.style.opacity = 0.5;
+      } else {
+        selectedValues.push(value);
+        item.style.opacity = 1;
+      }
+      changeColor(selectedValues);
+    };
+  }
+
+  // 重新渲染视图
+  function changeColor(value) {
+    const { transform = [] } = options;
+    const newTransform = [{ type: 'filter', color: { value } }, ...transform];
+    chart.options({
+      ...options,
+      transform: newTransform, // 指定新的 transform
+      scale: { color: { domain } },
+    });
+    chart.render(); // 重新渲染图表
+  }
+}
+
+// Create a WebGL renderer.
+const renderer = new WebGLRenderer();
+renderer.registerPlugin(new ThreeDPlugin());
+renderer.registerPlugin(new ControlPlugin());
+
+// Customize our own Chart with threedlib.
+const Chart = extend(Runtime, { ...corelib(), ...threedlib() });
+const chart = new Chart({
+  container: 'container',
+  theme: 'classic',
+  renderer,
+  depth: 400, // Define the depth of chart.
+});
+
+chart
+  .point3D()
+  .data({
+    type: 'fetch',
+    value:
+      'https://gw.alipayobjects.com/os/bmw-prod/2c813e2d-2276-40b9-a9af-cf0a0fb7e942.csv',
+  })
+  .encode('x', 'Horsepower')
+  .encode('y', 'Miles_per_Gallon')
+  .encode('z', 'Weight_in_lbs')
+  .encode('color', 'Origin')
+  .coordinate({ type: 'cartesian3D' })
+  .scale('x', { nice: true })
+  .scale('y', { nice: true })
+  .scale('z', { nice: true })
+  .legend(false)
+  .axis('x', { gridLineWidth: 2 })
+  .axis('y', { gridLineWidth: 2, titleBillboardRotation: -Math.PI / 2 })
+  .axis('z', { gridLineWidth: 2 });
+
+chart.render().then(() => {
+  legendColor(chart);
+  cameraButton(chart);
+
+  const { canvas } = chart.getContext();
+  const camera = canvas.getCamera();
+  // Use perspective projection mode.
+  camera.setPerspective(0.1, 5000, 45, 640 / 480);
+  camera.setType(CameraType.ORBITING);
+
+  // Add a directional light into scene.
+  const light = new DirectionalLight({
+    style: {
+      intensity: 3,
+      fill: 'white',
+      direction: [-1, 0, 1],
+    },
+  });
+  canvas.appendChild(light);
+});

--- a/site/examples/threed/scatter/demo/meta.json
+++ b/site/examples/threed/scatter/demo/meta.json
@@ -26,7 +26,7 @@
         "zh": "球体",
         "en": "Sphere"
       },
-      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*KNCUQqzw2JsAAAAAAAAAAAAADmJ7AQ/original"
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*8t0aRJLbhuwAAAAAAAAAAAAADmJ7AQ/original"
     },
     {
       "filename": "custom-legend.ts",
@@ -35,6 +35,14 @@
         "en": "Customize legend"
       },
       "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*SmF_Ro5UYcwAAAAAAAAAAAAADmJ7AQ/original"
+    },
+    {
+      "filename": "camera-animation.ts",
+      "title": {
+        "zh": "相机动画",
+        "en": "Camera animation"
+      },
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*ffrAS7t1EDcAAAAAAAAAAAAADmJ7AQ/original"
     }
   ]
 }


### PR DESCRIPTION
当用户经过了一番相机操作，有时想回到初始状态，例如 [plot.ly](https://plotly.com/javascript/3d-line-plots/) 在操作工具栏中就提供了 “Reset camera to default” 按钮：

<img width="647" alt="截屏2023-08-18 下午5 13 18" src="https://github.com/antvis/G2/assets/3608471/d7ff4d7d-efad-4924-8fe0-9de35123a441">

使用 G 提供的[相机动画 API](https://g.antv.antgroup.com/api/camera/animation)，我们可以实现在任意相机位置间平滑过渡：

![Aug-18-2023 17-15-05](https://github.com/antvis/G2/assets/3608471/e72b28a0-ece8-4acd-8409-a8ae1774e2b8)