### PR TITLE
fix(bundle): add ./esm/index.js to package.sideEffects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [5.0.24](https://github.com/antvis/g2/compare/5.0.23...5.0.24) (2023-08-30)
+
+
+### Bug Fixes
+
+* **test:** call defined render function ([#5481](https://github.com/antvis/g2/issues/5481)) ([c0c5746](https://github.com/antvis/g2/commit/c0c574683f3cd97b1813fa3dc7454137b8ae6ad4))
+* **theme:** update default color of light theme ([#5487](https://github.com/antvis/g2/issues/5487)) ([7cbe9a7](https://github.com/antvis/g2/commit/7cbe9a7cf8ea537c274288c4f55118b9544ae622))
+
+
+### Features
+
+* 3d line plot ([#5471](https://github.com/antvis/g2/issues/5471)) ([4d157cd](https://github.com/antvis/g2/commit/4d157cd162a805d8a68a29a5abf216074fb2058f))
+* **builtinlib:** move some components from core to builtinlib ([#5485](https://github.com/antvis/g2/issues/5485)) ([fc70bf5](https://github.com/antvis/g2/commit/fc70bf5423b73b1b06ff3b551e2a5a5902dd3527))
+* **lib:** change graphlib and plotlib ([#5484](https://github.com/antvis/g2/issues/5484)) ([ad175a0](https://github.com/antvis/g2/commit/ad175a0b232552c94c3c6d6305da28a9c42ee497))
+
+
+
 ## [5.0.23](https://github.com/antvis/g2/compare/5.0.22...5.0.23) (2023-08-29)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2",
-  "version": "5.0.23",
+  "version": "5.0.24",
   "description": "the Grammar of Graphics in Javascript",
   "license": "MIT",
   "main": "lib/index.js",
@@ -42,7 +42,7 @@
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },
   "sideEffects": [
-    "./src/index.ts"
+    "./esm/index.js"
   ],
   "keywords": [
     "antv",

--- a/site/package.json
+++ b/site/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.23",
+  "version": "5.0.24",
   "scripts": {
     "start": "dumi dev",
     "build": "dumi build",


### PR DESCRIPTION
# SideEffects

目前出现了一系列**开发环境**和**线上环境**运行结果不一致的问题。

## 存在问题

经过排查这个问题和 https://github.com/antvis/G2/pull/5391 引入的 treeshaking 能力有关系: `package.json` 里面 `sideEffects` 写错文件，指定的有副作用的应该是构建后产物 `esm/index.js` 而不是 `src/index.ts`

```json
{
  "sideEffects": ["src/index.ts"]
}
```

这导致打包后的产物少了以下的两行代码：

```js
import { runtime } from '@antv/g';

runtime.enableCSSParsing = false;
```

最后使得线上和线下的运行结果不一致。

## 解决办法

修改 `package.json` 如下：

```json
{
  "sideEffects": ["./esm/index.js"]
}
```

## 未来工作

@xiaoiver  `@antv/g` 可以不把 `enableCSSParsing` 作为一个全局配置，而是和 canvas 的一个配置。这样 G2 就没有 sideEffects 了。 

```js
import { Canvas } from '@anvtv/g';

const canvas = new Canvas({
  enableCSSParsing: false,
});
```