### PR TITLE
Add Usage Trends of Antv Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ If all goes well, you can get the following lovely bar chart!
 
 <img src="https://gw.alipayobjects.com/zos/antfincdn/hTzzaqgHgQ/Antv%252520G2%252520%26%252520G2Plot.png" width="200" height="266" alt="code"/>
 
+## 📮 Usage Trend of AntV Packages
+
+[Usage Trend of AntV Packages](https://npm-compare.com/@antv/g2,@antv/g2plot,@antv/g6,@antv/graphlib,@antv/x6,@antv/l7,@antv/l7plot,@antv/xflow,@antv/graphin)
+
 ## 📄 License
 
 MIT@[AntV](https://github.com/antvis).

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If all goes well, you can get the following lovely bar chart!
 
 <img src="https://gw.alipayobjects.com/zos/antfincdn/hTzzaqgHgQ/Antv%252520G2%252520%26%252520G2Plot.png" width="200" height="266" alt="code"/>
 
-## 📮 Usage Trend of AntV Packages
+## 📊 Usage Trend of AntV Packages
 
 [Usage Trend of AntV Packages](https://npm-compare.com/@antv/g2,@antv/g2plot,@antv/g6,@antv/graphlib,@antv/x6,@antv/l7,@antv/l7plot,@antv/xflow,@antv/graphin)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,6 +94,10 @@ chart.render();
 
 <img src="https://gw.alipayobjects.com/zos/antfincdn/hTzzaqgHgQ/Antv%252520G2%252520%26%252520G2Plot.png" width="200" height="266" alt="code"/>
 
+## 📊 AntV系列使用趋势
+
+[AntV系列使用趋势](https://npm-compare.com/@antv/g2,@antv/g2plot,@antv/g6,@antv/graphlib,@antv/x6,@antv/l7,@antv/l7plot,@antv/xflow,@antv/graphin)
+
 ## 📄 许可证
 
 MIT@[AntV](https://github.com/antvis).


### PR DESCRIPTION
I hope you're doing well! I've been a fan of the AntV packages for a while now, and I've found them incredibly useful for my projects. I noticed that the README for the AntV serial packages lacks some valuable information that could help users get a better sense of the package's popularity and activity on GitHub.

To enhance the user experience and provide more insights into the AntV packages, I would like to propose adding a link to an NPM usage trend tool in the README. This tool will allow users to see the usage trend, the latest commit time, and the GitHub star count for each AntV serial package.

By including this link in the README, users will have quick access to important information that can help them make informed decisions when choosing the right AntV package for their projects.

Thank you for your consideration, and I look forward to hearing your thoughts on this enhancement.

