### PR TITLE
feat(lib): change graphlib and plotlib

### DIFF
--- a/__tests__/unit/lib/graph.spec.ts
+++ b/__tests__/unit/lib/graph.spec.ts
@@ -1,11 +1,17 @@
 import { graphlib } from '../../../src/lib';
-import { ForceGraph, Tree } from '../../../src/mark';
+import { ForceGraph, Tree, Sankey, Treemap, Pack } from '../../../src/mark';
+import { Cluster, Arc } from '../../../src/data';
 
 describe('graphlib', () => {
   it('graphlib() should returns expected graph components.', () => {
     expect(graphlib()).toEqual({
+      'data.cluster': Cluster,
+      'data.arc': Arc,
       'mark.forceGraph': ForceGraph,
       'mark.tree': Tree,
+      'mark.sankey': Sankey,
+      'mark.treemap': Treemap,
+      'mark.pack': Pack,
     });
   });
 });

--- a/__tests__/unit/lib/plot.spec.ts
+++ b/__tests__/unit/lib/plot.spec.ts
@@ -1,23 +1,11 @@
 import { plotlib } from '../../../src/lib';
-import {
-  Sankey,
-  Treemap,
-  Pack,
-  Boxplot,
-  WordCloud,
-  Gauge,
-} from '../../../src/mark';
-import { Venn, Cluster, Arc } from '../../../src/data';
+import { Boxplot, WordCloud, Gauge } from '../../../src/mark';
+import { Venn } from '../../../src/data';
 
 describe('plotlib', () => {
   it('plotlib() should returns expected plot components.', () => {
     expect(plotlib()).toEqual({
       'data.venn': Venn,
-      'data.cluster': Cluster,
-      'data.arc': Arc,
-      'mark.sankey': Sankey,
-      'mark.treemap': Treemap,
-      'mark.pack': Pack,
       'mark.boxplot': Boxplot,
       'mark.wordCloud': WordCloud,
       'mark.gauge': Gauge,

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -1,8 +1,14 @@
-import { ForceGraph, Tree } from '../mark';
+import { Sankey, Treemap, Pack, ForceGraph, Tree } from '../mark';
+import { Arc, Cluster } from '../data';
 
 export function graphlib() {
   return {
+    'data.arc': Arc,
+    'data.cluster': Cluster,
     'mark.forceGraph': ForceGraph,
     'mark.tree': Tree,
+    'mark.pack': Pack,
+    'mark.sankey': Sankey,
+    'mark.treemap': Treemap,
   } as const;
 }

--- a/src/lib/plot.ts
+++ b/src/lib/plot.ts
@@ -1,15 +1,10 @@
-import { Sankey, Treemap, Pack, Boxplot, WordCloud, Gauge } from '../mark';
-import { Arc, Cluster, Venn } from '../data';
+import { Boxplot, WordCloud, Gauge } from '../mark';
+import { Venn } from '../data';
 
 export function plotlib() {
   return {
     'data.venn': Venn,
-    'data.arc': Arc,
-    'data.cluster': Cluster,
-    'mark.sankey': Sankey,
-    'mark.treemap': Treemap,
     'mark.boxplot': Boxplot,
-    'mark.pack': Pack,
     'mark.gauge': Gauge,
     'mark.wordCloud': WordCloud,
   } as const;


### PR DESCRIPTION
调整 graphlib 和 plotlib：

```ts
export function graphlib() {
  return {
    'mark.forceGraph': ForceGraph,
    'mark.tree': Tree,
    'mark.pack': Pack,
    'data.arc': Arc,
    'data.cluster': Cluster,
    'mark.sankey': Sankey,
    'mark.treemap': Treemap,
  } as const;
}
```

```ts
export function plotlib() {
  return {
    'data.venn': Venn,
    'mark.boxplot': Boxplot,
    'mark.gauge': Gauge,
    'mark.wordCloud': WordCloud,
  } as const;
}
```