### PR TITLE
fix: bundle sideEffects config

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test": "node --expose-gc --max-old-space-size=4096 --unhandled-rejections=strict node_modules/jest/bin/jest __tests__/ --coverage -i  --logHeapUsage",
     "test:unit": "node --expose-gc --max-old-space-size=4096 --unhandled-rejections=strict node_modules/jest/bin/jest __tests__/unit/ --coverage -i  --logHeapUsage",
     "test:integration": "node --expose-gc --max-old-space-size=4096 --unhandled-rejections=strict node_modules/jest/bin/jest __tests__/integration/ --coverage -i  --logHeapUsage",
+    "preview": "vite preview",
     "build:umd": "rimraf ./dist && rollup -c && npm run size",
     "build:cjs": "rimraf ./lib && tsc --module commonjs --outDir lib",
     "build:esm": "rimraf ./esm && tsc --module ESNext --outDir esm",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,6 +20,8 @@ export default [
     input,
     treeshake: {
       preset: 'smallest',
+      // Set `src/exports` as a sideEffects file.
+      moduleSideEffects: (id, external) => id.includes('src/exports.ts') ? true : false,
     },
     output: [
       {


### PR DESCRIPTION
- ref https://github.com/antvis/G2/pull/5597
- fix bundle sideEffects
- add `preview` scripts

前一个分支的构建，因为没有注意到 sideEffects，导致构建出来的 bundle 文件中，下面的代码被移除。

```ts
import { runtime } from '@antv/g';
runtime.enableCSSParsing = false;
```

带来了一些渲染问题。