### PR TITLE
fix(tooltip): for fisheye

### DIFF
--- a/src/interaction/fisheye.ts
+++ b/src/interaction/fisheye.ts
@@ -36,7 +36,9 @@ export function Fisheye({
         setState('fisheye', (options) => {
           // Clone options and mutate it.
           // Disable animation.
-          const clonedOptions = deepMix({}, options);
+          const clonedOptions = deepMix({}, options, {
+            interaction: { tooltip: { preserve: true } },
+          });
           for (const mark of clonedOptions.marks) mark.animate = false;
           const [x, y] = focus;
           const fisheye = maybeCoordinate(clonedOptions);

--- a/src/interaction/tooltip.ts
+++ b/src/interaction/tooltip.ts
@@ -442,6 +442,7 @@ export function seriesTooltip(
     theme,
     disableNative = false,
     marker = true,
+    preserve = false,
     style: _style = {},
     css = {},
     ...rest
@@ -742,7 +743,11 @@ export function seriesTooltip(
     emitter.off('tooltip:hide', onTooltipHide);
     emitter.off('tooltip:disable', onTooltipDisable);
     emitter.off('tooltip:enable', onTooltipEnable);
-    destroy();
+    if (preserve) {
+      hideTooltip({ root, single, emitter, nativeEvent: false });
+    } else {
+      destroy();
+    }
   };
 }
 
@@ -774,6 +779,7 @@ export function tooltip(
     shared = false,
     body = true,
     disableNative = false,
+    preserve = false,
     css = {},
   }: Record<string, any>,
 ) {
@@ -899,7 +905,11 @@ export function tooltip(
     removeEventListeners();
     emitter.off('tooltip:show', onTooltipShow);
     emitter.off('tooltip:hide', onTooltipHide);
-    destroyTooltip({ root, single });
+    if (preserve) {
+      hideTooltip({ root, single, emitter, nativeEvent: false });
+    } else {
+      destroyTooltip({ root, single });
+    }
   };
 }
 

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -424,7 +424,8 @@ function updateTooltip(
     container: selection.node(),
     update: (options) => Promise.resolve(options),
   };
-  applyTooltip(target, [], context.emitter);
+  const newTooltip = applyTooltip(target, [], context.emitter);
+  nameInteraction.set('tooltip', newTooltip);
 }
 
 async function initializeView(


### PR DESCRIPTION
- close: https://github.com/antvis/G2/issues/5577
- 出现原因：每次都新建一个 tooltip
- 解决办法：针对 fisheye 每次都是隐藏 tooltip，不选择新建一个
- 同时解决了一个 tooltip 内存泄漏的问题，可能解决了这个 https://github.com/antvis/G2/issues/5555 里面提到的相关问题