### PR TITLE
chore: set target to es5 for umd

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ chart
   .encode('x', 'genre') // Assign genre column to x position channel.
   .encode('y', 'sold'); // Assign sold column to y position channel.
 
-// Render visualization。
+// Render visualization.
 chart.render();
 ```
 

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     },
     {
       "path": "dist/g2.min.js",
-      "limit": "1.2 Mb"
+      "limit": "1.5 Mb"
     }
   ],
   "author": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,9 +33,16 @@ export default {
     resolve(),
     commonjs(),
     typescript({
-      exclude: 'node_modules/**',
       useTsconfigDeclarationDir: true,
-      extensions: ['.js', '.ts'],
+      tsconfigOverride: {
+        compilerOptions: {
+          target: 'es5',
+          downlevelIteration: true,
+          allowJs: true, // To transform js files in node_modules to es5.
+          declaration: false, // Avoid failing to generate types from js files.
+        },
+      },
+      include: ['src/**/*.ts+(|x)', '**/node_modules/**/*.js+(|x)'],
     }),
     terser(),
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,5 @@
     "baseUrl": "src",
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
将 umd 的 target 设置为 es5，在打包 src 的情况同时打包 node_modules 里面的文件。