### PR TITLE
fix(api): only remove created container

### DIFF
--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -567,6 +567,24 @@ describe('Chart', () => {
     expect(chart.getGroup()).toEqual(null);
   });
 
+  it('chart.destroy() should remove created node.', () => {
+    const chart = new Chart({});
+    const container = chart.getContainer();
+    document.body.append(container);
+    expect(container.parentNode).not.toBe(null);
+    chart.destroy();
+    expect(container.parentNode).toBe(null);
+  });
+
+  it('chart.destroy() should not remove provided node.', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const chart = new Chart({ container });
+    expect(container.parentNode).not.toBe(null);
+    chart.destroy();
+    expect(container.parentNode).not.toBe(null);
+  });
+
   it('chart.clear() should clear group.', async () => {
     const chart = new Chart({});
     chart.data([

--- a/__tests__/unit/lib/threed.spec.ts
+++ b/__tests__/unit/lib/threed.spec.ts
@@ -1,7 +1,7 @@
 import { threedlib } from '../../../src/lib';
 import { Cartesian3D } from '../../../src/coordinate';
 import { AxisZ } from '../../../src/component';
-import { Point3D, Line3D } from '../../../src/mark';
+import { Point3D, Line3D, Interval3D } from '../../../src/mark';
 
 describe('threedlib', () => {
   it('threedlib() should returns expected threed components.', () => {
@@ -10,6 +10,7 @@ describe('threedlib', () => {
       'component.axisZ': AxisZ,
       'mark.point3D': Point3D,
       'mark.line3D': Line3D,
+      'mark.interval3D': Interval3D,
     });
   });
 });

--- a/src/api/runtime.ts
+++ b/src/api/runtime.ts
@@ -14,6 +14,7 @@ import {
   optionsOf,
   updateRoot,
   createEmptyPromise,
+  REMOVE_FLAG,
 } from './utils';
 import { CompositionNode } from './composition';
 import { Node } from './node';
@@ -155,7 +156,7 @@ export class Runtime<Spec extends G2Spec = G2Spec> extends CompositionNode {
     this._unbindAutoFit();
     this._reset();
     destroy(options, this._context, true);
-    removeContainer(this._container);
+    if (this._container[REMOVE_FLAG]) removeContainer(this._container);
     this.emit(ChartEvent.AFTER_DESTROY);
   }
 

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -29,10 +29,16 @@ export const VIEW_KEYS = [
   'title',
 ];
 
+export const REMOVE_FLAG = '__remove__';
+
 export function normalizeContainer(
   container: string | HTMLElement,
 ): HTMLElement {
-  if (container === undefined) return document.createElement('div');
+  if (container === undefined) {
+    const container = document.createElement('div');
+    container[REMOVE_FLAG] = true;
+    return container;
+  }
   if (typeof container === 'string') {
     const node = document.getElementById(container);
     return node;


### PR DESCRIPTION
- 存在问题：chart.destroy 会把 container 从 DOM 树里面移除。
- 解决办法：如果 container 是外部传入，不移除；如果是内部创建，移除。