### PR TITLE
feat: add default format to tooltip title #5684

### DIFF
--- a/__tests__/plots/tooltip/aapl-line-date-default-format.ts
+++ b/__tests__/plots/tooltip/aapl-line-date-default-format.ts
@@ -1,0 +1,23 @@
+import { G2Spec } from '../../../src';
+import { seriesTooltipSteps } from './utils';
+
+export function aaplLineDateDefaultFormat(): G2Spec {
+  return {
+    type: 'view',
+    children: [
+      {
+        type: 'line',
+        data: {
+          type: 'fetch',
+          value: 'data/aapl.csv',
+        },
+        encode: {
+          x: 'date',
+          y: 'close',
+        },
+      },
+    ],
+  };
+}
+
+aaplLineDateDefaultFormat.steps = seriesTooltipSteps([200, 300]);

--- a/__tests__/plots/tooltip/index.ts
+++ b/__tests__/plots/tooltip/index.ts
@@ -58,6 +58,7 @@ export { aaplLineSliderFilter } from './appl-line-slider-filter';
 export { aaplLineAreaBasicSample } from './aapl-line-area-basic-sample';
 export { aaplLineAreaBasicSampleMount } from './aapl-line-area-basic-sample-mount';
 export { aaplAreaMissingDataTranspose } from './aapl-area-missing-data-transpose';
+export { aaplLineDateDefaultFormat } from './aapl-line-date-default-format';
 export { alphabetIntervalBrushTooltip } from './alphabet-interval-brush-tooltip';
 export { mockLineFalsy } from './mock-line-falsy';
 export { provincesLineGroupName } from './provinces-line-group-name';

--- a/src/transform/maybeTitle.ts
+++ b/src/transform/maybeTitle.ts
@@ -1,6 +1,7 @@
 import { deepMix } from '@antv/util';
 import { isUnset } from '../utils/helper';
 import { TransformComponent as TC } from '../runtime';
+import { dynamicFormatDateTime } from '../utils/dateFormat';
 import { columnOf } from './utils/helper';
 
 export type MaybeTitleOptions = {
@@ -27,7 +28,13 @@ export const MaybeTitle: TC<MaybeTitleOptions> = (options = {}) => {
     if (titles.length === 0) return [I, mark];
     const T = [];
     for (const i of I) {
-      T[i] = { value: titles.map((t) => t[i]).join(', ') };
+      T[i] = {
+        value: titles
+          .map((t) =>
+            t[i] instanceof Date ? dynamicFormatDateTime(t[i] as Date) : t[i],
+          )
+          .join(', '),
+      };
     }
     return [
       I,

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -1,0 +1,22 @@
+function fillZero(digit: number) {
+  if (Math.abs(digit) > 10) return String(digit);
+  return digit.toString().padStart(2, '0');
+}
+
+export function dynamicFormatDateTime(date: Date) {
+  const year = date.getFullYear();
+  const month = fillZero(date.getMonth() + 1);
+  const day = fillZero(date.getDate());
+
+  const yyyyMMDD = `${year}-${month}-${day}`;
+
+  const hour = date.getHours();
+  const minutes = date.getMinutes();
+  const seconds = date.getSeconds();
+
+  if (hour || minutes || seconds)
+    return `${yyyyMMDD} ${fillZero(hour)}:${fillZero(minutes)}:${fillZero(
+      seconds,
+    )}`;
+  return yyyyMMDD;
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] benchmarks are included
- [x] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change
###### 解决问题
#5684 当图表中 encode 的 x 为日期字段的时候，tooltip title 会默认显示 x 轴的数据，对于日期的默认格式化效果不是很友好。
###### 解决办法
1. 先判断当前的tooltip title 是否有用户自定义的处理，如果有，对title不做任何处理
2. 如果没有用户自定义处理，对日期格式进行动态字符处理
###### DEMO
1. 存在自定义处理
![image](https://github.com/antvis/G2/assets/25734833/44d67628-8183-4de6-9075-4310b9af8596)
```ts
import { G2Spec } from '../../../src';
import { seriesTooltipSteps } from './utils';

export function aaplLine(): G2Spec {
  return {
    type: 'view',
    children: [
      {
        type: 'line',
        data: {
          type: 'fetch',
          value: 'data/aapl.csv',
        },
        encode: {
          x: 'date',
          y: 'close',
        },
        tooltip: {
          title: (d) => new Date(d.date).toUTCString(),
        },
      },
    ],
  };
}

aaplLine.steps = seriesTooltipSteps([200, 300]);

```
2. 移除自定义处理
![image](https://github.com/antvis/G2/assets/25734833/9c83316e-6907-4b2e-b45a-0276d747e04e)
```ts
import { G2Spec } from '../../../src';
import { seriesTooltipSteps } from './utils';

export function aaplLine(): G2Spec {
  return {
    type: 'view',
    children: [
      {
        type: 'line',
        data: {
          type: 'fetch',
          value: 'data/aapl.csv',
        },
        encode: {
          x: 'date',
          y: 'close',
        },
        // tooltip: {
        //   title: (d) => new Date(d.date).toUTCString(),
        // },
      },
    ],
  };
}

aaplLine.steps = seriesTooltipSteps([200, 300]);

```

<!-- Provide a description of the change below this comment. -->
