### PR TITLE
fix: 修复 `site/docs/../intervalThreed.zh.md` 中元素全部为黑的问题

### DIFF
--- a/site/docs/spec/threed/intervalThreed.zh.md
+++ b/site/docs/spec/threed/intervalThreed.zh.md
@@ -61,7 +61,8 @@ order: 3
     .legend(false)
     .axis('x', { gridLineWidth: 2 })
     .axis('y', { gridLineWidth: 2, titleBillboardRotation: -Math.PI / 2 })
-    .axis('z', { gridLineWidth: 2 });
+    .axis('z', { gridLineWidth: 2 })
+    .style('opacity', 0.7);
 
   chart.render().then(() => {
     const { canvas } = chart.getContext();

--- a/site/docs/spec/threed/intervalThreed.zh.md
+++ b/site/docs/spec/threed/intervalThreed.zh.md
@@ -67,11 +67,11 @@ order: 3
     const { canvas } = chart.getContext();
     const camera = canvas.getCamera();
     camera.setPerspective(0.1, 5000, 80, 1280 / 960);
-    camera.setType(CameraType.ORBITING);
+    camera.setType(g.CameraType.ORBITING);
     camera.rotate(-20, -20, 0);
 
     // Add a directional light into scene.
-    const light = new DirectionalLight({
+    const light = new gPlugin3d.DirectionalLight({
       style: {
         intensity: 2.5,
         fill: 'white',

--- a/site/docs/spec/threed/intervalThreed.zh.md
+++ b/site/docs/spec/threed/intervalThreed.zh.md
@@ -67,7 +67,7 @@ order: 3
   chart.render().then(() => {
     const { canvas } = chart.getContext();
     const camera = canvas.getCamera();
-    camera.setPerspective(0.1, 5000, 80, 1280 / 960);
+    camera.setPerspective(0.1, 5000, 50, 1280 / 960);
     camera.setType(g.CameraType.ORBITING);
     camera.rotate(-20, -20, 0);
 


### PR DESCRIPTION
#### Description of change
修复该页面由于库引用错误所导致的没有光照效果、元素全部为黑色的问题。https://g2.antv.antgroup.com/spec/threed/interval-threed
<img width="1143" alt="image" src="https://github.com/antvis/G2/assets/30697592/758c1fe6-d160-417c-9a29-49c0664fb1f8">

从全局引用相关变量：
- `CameraType.ORBITING` 改为 `g.CameraType.ORBITING`
- `new DirectionalLight` 改为 `new gPlugin3d.DirectionalLight`