### PR TITLE
fix(tooltip): find closest for band scale

### DIFF
--- a/__tests__/integration/snapshots/tooltip/mock-tooltip-closest/step0.html
+++ b/__tests__/integration/snapshots/tooltip/mock-tooltip-closest/step0.html
@@ -1,0 +1,75 @@
+<div
+  xmlns="http://www.w3.org/1999/xhtml"
+  class="g2-tooltip"
+  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular; left: 560px; top: 310px;"
+>
+  <div
+    class="g2-tooltip-title"
+    style="color: rgba(0, 0, 0, 0.45); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+  >
+    10:40
+  </div>
+  <ul
+    class="g2-tooltip-list"
+    style="margin: 0px; list-style-type: none; padding: 0px;"
+  >
+    <li
+      class="g2-tooltip-list-item"
+      data-index="0"
+      style="list-style-type: none; display: flex; line-height: 2em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="g2-tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="g2-tooltip-list-item-marker"
+          style="background: rgb(253, 174, 107); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="g2-tooltip-list-item-name-label"
+          title="people"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          people
+        </span>
+      </span>
+      <span
+        class="g2-tooltip-list-item-value"
+        title="2"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        2
+      </span>
+    </li>
+    <li
+      class="g2-tooltip-list-item"
+      data-index="1"
+      style="list-style-type: none; display: flex; line-height: 2em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="g2-tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="g2-tooltip-list-item-marker"
+          style="background: rgb(23, 131, 255); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="g2-tooltip-list-item-name-label"
+          title="waiting"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          waiting
+        </span>
+      </span>
+      <span
+        class="g2-tooltip-list-item-value"
+        title="1"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        1
+      </span>
+    </li>
+  </ul>
+</div>

--- a/__tests__/integration/snapshots/tooltip/mock-tooltip-closest/step1.html
+++ b/__tests__/integration/snapshots/tooltip/mock-tooltip-closest/step1.html
@@ -1,0 +1,75 @@
+<div
+  xmlns="http://www.w3.org/1999/xhtml"
+  class="g2-tooltip"
+  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: Roboto-Regular; left: 155px; top: 310px;"
+>
+  <div
+    class="g2-tooltip-title"
+    style="color: rgba(0, 0, 0, 0.45); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+  >
+    10:15
+  </div>
+  <ul
+    class="g2-tooltip-list"
+    style="margin: 0px; list-style-type: none; padding: 0px;"
+  >
+    <li
+      class="g2-tooltip-list-item"
+      data-index="0"
+      style="list-style-type: none; display: flex; line-height: 2em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="g2-tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="g2-tooltip-list-item-marker"
+          style="background: rgb(253, 174, 107); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="g2-tooltip-list-item-name-label"
+          title="people"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          people
+        </span>
+      </span>
+      <span
+        class="g2-tooltip-list-item-value"
+        title="3"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        3
+      </span>
+    </li>
+    <li
+      class="g2-tooltip-list-item"
+      data-index="1"
+      style="list-style-type: none; display: flex; line-height: 2em; align-items: center; justify-content: space-between; white-space: nowrap;"
+    >
+      <span
+        class="g2-tooltip-list-item-name"
+        style="display: flex; align-items: center; max-width: 216px;"
+      >
+        <span
+          class="g2-tooltip-list-item-marker"
+          style="background: rgb(23, 131, 255); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"
+        />
+        <span
+          class="g2-tooltip-list-item-name-label"
+          title="waiting"
+          style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+        >
+          waiting
+        </span>
+      </span>
+      <span
+        class="g2-tooltip-list-item-value"
+        title="6"
+        style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;"
+      >
+        6
+      </span>
+    </li>
+  </ul>
+</div>

--- a/__tests__/plots/tooltip/index.ts
+++ b/__tests__/plots/tooltip/index.ts
@@ -65,3 +65,4 @@ export { pointsPointRegressionQuad } from './points-point-regression-quad';
 export { alphabetIntervalTooltipRenderUpdate } from './alphabet-interval-tooltip-render-update';
 export { mockIntervalShared } from './mock-interval-shared';
 export { stateAgesIntervalCustomStyle } from './stateages-interval-custom-style';
+export { mockTooltipClosest } from './mock-tooltip-closest';

--- a/__tests__/plots/tooltip/mock-tooltip-closest.ts
+++ b/__tests__/plots/tooltip/mock-tooltip-closest.ts
@@ -1,0 +1,39 @@
+import { seriesTooltipSteps } from './utils';
+
+export function mockTooltipClosest() {
+  return {
+    type: 'view',
+    data: [
+      { time: '10:10', call: 4, waiting: 2, people: 2 },
+      { time: '10:15', call: 2, waiting: 6, people: 3 },
+      { time: '10:20', call: 13, waiting: 2, people: 5 },
+      { time: '10:25', call: 9, waiting: 9, people: 1 },
+      { time: '10:30', call: 5, waiting: 2, people: 3 },
+      { time: '10:35', call: 8, waiting: 2, people: 1 },
+      { time: '10:40', call: 13, waiting: 1, people: 2 },
+    ],
+    children: [
+      {
+        type: 'interval',
+        encode: { x: 'time', y: 'waiting' },
+        axis: { y: { title: 'Waiting', titleFill: '#5B8FF9' } },
+      },
+      {
+        type: 'line',
+        encode: { x: 'time', y: 'people', shape: 'smooth' },
+        scale: { y: { independent: true } },
+        style: { stroke: '#fdae6b', lineWidth: 2 },
+        axis: {
+          y: {
+            position: 'right',
+            grid: null,
+            title: 'People',
+            titleFill: '#fdae6b',
+          },
+        },
+      },
+    ],
+  };
+}
+
+mockTooltipClosest.steps = seriesTooltipSteps([570, 300], [145, 300]);


### PR DESCRIPTION
close: https://github.com/antvis/G2/issues/5543

## 存在问题

双轴图，存在 Item Mark（比如 Interval）和 Series Mark（比如 Line）的时候会有问题：

- 没有拾取到 line 到数据：

<img src="https://github.com/antvis/G2/assets/49330279/d33d1b9a-f60f-4a41-be30-41a4c68ce0b3" width=640 />

- 没有拾取到 interval 的数据：

<img src="https://github.com/antvis/G2/assets/49330279/f336cf3c-d6da-431a-af04-0666715e8323" width=640 />

## 出现原因

- Series Mark 默认不会去拾取超出范围的元素的数据
- Item Mark 默认只会拾取包含鼠标位置的元素的数据

## 解决办法

当是 Band 比例尺的时候，Series tooltip 找到最近的元素。

## TODO

- [x] code
- [x] docs
- [x] examples
- [x] tests

