### PR TITLE
fix: set target to es6 for umd

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UMD</title>
+    <script src="./dist/g2.min.js"></script>
+  </head>
+  <body>
+    <div id="container"></div>
+  </body>
+  <script>
+    const data = [
+      { genre: 'Sports', sold: 275 },
+      { genre: 'Strategy', sold: 115 },
+      { genre: 'Action', sold: 120 },
+      { genre: 'Shooter', sold: 350 },
+      { genre: 'Other', sold: 150 },
+    ];
+
+    const chart = new G2.Chart({
+      container: 'container',
+    });
+
+    chart
+      .interval()
+      .data(data)
+      .encode('x', 'genre')
+      .encode('y', 'sold')
+      .encode('color', 'genre');
+
+    chart.render();
+  </script>
+</html>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,15 +34,6 @@ export default {
     commonjs(),
     typescript({
       useTsconfigDeclarationDir: true,
-      tsconfigOverride: {
-        compilerOptions: {
-          target: 'es5',
-          downlevelIteration: true,
-          allowJs: true, // To transform js files in node_modules to es5.
-          declaration: false, // Avoid failing to generate types from js files.
-        },
-      },
-      include: ['src/**/*.ts+(|x)', '**/node_modules/**/*.js+(|x)'],
     }),
     terser(),
   ],

--- a/vite.config.js
+++ b/vite.config.js
@@ -31,6 +31,7 @@ export default defineConfig(
         port: 8080,
         open: '/',
       },
+      build: { outDir: '../' },
     },
     linkOptions,
   ),


### PR DESCRIPTION
# 打包问题

修复 https://github.com/antvis/G2/pull/5515 带来的问题：

- fix: https://github.com/antvis/G2/issues/5548
- fix: https://github.com/antvis/G2/issues/5552

## 问题

出现原因是通过 tsc 打包 es5 的时候会存在一些问题。

## 解决办法

- 暂时先提供 es6 的版本
- 增加 `npm run preview` 配置去预览 umd 绘制的图表，每次发包之前预览一下，防止打包环节引入的 bug。