### PR TITLE
fix: remove console.log in runtime

### DIFF
--- a/src/runtime/transform.ts
+++ b/src/runtime/transform.ts
@@ -342,6 +342,5 @@ function normalizedDataSource(data) {
   if (!data) return { type: 'inline', value: null };
   if (Array.isArray(data)) return { type: 'inline', value: data };
   const { type = 'inline', ...rest } = data;
-  console.log(rest);
   return { ...rest, type };
 }


### PR DESCRIPTION
Remove `console.log` introduced by https://github.com/antvis/G2/pull/5508