### PR TITLE
fix(runtime): process data

### DIFF
--- a/__tests__/plots/static/gauge-default.ts
+++ b/__tests__/plots/static/gauge-default.ts
@@ -2,7 +2,8 @@ import { G2Spec } from '../../../src';
 
 export function gaugeDefault(): G2Spec {
   return {
-    type: 'gauge',
+    type: 'view',
+    legend: false,
     data: {
       value: {
         target: 120,
@@ -10,5 +11,6 @@ export function gaugeDefault(): G2Spec {
         name: 'score',
       },
     },
+    children: [{ type: 'gauge' }],
   };
 }

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -500,8 +500,16 @@ async function transformMarks(
       const { composite = true } = props;
       if (!composite) flattenMarks.push(mark);
       else {
+        // Unwrap data from { value: data } to data,
+        // then the composite mark can process the normalized data.
+        const { data } = mark;
+        const newMark = {
+          ...mark,
+          data: data ? (Array.isArray(data) ? data : data.value) : data,
+        };
+
         // Convert composite mark to marks.
-        const marks = await useMark(mark, context);
+        const marks = await useMark(newMark, context);
         const M = Array.isArray(marks) ? marks : [marks];
         discovered.unshift(...M.map((d, i) => ({ ...d, key: `${key}-${i}` })));
       }

--- a/src/runtime/transform.ts
+++ b/src/runtime/transform.ts
@@ -42,9 +42,20 @@ export async function applyDataTransform(
   const transform = [connector, ...T];
   const transformFunctions = transform.map(useData);
   const transformedData = await composeAsync(transformFunctions)(data);
+
+  // Maintain the consistency of shape between input and output data.
+  // If the shape of raw data is like { value: any }
+  // and the returned transformedData is Object,
+  // returns the wrapped data: { value: transformedData },
+  // otherwise returns the processed tabular data.
+  const newData =
+    data && !Array.isArray(data) && !Array.isArray(transformedData)
+      ? { value: transformedData }
+      : transformedData;
+
   return [
     Array.isArray(transformedData) ? indexOf(transformedData) : [],
-    { ...mark, data: transformedData },
+    { ...mark, data: newData },
   ];
 }
 


### PR DESCRIPTION
## 数据处理

之前如下的代码无法正常渲染：

```ts
export function gaugeDefault(): G2Spec {
  return {
    type: 'view',
    data: {
      value: {
        target: 120,
        total: 400,
        name: 'score',
      },
    },
    children: [{ type: 'gauge' }],
  };
}
```

## 原因

原因是因为在 view 层会把非表格数据 `{ value: { target: 120,  total: 400, name: 'score', } }` 处理成 `{ target: 120,  total: 400, name: 'score', }` 给 gauge，导致 gauge 处理出错。

本质上还是非表格数据必须写成 `{ value: data }` 的形式，但是表格数据可以直接写成 `data`。

## 解决办法

view 层处理数据的时候保证数据的结构：如果是表格数据就返回表格数据，否者返回 `{ value: data }` 形式的数据。

## 结果

<img src="https://github.com/antvis/G2/assets/49330279/2e097219-54ed-4138-99de-f24fce6c4dbf" width=640 />

## 额外

至于为啥 G2 官网上代码可以正常运行，是因为 G2 官网的 Chart 为了更好展示 Spec 会有一些额外的处理。

![image](https://github.com/antvis/G2/assets/49330279/7ef40a6b-249e-4138-bc95-008001c36cb6)

![image](https://github.com/antvis/G2/assets/49330279/1c94fbad-a768-46b0-b700-1b16bc697b13)

