### PR TITLE
fix: add minHeight option for the interval

### DIFF
--- a/src/shape/interval/color.ts
+++ b/src/shape/interval/color.ts
@@ -16,6 +16,10 @@ export type ColorOptions = {
    * Maximum width of each interval.
    */
   maxWidth?: number;
+  /**
+   * Minimum height of each interval
+   */
+  minHeight?: number;
   [key: string]: any;
 };
 
@@ -40,6 +44,7 @@ export function rect(
     radiusTopRight = radius,
     minWidth = -Infinity,
     maxWidth = Infinity,
+    minHeight = -Infinity,
     ...rest
   } = style;
   if (!isPolar(coordinate) && !isHelix(coordinate)) {
@@ -48,13 +53,19 @@ export function rect(
     const [p0, , p2] = tpShape ? reorder(points) : points;
     const [x, y] = p0;
     const [width, height] = sub(p2, p0);
+
     // Deal with width or height is negative.
     const absX = width > 0 ? x : x + width;
     const absY = height > 0 ? y : y + height;
+
+    const heightDiff = minHeight - height;
+    // when data is 0, minHeight get actions.
+    const isMinHeight = heightDiff > 0 && height === 0 ? true : false;
+
     const absWidth = Math.abs(width);
-    const absHeight = Math.abs(height);
+    const absHeight = Math.abs(isMinHeight ? minHeight : height);
     const finalX = absX + insetLeft;
-    const finalY = absY + insetTop;
+    const finalY = isMinHeight ? absY + insetTop - heightDiff : absY + insetTop;
     const finalWidth = absWidth - (insetLeft + insetRight);
     const finalHeight = absHeight - (insetTop + insetBottom);
 
@@ -62,11 +73,10 @@ export function rect(
       ? finalWidth
       : clamp(finalWidth, minWidth, maxWidth);
     const clampHeight = tpShape
-      ? clamp(finalHeight, minWidth, maxWidth)
+      ? clamp(finalHeight, minHeight, maxWidth)
       : finalHeight;
     const clampX = finalX - (clampWidth - finalWidth) / 2;
     const clampY = finalY - (clampHeight - finalHeight) / 2;
-
     return select(document.createElement('rect', {}))
       .style('x', clampX)
       .style('y', clampY)
@@ -89,7 +99,6 @@ export function rect(
   const path = arc()
     .cornerRadius(radius as number)
     .padAngle((inset * Math.PI) / 180);
-
   return select(document.createElement('path', {}))
     .style('path', path(arcObject))
     .style('transform', `translate(${center[0]}, ${center[1]})`)
@@ -145,6 +154,7 @@ export const Color: SC<ColorOptions> = (options, context) => {
       insetTop = inset,
       minWidth,
       maxWidth,
+      minHeight,
       ...rest
     } = style;
     const { color = defaultColor, opacity } = value;
@@ -179,6 +189,7 @@ export const Color: SC<ColorOptions> = (options, context) => {
       insetTop,
       minWidth,
       maxWidth,
+      minHeight,
     };
 
     return (


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] benchmarks are included
- [ ] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change
*  add the minHeight style option for the histogram(rect).
fix the issue #5686
<!-- Provide a description of the change below this comment. -->
![3106527781](https://github.com/antvis/G2/assets/48038769/3f345fd9-862c-4387-bd0f-b6c520b02b9a)
![2464533322](https://github.com/antvis/G2/assets/48038769/2f81b173-b8d5-4076-aa3c-79f81762e876)
