### PR TITLE
chore: run build action when trigger pull_request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: [push]
+on:
+  push:
+    branches: [v5]
+  pull_request:
+    branches: [v5]
 
 jobs:
   build:


### PR DESCRIPTION
之前 Build CI 在外部用户的 PR 一直无法运行：

![image](https://github.com/antvis/G2/assets/49330279/aad6cdf9-5ec3-4539-99a7-d3921d092f84)

应该是缺失在提交 PR 的时候运行 CI 能力造成的。所以这里修改运行 CI 的时机。