### PR TITLE
fix: fix the transpose color gradient render

### DIFF
--- a/__tests__/integration/snapshots/static/temperature2LineGradientColorTranspose.svg
+++ b/__tests__/integration/snapshots/static/temperature2LineGradientColorTranspose.svg
@@ -1,0 +1,1367 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="640"
+  height="1000"
+  style="background: transparent;"
+  color-interpolation-filters="sRGB"
+>
+  <defs>
+    <linearGradient
+      gradientUnits="userSpaceOnUse"
+      id="g-pattern-0"
+      x1="371.26400000000007"
+      y1="451"
+      x2="-5.684341886080802e-14"
+      y2="451"
+    >
+      <stop offset="0" stop-color="rgb(144,12,0)" />
+      <stop offset="0.08510638297872342" stop-color="rgb(176,27,6)" />
+      <stop offset="0.1063829787234042" stop-color="rgb(190,37,10)" />
+      <stop offset="0.1063829787234042" stop-color="rgb(190,37,10)" />
+      <stop offset="0.11914893617021258" stop-color="rgb(199,43,12)" />
+      <stop offset="0.1872340425531912" stop-color="rgb(240,86,22)" />
+      <stop offset="0.208510638297872" stop-color="rgb(249,101,25)" />
+      <stop offset="0.23404255319148906" stop-color="rgb(255,119,28)" />
+      <stop offset="0.23829787234042532" stop-color="rgb(255,122,28)" />
+      <stop offset="0.25531914893616997" stop-color="rgb(255,134,30)" />
+      <stop offset="0.25531914893616997" stop-color="rgb(255,134,30)" />
+      <stop offset="0.2638297872340424" stop-color="rgb(255,140,31)" />
+      <stop offset="0.2723404255319146" stop-color="rgb(255,146,32)" />
+      <stop offset="0.2851063829787233" stop-color="rgb(255,154,33)" />
+      <stop offset="0.2978723404255317" stop-color="rgb(255,163,35)" />
+      <stop offset="0.30212765957446797" stop-color="rgb(255,166,35)" />
+      <stop offset="0.3063829787234041" stop-color="rgb(255,169,36)" />
+      <stop offset="0.33617021276595715" stop-color="rgb(253,187,40)" />
+      <stop offset="0.3404255319148934" stop-color="rgb(252,190,40)" />
+      <stop offset="0.34893617021276585" stop-color="rgb(248,195,41)" />
+      <stop offset="0.3531914893617021" stop-color="rgb(247,197,42)" />
+      <stop offset="0.3531914893617021" stop-color="rgb(247,197,42)" />
+      <stop offset="0.35744680851063804" stop-color="rgb(245,199,43)" />
+      <stop offset="0.35744680851063804" stop-color="rgb(245,199,43)" />
+      <stop offset="0.37021276595744673" stop-color="rgb(239,206,45)" />
+      <stop offset="0.37446808510638296" stop-color="rgb(237,209,45)" />
+      <stop offset="0.37446808510638296" stop-color="rgb(237,209,45)" />
+      <stop offset="0.37872340425531886" stop-color="rgb(234,211,46)" />
+      <stop offset="0.38297872340425504" stop-color="rgb(232,213,47)" />
+      <stop offset="0.38297872340425504" stop-color="rgb(232,213,47)" />
+      <stop offset="0.3872340425531914" stop-color="rgb(230,215,48)" />
+      <stop offset="0.3872340425531914" stop-color="rgb(230,215,48)" />
+      <stop offset="0.3914893617021276" stop-color="rgb(227,217,49)" />
+      <stop offset="0.3914893617021276" stop-color="rgb(227,217,49)" />
+      <stop offset="0.39574468085106385" stop-color="rgb(225,219,50)" />
+      <stop offset="0.39574468085106385" stop-color="rgb(225,219,50)" />
+      <stop offset="0.3999999999999998" stop-color="rgb(222,221,50)" />
+      <stop offset="0.3999999999999998" stop-color="rgb(222,221,50)" />
+      <stop offset="0.40425531914893603" stop-color="rgb(219,223,51)" />
+      <stop offset="0.40851063829787215" stop-color="rgb(217,225,52)" />
+      <stop offset="0.40851063829787215" stop-color="rgb(217,225,52)" />
+      <stop offset="0.40851063829787215" stop-color="rgb(217,225,52)" />
+      <stop offset="0.40851063829787215" stop-color="rgb(217,225,52)" />
+      <stop offset="0.40851063829787215" stop-color="rgb(217,225,52)" />
+      <stop offset="0.40851063829787215" stop-color="rgb(217,225,52)" />
+      <stop offset="0.42127659574468057" stop-color="rgb(208,230,55)" />
+      <stop offset="0.42127659574468057" stop-color="rgb(208,230,55)" />
+      <stop offset="0.4255319148936168" stop-color="rgb(205,231,56)" />
+      <stop offset="0.4255319148936168" stop-color="rgb(205,231,56)" />
+      <stop offset="0.42978723404255315" stop-color="rgb(202,233,57)" />
+      <stop offset="0.42978723404255315" stop-color="rgb(202,233,57)" />
+      <stop offset="0.42978723404255315" stop-color="rgb(202,233,57)" />
+      <stop offset="0.4382978723404255" stop-color="rgb(196,236,60)" />
+      <stop offset="0.4382978723404255" stop-color="rgb(196,236,60)" />
+      <stop offset="0.4382978723404255" stop-color="rgb(196,236,60)" />
+      <stop offset="0.4382978723404255" stop-color="rgb(196,236,60)" />
+      <stop offset="0.4425531914893615" stop-color="rgb(193,237,61)" />
+      <stop offset="0.4425531914893615" stop-color="rgb(193,237,61)" />
+      <stop offset="0.4425531914893615" stop-color="rgb(193,237,61)" />
+      <stop offset="0.4468085106382978" stop-color="rgb(190,239,62)" />
+      <stop offset="0.4468085106382978" stop-color="rgb(190,239,62)" />
+      <stop offset="0.45106382978723386" stop-color="rgb(187,240,63)" />
+      <stop offset="0.45106382978723386" stop-color="rgb(187,240,63)" />
+      <stop offset="0.45106382978723386" stop-color="rgb(187,240,63)" />
+      <stop offset="0.45106382978723386" stop-color="rgb(187,240,63)" />
+      <stop offset="0.45106382978723386" stop-color="rgb(187,240,63)" />
+      <stop offset="0.45531914893617015" stop-color="rgb(183,241,65)" />
+      <stop offset="0.45531914893617015" stop-color="rgb(183,241,65)" />
+      <stop offset="0.45531914893617015" stop-color="rgb(183,241,65)" />
+      <stop offset="0.45531914893617015" stop-color="rgb(183,241,65)" />
+      <stop offset="0.45531914893617015" stop-color="rgb(183,241,65)" />
+      <stop offset="0.45531914893617015" stop-color="rgb(183,241,65)" />
+      <stop offset="0.45957446808510644" stop-color="rgb(180,242,66)" />
+      <stop offset="0.4638297872340423" stop-color="rgb(177,243,67)" />
+      <stop offset="0.4638297872340423" stop-color="rgb(177,243,67)" />
+      <stop offset="0.4638297872340423" stop-color="rgb(177,243,67)" />
+      <stop offset="0.4638297872340423" stop-color="rgb(177,243,67)" />
+      <stop offset="0.4638297872340423" stop-color="rgb(177,243,67)" />
+      <stop offset="0.4680851063829785" stop-color="rgb(174,245,69)" />
+      <stop offset="0.4680851063829785" stop-color="rgb(174,245,69)" />
+      <stop offset="0.4723404255319148" stop-color="rgb(170,246,70)" />
+      <stop offset="0.4723404255319148" stop-color="rgb(170,246,70)" />
+      <stop offset="0.4765957446808511" stop-color="rgb(167,246,72)" />
+      <stop offset="0.4765957446808511" stop-color="rgb(167,246,72)" />
+      <stop offset="0.4765957446808511" stop-color="rgb(167,246,72)" />
+      <stop offset="0.4765957446808511" stop-color="rgb(167,246,72)" />
+      <stop offset="0.4765957446808511" stop-color="rgb(167,246,72)" />
+      <stop offset="0.4808510638297872" stop-color="rgb(164,247,73)" />
+      <stop offset="0.4808510638297872" stop-color="rgb(164,247,73)" />
+      <stop offset="0.4808510638297872" stop-color="rgb(164,247,73)" />
+      <stop offset="0.4808510638297872" stop-color="rgb(164,247,73)" />
+      <stop offset="0.4851063829787232" stop-color="rgb(160,248,75)" />
+      <stop offset="0.4851063829787232" stop-color="rgb(160,248,75)" />
+      <stop offset="0.4851063829787232" stop-color="rgb(160,248,75)" />
+      <stop offset="0.48936170212765945" stop-color="rgb(157,249,76)" />
+      <stop offset="0.48936170212765945" stop-color="rgb(157,249,76)" />
+      <stop offset="0.48936170212765945" stop-color="rgb(157,249,76)" />
+      <stop offset="0.48936170212765945" stop-color="rgb(157,249,76)" />
+      <stop offset="0.49787234042553186" stop-color="rgb(150,250,80)" />
+      <stop offset="0.49787234042553186" stop-color="rgb(150,250,80)" />
+      <stop offset="0.49787234042553186" stop-color="rgb(150,250,80)" />
+      <stop offset="0.49787234042553186" stop-color="rgb(150,250,80)" />
+      <stop offset="0.5021276595744681" stop-color="rgb(147,251,82)" />
+      <stop offset="0.5021276595744681" stop-color="rgb(147,251,82)" />
+      <stop offset="0.5021276595744681" stop-color="rgb(147,251,82)" />
+      <stop offset="0.5021276595744681" stop-color="rgb(147,251,82)" />
+      <stop offset="0.5021276595744681" stop-color="rgb(147,251,82)" />
+      <stop offset="0.5021276595744681" stop-color="rgb(147,251,82)" />
+      <stop offset="0.5063829787234041" stop-color="rgb(143,251,83)" />
+      <stop offset="0.5063829787234041" stop-color="rgb(143,251,83)" />
+      <stop offset="0.5063829787234041" stop-color="rgb(143,251,83)" />
+      <stop offset="0.5106382978723403" stop-color="rgb(140,252,85)" />
+      <stop offset="0.5106382978723403" stop-color="rgb(140,252,85)" />
+      <stop offset="0.5106382978723403" stop-color="rgb(140,252,85)" />
+      <stop offset="0.5106382978723403" stop-color="rgb(140,252,85)" />
+      <stop offset="0.5106382978723403" stop-color="rgb(140,252,85)" />
+      <stop offset="0.5106382978723403" stop-color="rgb(140,252,85)" />
+      <stop offset="0.5148936170212766" stop-color="rgb(137,252,87)" />
+      <stop offset="0.5148936170212766" stop-color="rgb(137,252,87)" />
+      <stop offset="0.5148936170212766" stop-color="rgb(137,252,87)" />
+      <stop offset="0.5148936170212766" stop-color="rgb(137,252,87)" />
+      <stop offset="0.5191489361702127" stop-color="rgb(133,253,89)" />
+      <stop offset="0.523404255319149" stop-color="rgb(130,253,91)" />
+      <stop offset="0.523404255319149" stop-color="rgb(130,253,91)" />
+      <stop offset="0.523404255319149" stop-color="rgb(130,253,91)" />
+      <stop offset="0.523404255319149" stop-color="rgb(130,253,91)" />
+      <stop offset="0.523404255319149" stop-color="rgb(130,253,91)" />
+      <stop offset="0.523404255319149" stop-color="rgb(130,253,91)" />
+      <stop offset="0.5276595744680849" stop-color="rgb(127,253,93)" />
+      <stop offset="0.5276595744680849" stop-color="rgb(127,253,93)" />
+      <stop offset="0.5276595744680849" stop-color="rgb(127,253,93)" />
+      <stop offset="0.5319148936170212" stop-color="rgb(124,253,95)" />
+      <stop offset="0.5319148936170212" stop-color="rgb(124,253,95)" />
+      <stop offset="0.5319148936170212" stop-color="rgb(124,253,95)" />
+      <stop offset="0.5319148936170212" stop-color="rgb(124,253,95)" />
+      <stop offset="0.5319148936170212" stop-color="rgb(124,253,95)" />
+      <stop offset="0.5319148936170212" stop-color="rgb(124,253,95)" />
+      <stop offset="0.5319148936170212" stop-color="rgb(124,253,95)" />
+      <stop offset="0.5361702127659573" stop-color="rgb(120,254,97)" />
+      <stop offset="0.5361702127659573" stop-color="rgb(120,254,97)" />
+      <stop offset="0.5361702127659573" stop-color="rgb(120,254,97)" />
+      <stop offset="0.5361702127659573" stop-color="rgb(120,254,97)" />
+      <stop offset="0.5361702127659573" stop-color="rgb(120,254,97)" />
+      <stop offset="0.5361702127659573" stop-color="rgb(120,254,97)" />
+      <stop offset="0.5404255319148936" stop-color="rgb(117,254,99)" />
+      <stop offset="0.5404255319148936" stop-color="rgb(117,254,99)" />
+      <stop offset="0.5446808510638298" stop-color="rgb(114,254,101)" />
+      <stop offset="0.5446808510638298" stop-color="rgb(114,254,101)" />
+      <stop offset="0.5446808510638298" stop-color="rgb(114,254,101)" />
+      <stop offset="0.5446808510638298" stop-color="rgb(114,254,101)" />
+      <stop offset="0.5531914893617021" stop-color="rgb(108,253,105)" />
+      <stop offset="0.5531914893617021" stop-color="rgb(108,253,105)" />
+      <stop offset="0.5531914893617021" stop-color="rgb(108,253,105)" />
+      <stop offset="0.5531914893617021" stop-color="rgb(108,253,105)" />
+      <stop offset="0.5531914893617021" stop-color="rgb(108,253,105)" />
+      <stop offset="0.5574468085106382" stop-color="rgb(105,253,107)" />
+      <stop offset="0.5574468085106382" stop-color="rgb(105,253,107)" />
+      <stop offset="0.5574468085106382" stop-color="rgb(105,253,107)" />
+      <stop offset="0.5574468085106382" stop-color="rgb(105,253,107)" />
+      <stop offset="0.5574468085106382" stop-color="rgb(105,253,107)" />
+      <stop offset="0.5617021276595745" stop-color="rgb(102,253,110)" />
+      <stop offset="0.5617021276595745" stop-color="rgb(102,253,110)" />
+      <stop offset="0.5617021276595745" stop-color="rgb(102,253,110)" />
+      <stop offset="0.5617021276595745" stop-color="rgb(102,253,110)" />
+      <stop offset="0.5617021276595745" stop-color="rgb(102,253,110)" />
+      <stop offset="0.5617021276595745" stop-color="rgb(102,253,110)" />
+      <stop offset="0.5617021276595745" stop-color="rgb(102,253,110)" />
+      <stop offset="0.5617021276595745" stop-color="rgb(102,253,110)" />
+      <stop offset="0.5617021276595745" stop-color="rgb(102,253,110)" />
+      <stop offset="0.5617021276595745" stop-color="rgb(102,253,110)" />
+      <stop offset="0.5659574468085107" stop-color="rgb(99,253,112)" />
+      <stop offset="0.5659574468085107" stop-color="rgb(99,253,112)" />
+      <stop offset="0.5659574468085107" stop-color="rgb(99,253,112)" />
+      <stop offset="0.5659574468085107" stop-color="rgb(99,253,112)" />
+      <stop offset="0.5659574468085107" stop-color="rgb(99,253,112)" />
+      <stop offset="0.5659574468085107" stop-color="rgb(99,253,112)" />
+      <stop offset="0.5702127659574466" stop-color="rgb(96,252,114)" />
+      <stop offset="0.5702127659574466" stop-color="rgb(96,252,114)" />
+      <stop offset="0.5702127659574466" stop-color="rgb(96,252,114)" />
+      <stop offset="0.5702127659574466" stop-color="rgb(96,252,114)" />
+      <stop offset="0.5744680851063829" stop-color="rgb(93,252,117)" />
+      <stop offset="0.5744680851063829" stop-color="rgb(93,252,117)" />
+      <stop offset="0.5744680851063829" stop-color="rgb(93,252,117)" />
+      <stop offset="0.5787234042553192" stop-color="rgb(90,251,119)" />
+      <stop offset="0.5787234042553192" stop-color="rgb(90,251,119)" />
+      <stop offset="0.5787234042553192" stop-color="rgb(90,251,119)" />
+      <stop offset="0.5787234042553192" stop-color="rgb(90,251,119)" />
+      <stop offset="0.5829787234042554" stop-color="rgb(87,251,121)" />
+      <stop offset="0.5829787234042554" stop-color="rgb(87,251,121)" />
+      <stop offset="0.5829787234042554" stop-color="rgb(87,251,121)" />
+      <stop offset="0.5829787234042554" stop-color="rgb(87,251,121)" />
+      <stop offset="0.5829787234042554" stop-color="rgb(87,251,121)" />
+      <stop offset="0.5829787234042554" stop-color="rgb(87,251,121)" />
+      <stop offset="0.5829787234042554" stop-color="rgb(87,251,121)" />
+      <stop offset="0.5829787234042554" stop-color="rgb(87,251,121)" />
+      <stop offset="0.5872340425531916" stop-color="rgb(85,250,124)" />
+      <stop offset="0.5872340425531916" stop-color="rgb(85,250,124)" />
+      <stop offset="0.5872340425531916" stop-color="rgb(85,250,124)" />
+      <stop offset="0.5872340425531916" stop-color="rgb(85,250,124)" />
+      <stop offset="0.5872340425531916" stop-color="rgb(85,250,124)" />
+      <stop offset="0.5872340425531916" stop-color="rgb(85,250,124)" />
+      <stop offset="0.5914893617021274" stop-color="rgb(82,250,126)" />
+      <stop offset="0.5957446808510637" stop-color="rgb(79,249,129)" />
+      <stop offset="0.5957446808510637" stop-color="rgb(79,249,129)" />
+      <stop offset="0.5957446808510637" stop-color="rgb(79,249,129)" />
+      <stop offset="0.5957446808510637" stop-color="rgb(79,249,129)" />
+      <stop offset="0.5957446808510637" stop-color="rgb(79,249,129)" />
+      <stop offset="0.5957446808510637" stop-color="rgb(79,249,129)" />
+      <stop offset="0.5957446808510637" stop-color="rgb(79,249,129)" />
+      <stop offset="0.6" stop-color="rgb(77,248,132)" />
+      <stop offset="0.6" stop-color="rgb(77,248,132)" />
+      <stop offset="0.6" stop-color="rgb(77,248,132)" />
+      <stop offset="0.6042553191489363" stop-color="rgb(74,247,134)" />
+      <stop offset="0.6042553191489363" stop-color="rgb(74,247,134)" />
+      <stop offset="0.6042553191489363" stop-color="rgb(74,247,134)" />
+      <stop offset="0.6042553191489363" stop-color="rgb(74,247,134)" />
+      <stop offset="0.6042553191489363" stop-color="rgb(74,247,134)" />
+      <stop offset="0.6042553191489363" stop-color="rgb(74,247,134)" />
+      <stop offset="0.6085106382978724" stop-color="rgb(72,247,137)" />
+      <stop offset="0.6085106382978724" stop-color="rgb(72,247,137)" />
+      <stop offset="0.6085106382978724" stop-color="rgb(72,247,137)" />
+      <stop offset="0.6085106382978724" stop-color="rgb(72,247,137)" />
+      <stop offset="0.6127659574468083" stop-color="rgb(69,246,139)" />
+      <stop offset="0.6127659574468083" stop-color="rgb(69,246,139)" />
+      <stop offset="0.6127659574468083" stop-color="rgb(69,246,139)" />
+      <stop offset="0.6127659574468083" stop-color="rgb(69,246,139)" />
+      <stop offset="0.6127659574468083" stop-color="rgb(69,246,139)" />
+      <stop offset="0.6170212765957446" stop-color="rgb(67,245,142)" />
+      <stop offset="0.6170212765957446" stop-color="rgb(67,245,142)" />
+      <stop offset="0.6170212765957446" stop-color="rgb(67,245,142)" />
+      <stop offset="0.6170212765957446" stop-color="rgb(67,245,142)" />
+      <stop offset="0.6212765957446807" stop-color="rgb(65,244,145)" />
+      <stop offset="0.6212765957446807" stop-color="rgb(65,244,145)" />
+      <stop offset="0.6212765957446807" stop-color="rgb(65,244,145)" />
+      <stop offset="0.6212765957446807" stop-color="rgb(65,244,145)" />
+      <stop offset="0.625531914893617" stop-color="rgb(63,242,147)" />
+      <stop offset="0.625531914893617" stop-color="rgb(63,242,147)" />
+      <stop offset="0.625531914893617" stop-color="rgb(63,242,147)" />
+      <stop offset="0.6297872340425533" stop-color="rgb(61,241,150)" />
+      <stop offset="0.6297872340425533" stop-color="rgb(61,241,150)" />
+      <stop offset="0.6297872340425533" stop-color="rgb(61,241,150)" />
+      <stop offset="0.6297872340425533" stop-color="rgb(61,241,150)" />
+      <stop offset="0.6297872340425533" stop-color="rgb(61,241,150)" />
+      <stop offset="0.6297872340425533" stop-color="rgb(61,241,150)" />
+      <stop offset="0.6340425531914893" stop-color="rgb(59,240,153)" />
+      <stop offset="0.6340425531914893" stop-color="rgb(59,240,153)" />
+      <stop offset="0.6340425531914893" stop-color="rgb(59,240,153)" />
+      <stop offset="0.6340425531914893" stop-color="rgb(59,240,153)" />
+      <stop offset="0.6382978723404256" stop-color="rgb(57,239,156)" />
+      <stop offset="0.6382978723404256" stop-color="rgb(57,239,156)" />
+      <stop offset="0.6382978723404256" stop-color="rgb(57,239,156)" />
+      <stop offset="0.6382978723404256" stop-color="rgb(57,239,156)" />
+      <stop offset="0.6382978723404256" stop-color="rgb(57,239,156)" />
+      <stop offset="0.6382978723404256" stop-color="rgb(57,239,156)" />
+      <stop offset="0.6425531914893616" stop-color="rgb(55,237,158)" />
+      <stop offset="0.6425531914893616" stop-color="rgb(55,237,158)" />
+      <stop offset="0.6425531914893616" stop-color="rgb(55,237,158)" />
+      <stop offset="0.6425531914893616" stop-color="rgb(55,237,158)" />
+      <stop offset="0.6468085106382979" stop-color="rgb(53,236,161)" />
+      <stop offset="0.6468085106382979" stop-color="rgb(53,236,161)" />
+      <stop offset="0.6468085106382979" stop-color="rgb(53,236,161)" />
+      <stop offset="0.6468085106382979" stop-color="rgb(53,236,161)" />
+      <stop offset="0.65531914893617" stop-color="rgb(50,233,167)" />
+      <stop offset="0.65531914893617" stop-color="rgb(50,233,167)" />
+      <stop offset="0.6595744680851063" stop-color="rgb(49,232,169)" />
+      <stop offset="0.6595744680851063" stop-color="rgb(49,232,169)" />
+      <stop offset="0.6638297872340426" stop-color="rgb(47,230,172)" />
+      <stop offset="0.6638297872340426" stop-color="rgb(47,230,172)" />
+      <stop offset="0.6638297872340426" stop-color="rgb(47,230,172)" />
+      <stop offset="0.6638297872340426" stop-color="rgb(47,230,172)" />
+      <stop offset="0.6680851063829788" stop-color="rgb(46,228,175)" />
+      <stop offset="0.6680851063829788" stop-color="rgb(46,228,175)" />
+      <stop offset="0.6680851063829788" stop-color="rgb(46,228,175)" />
+      <stop offset="0.6680851063829788" stop-color="rgb(46,228,175)" />
+      <stop offset="0.6680851063829788" stop-color="rgb(46,228,175)" />
+      <stop offset="0.672340425531915" stop-color="rgb(45,227,178)" />
+      <stop offset="0.672340425531915" stop-color="rgb(45,227,178)" />
+      <stop offset="0.672340425531915" stop-color="rgb(45,227,178)" />
+      <stop offset="0.6808510638297871" stop-color="rgb(43,223,183)" />
+      <stop offset="0.6808510638297871" stop-color="rgb(43,223,183)" />
+      <stop offset="0.6851063829787233" stop-color="rgb(42,221,186)" />
+      <stop offset="0.6851063829787233" stop-color="rgb(42,221,186)" />
+      <stop offset="0.6851063829787233" stop-color="rgb(42,221,186)" />
+      <stop offset="0.6893617021276597" stop-color="rgb(41,220,189)" />
+      <stop offset="0.6893617021276597" stop-color="rgb(41,220,189)" />
+      <stop offset="0.6978723404255319" stop-color="rgb(39,216,194)" />
+      <stop offset="0.6978723404255319" stop-color="rgb(39,216,194)" />
+      <stop offset="0.7021276595744681" stop-color="rgb(39,214,197)" />
+      <stop offset="0.7021276595744681" stop-color="rgb(39,214,197)" />
+      <stop offset="0.7063829787234043" stop-color="rgb(38,212,200)" />
+      <stop offset="0.7063829787234043" stop-color="rgb(38,212,200)" />
+      <stop offset="0.7106382978723405" stop-color="rgb(38,210,202)" />
+      <stop offset="0.7106382978723405" stop-color="rgb(38,210,202)" />
+      <stop offset="0.7148936170212766" stop-color="rgb(37,207,205)" />
+      <stop offset="0.7191489361702126" stop-color="rgb(37,205,208)" />
+      <stop offset="0.723404255319149" stop-color="rgb(37,203,210)" />
+      <stop offset="0.723404255319149" stop-color="rgb(37,203,210)" />
+      <stop offset="0.7276595744680853" stop-color="rgb(37,201,213)" />
+      <stop offset="0.7276595744680853" stop-color="rgb(37,201,213)" />
+      <stop offset="0.7276595744680853" stop-color="rgb(37,201,213)" />
+      <stop offset="0.7276595744680853" stop-color="rgb(37,201,213)" />
+      <stop offset="0.7319148936170214" stop-color="rgb(37,198,215)" />
+      <stop offset="0.7319148936170214" stop-color="rgb(37,198,215)" />
+      <stop offset="0.7319148936170214" stop-color="rgb(37,198,215)" />
+      <stop offset="0.7319148936170214" stop-color="rgb(37,198,215)" />
+      <stop offset="0.7319148936170214" stop-color="rgb(37,198,215)" />
+      <stop offset="0.7361702127659576" stop-color="rgb(37,196,218)" />
+      <stop offset="0.7361702127659576" stop-color="rgb(37,196,218)" />
+      <stop offset="0.7361702127659576" stop-color="rgb(37,196,218)" />
+      <stop offset="0.7361702127659576" stop-color="rgb(37,196,218)" />
+      <stop offset="0.7361702127659576" stop-color="rgb(37,196,218)" />
+      <stop offset="0.7404255319148935" stop-color="rgb(37,194,220)" />
+      <stop offset="0.7404255319148935" stop-color="rgb(37,194,220)" />
+      <stop offset="0.7404255319148935" stop-color="rgb(37,194,220)" />
+      <stop offset="0.7404255319148935" stop-color="rgb(37,194,220)" />
+      <stop offset="0.7404255319148935" stop-color="rgb(37,194,220)" />
+      <stop offset="0.7489361702127659" stop-color="rgb(38,189,225)" />
+      <stop offset="0.7489361702127659" stop-color="rgb(38,189,225)" />
+      <stop offset="0.7531914893617023" stop-color="rgb(38,186,227)" />
+      <stop offset="0.7574468085106385" stop-color="rgb(39,184,229)" />
+      <stop offset="0.7574468085106385" stop-color="rgb(39,184,229)" />
+      <stop offset="0.7617021276595743" stop-color="rgb(39,181,231)" />
+      <stop offset="0.7659574468085105" stop-color="rgb(40,179,233)" />
+      <stop offset="0.7659574468085105" stop-color="rgb(40,179,233)" />
+      <stop offset="0.7702127659574468" stop-color="rgb(41,176,235)" />
+      <stop offset="0.7702127659574468" stop-color="rgb(41,176,235)" />
+      <stop offset="0.7702127659574468" stop-color="rgb(41,176,235)" />
+      <stop offset="0.7744680851063831" stop-color="rgb(41,174,236)" />
+      <stop offset="0.7744680851063831" stop-color="rgb(41,174,236)" />
+      <stop offset="0.7744680851063831" stop-color="rgb(41,174,236)" />
+      <stop offset="0.7787234042553193" stop-color="rgb(42,171,238)" />
+      <stop offset="0.7787234042553193" stop-color="rgb(42,171,238)" />
+      <stop offset="0.7787234042553193" stop-color="rgb(42,171,238)" />
+      <stop offset="0.7829787234042552" stop-color="rgb(43,168,240)" />
+      <stop offset="0.7872340425531914" stop-color="rgb(44,165,241)" />
+      <stop offset="0.7872340425531914" stop-color="rgb(44,165,241)" />
+      <stop offset="0.7872340425531914" stop-color="rgb(44,165,241)" />
+      <stop offset="0.7957446808510639" stop-color="rgb(46,160,244)" />
+      <stop offset="0.7957446808510639" stop-color="rgb(46,160,244)" />
+      <stop offset="0.7957446808510639" stop-color="rgb(46,160,244)" />
+      <stop offset="0.8000000000000002" stop-color="rgb(47,157,245)" />
+      <stop offset="0.8000000000000002" stop-color="rgb(47,157,245)" />
+      <stop offset="0.8042553191489361" stop-color="rgb(48,154,246)" />
+      <stop offset="0.8085106382978724" stop-color="rgb(49,151,247)" />
+      <stop offset="0.8170212765957447" stop-color="rgb(52,146,248)" />
+      <stop offset="0.8170212765957447" stop-color="rgb(52,146,248)" />
+      <stop offset="0.8170212765957447" stop-color="rgb(52,146,248)" />
+      <stop offset="0.8212765957446809" stop-color="rgb(53,143,248)" />
+      <stop offset="0.825531914893617" stop-color="rgb(54,140,249)" />
+      <stop offset="0.8340425531914895" stop-color="rgb(57,134,249)" />
+      <stop offset="0.8382978723404257" stop-color="rgb(58,131,249)" />
+      <stop offset="0.8382978723404257" stop-color="rgb(58,131,249)" />
+      <stop offset="0.8425531914893619" stop-color="rgb(59,128,248)" />
+      <stop offset="0.8468085106382978" stop-color="rgb(61,125,248)" />
+      <stop offset="0.8468085106382978" stop-color="rgb(61,125,248)" />
+      <stop offset="0.851063829787234" stop-color="rgb(62,122,247)" />
+      <stop offset="0.8553191489361702" stop-color="rgb(63,119,246)" />
+      <stop offset="0.8808510638297874" stop-color="rgb(70,101,235)" />
+      <stop offset="0.8808510638297874" stop-color="rgb(70,101,235)" />
+      <stop offset="0.8936170212765958" stop-color="rgb(73,92,226)" />
+      <stop offset="0.9021276595744682" stop-color="rgb(74,86,219)" />
+      <stop offset="0.9063829787234045" stop-color="rgb(74,83,215)" />
+      <stop offset="0.9234042553191492" stop-color="rgb(75,72,195)" />
+      <stop offset="0.9276595744680853" stop-color="rgb(75,69,189)" />
+      <stop offset="0.9404255319148938" stop-color="rgb(73,60,170)" />
+      <stop offset="1" stop-color="rgb(35,23,27)" />
+    </linearGradient>
+  </defs>
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-14" fill="none" transform="matrix(1,0,0,1,0,0)" class="view">
+        <g transform="matrix(1,0,0,1,0,0)">
+          <path
+            id="g-svg-15"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 640,0 l 0,1000 l-640 0 z"
+            width="640"
+            height="1000"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,16,16)">
+          <path
+            id="g-svg-16"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 608,0 l 0,968 l-608 0 z"
+            width="608"
+            height="968"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,107.160004,16)">
+          <path
+            id="g-svg-17"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 516.8399998699315,0 l 0,902 l-516.8399998699315 0 z"
+            width="516.8399998699315"
+            height="902"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,107.160004,16)">
+          <path
+            id="g-svg-18"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 516.8399998699315,0 l 0,902 l-516.8399998699315 0 z"
+            width="516.8399998699315"
+            height="902"
+          />
+        </g>
+        <g
+          id="g-svg-19"
+          fill="none"
+          transform="matrix(1,0,0,1,0,0)"
+          class="component"
+        >
+          <g
+            id="g-svg-21"
+            fill="none"
+            class="axis"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <g
+              id="g-svg-22"
+              fill="none"
+              transform="matrix(1,0,0,1,0,0)"
+              class="axis-grid-group"
+            >
+              <g
+                id="g-svg-23"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-grid"
+              >
+                <g
+                  id="g-svg-24"
+                  fill="none"
+                  transform="matrix(1,0,0,1,0,0)"
+                  class="grid-line-group"
+                >
+                  <g transform="matrix(1,0,0,1,107.160004,16)">
+                    <path
+                      id="g-svg-26"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,107.160004,243.353424)">
+                    <path
+                      id="g-svg-27"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,107.160004,468.235626)">
+                    <path
+                      id="g-svg-28"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,107.160004,693.117798)">
+                    <path
+                      id="g-svg-29"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-25"
+                  fill="none"
+                  transform="matrix(1,0,0,1,0,0)"
+                  class="grid-region-group"
+                />
+              </g>
+            </g>
+            <g
+              id="g-svg-30"
+              fill="none"
+              transform="matrix(1,0,0,1,0,0)"
+              class="axis-main-group"
+            >
+              <g
+                id="g-svg-31"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,107.160004,16)">
+                  <line
+                    id="g-svg-32"
+                    fill="none"
+                    x1="0"
+                    y1="902"
+                    x2="0"
+                    y2="0"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-33"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-34"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,16)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-38"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-35"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,243.353424)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-39"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-36"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,468.235626)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-40"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-37"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,693.117798)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-41"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-42"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-43"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,16)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-47"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      October
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-44"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,243.353424)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-48"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      2012
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-45"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,468.235626)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-49"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      April
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-46"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,693.117798)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-50"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      July
+                    </text>
+                  </g>
+                </g>
+              </g>
+            </g>
+            <g
+              id="g-svg-51"
+              fill="none"
+              transform="matrix(1,0,0,1,17.000004,461.250000)"
+              class="axis-title-group"
+            >
+              <g transform="matrix(0,-1,1,0,11.500000,0)">
+                <text
+                  id="g-svg-52"
+                  fill="rgba(29,33,41,1)"
+                  dominant-baseline="central"
+                  paint-order="stroke"
+                  dx="0.5"
+                  font-family="sans-serif"
+                  font-size="12"
+                  font-style="normal"
+                  font-variant="normal"
+                  font-weight="normal"
+                  stroke-width="1"
+                  text-anchor="middle"
+                  class="axis-title"
+                  opacity="0.9"
+                >
+                  date
+                </text>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+          id="g-svg-20"
+          fill="none"
+          transform="matrix(1,0,0,1,0,0)"
+          class="component"
+        >
+          <g
+            id="g-svg-54"
+            fill="none"
+            class="axis"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <g
+              id="g-svg-55"
+              fill="none"
+              transform="matrix(1,0,0,1,0,0)"
+              class="axis-grid-group"
+            >
+              <g
+                id="g-svg-56"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-grid"
+              >
+                <g
+                  id="g-svg-57"
+                  fill="none"
+                  transform="matrix(1,0,0,1,0,0)"
+                  class="grid-line-group"
+                >
+                  <g transform="matrix(1,0,0,1,107.160004,16)">
+                    <path
+                      id="g-svg-59"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,902 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,193.300003,16)">
+                    <path
+                      id="g-svg-60"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,902 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,279.440002,16)">
+                    <path
+                      id="g-svg-61"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,902 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,365.579987,16)">
+                    <path
+                      id="g-svg-62"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,902 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,451.720001,16)">
+                    <path
+                      id="g-svg-63"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,902 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,537.859985,16)">
+                    <path
+                      id="g-svg-64"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,902 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,624,16)">
+                    <path
+                      id="g-svg-65"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,902 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-58"
+                  fill="none"
+                  transform="matrix(1,0,0,1,0,0)"
+                  class="grid-region-group"
+                />
+              </g>
+            </g>
+            <g
+              id="g-svg-66"
+              fill="none"
+              transform="matrix(1,0,0,1,0,0)"
+              class="axis-main-group"
+            >
+              <g
+                id="g-svg-67"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,107.160004,918)">
+                  <line
+                    id="g-svg-68"
+                    fill="none"
+                    x1="0"
+                    y1="0"
+                    x2="516.8399998699315"
+                    y2="0"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-69"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-70"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,918)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-77"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-71"
+                  fill="none"
+                  transform="matrix(1,0,0,1,193.300003,918)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-78"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-72"
+                  fill="none"
+                  transform="matrix(1,0,0,1,279.440002,918)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-79"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-73"
+                  fill="none"
+                  transform="matrix(1,0,0,1,365.579987,918)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-80"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-74"
+                  fill="none"
+                  transform="matrix(1,0,0,1,451.720001,918)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-81"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-75"
+                  fill="none"
+                  transform="matrix(1,0,0,1,537.859985,918)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-82"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-76"
+                  fill="none"
+                  transform="matrix(1,0,0,1,624,918)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-83"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-84"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-85"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,926)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-92"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      40
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-86"
+                  fill="none"
+                  transform="matrix(1,0,0,1,193.300003,926)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-93"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      45
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-87"
+                  fill="none"
+                  transform="matrix(1,0,0,1,279.440002,926)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-94"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      50
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-88"
+                  fill="none"
+                  transform="matrix(1,0,0,1,365.579987,926)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-95"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      55
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-89"
+                  fill="none"
+                  transform="matrix(1,0,0,1,451.720001,926)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-96"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      60
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-90"
+                  fill="none"
+                  transform="matrix(1,0,0,1,537.859985,926)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-97"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      65
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-91"
+                  fill="none"
+                  transform="matrix(1,0,0,1,624,926)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-98"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      70
+                    </text>
+                  </g>
+                </g>
+              </g>
+            </g>
+            <g
+              id="g-svg-99"
+              fill="none"
+              transform="matrix(1,0,0,1,365.839996,984)"
+              class="axis-title-group"
+            >
+              <g transform="matrix(1,0,0,1,0,0)">
+                <text
+                  id="g-svg-100"
+                  fill="rgba(29,33,41,1)"
+                  dominant-baseline="central"
+                  paint-order="stroke"
+                  dx="0.5"
+                  font-family="sans-serif"
+                  font-size="12"
+                  font-style="normal"
+                  font-variant="normal"
+                  font-weight="normal"
+                  stroke-width="1"
+                  text-anchor="middle"
+                  class="axis-title"
+                  dy="-11.5px"
+                  opacity="0.9"
+                >
+                  value
+                </text>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g transform="matrix(1,0,0,1,107.160004,16)">
+          <path
+            id="g-svg-102"
+            fill="rgba(0,0,0,0)"
+            class="plot"
+            d="M 0,0 l 516.8399998699315,0 l 0,902 l-516.8399998699315 0 z"
+            width="516.8399998699315"
+            height="902"
+          />
+          <g
+            id="g-svg-103"
+            fill="none"
+            transform="matrix(1,0,0,1,0,0)"
+            class="main-layer"
+          >
+            <g transform="matrix(1,0,0,1,74.080002,0)">
+              <path
+                id="g-svg-105"
+                fill="none"
+                d="M 316.99600000000004,0 L 292.87600000000003,0 L 292.87600000000003,2.471 L 261.86600000000004,2.471 L 261.86600000000004,4.942 L 252.39100000000002,4.942 L 252.39100000000002,7.414 L 248.945,7.414 L 248.945,9.885 L 233.44,9.885 L 233.44,12.356 L 216.212,12.356 L 216.212,14.827 L 214.48900000000003,14.827 L 214.48900000000003,17.299 L 214.48900000000003,17.299 L 214.48900000000003,19.77 L 242.91500000000002,19.77 L 242.91500000000002,22.241 L 280.817,22.241 L 280.817,24.712 L 292.87600000000003,24.712 L 292.87600000000003,27.184 L 320.44100000000003,27.184 L 320.44100000000003,29.655 L 368.68,29.655 L 368.68,32.126 L 371.264,32.126 L 371.264,34.597 L 323.887,34.597 L 323.887,37.068 L 293.738,37.068 L 293.738,39.54 L 273.064,39.54 L 273.064,42.011 L 254.113,42.011 L 254.113,44.482 L 236.885,44.482 L 236.885,46.953 L 215.35000000000002,46.953 L 215.35000000000002,49.425 L 245.49900000000002,49.425 L 245.49900000000002,51.896 L 320.44100000000003,51.896 L 320.44100000000003,54.367 L 322.16400000000004,54.367 L 322.16400000000004,56.838 L 244.63800000000003,56.838 L 244.63800000000003,59.31 L 190.37,59.31 L 190.37,61.781 L 190.37,61.781 L 190.37,64.252 L 220.519,64.252 L 220.519,66.723 L 232.57800000000003,66.723 L 232.57800000000003,69.195 L 229.13300000000004,69.195 L 229.13300000000004,71.666 L 208.459,71.666 L 208.459,74.137 L 210.18200000000002,74.137 L 210.18200000000002,76.608 L 292.01500000000004,76.608 L 292.01500000000004,79.079 L 277.37100000000004,79.079 L 277.37100000000004,81.551 L 155.914,81.551 L 155.914,84.022 L 113.705,84.022 L 113.705,86.493 L 131.79500000000002,86.493 L 131.79500000000002,88.964 L 132.656,88.964 L 132.656,91.436 L 115.42800000000001,91.436 L 115.42800000000001,93.907 L 142.993,93.907 L 142.993,96.378 L 186.063,96.378 L 186.063,98.849 L 180.03300000000002,98.849 L 180.03300000000002,101.321 L 166.25099999999998,101.321 L 166.25099999999998,103.792 L 165.389,103.792 L 165.389,106.263 L 161.082,106.263 L 161.082,108.734 L 157.637,108.734 L 157.637,111.205 L 146.438,111.205 L 146.438,113.677 L 140.409,113.677 L 140.409,116.148 L 148.161,116.148 L 148.161,118.619 L 116.289,118.619 L 116.289,121.09 L 93.032,121.09 L 93.032,123.562 L 111.121,123.562 L 111.121,126.033 L 127.48800000000001,126.033 L 127.48800000000001,128.504 L 157.637,128.504 L 157.637,130.975 L 181.75600000000003,130.975 L 181.75600000000003,133.447 L 155.05200000000002,133.447 L 155.05200000000002,135.918 L 142.13100000000003,135.918 L 142.13100000000003,138.389 L 149.02300000000002,138.389 L 149.02300000000002,140.86 L 126.62599999999999,140.86 L 126.62599999999999,143.332 L 102.50699999999999,143.332 L 102.50699999999999,145.803 L 92.17,145.803 L 92.17,148.274 L 186.063,148.274 L 186.063,150.745 L 292.87600000000003,150.745 L 292.87600000000003,153.216 L 274.78700000000003,153.216 L 274.78700000000003,155.688 L 192.954,155.688 L 192.954,158.159 L 134.37900000000002,158.159 L 134.37900000000002,160.63 L 110.26,160.63 L 110.26,163.101 L 85.27900000000001,163.101 L 85.27900000000001,165.573 L 55.13000000000001,165.573 L 55.13000000000001,168.044 L 65.467,168.044 L 65.467,170.515 L 114.567,170.515 L 114.567,172.986 L 105.95299999999999,172.986 L 105.95299999999999,175.458 L 65.467,175.458 L 65.467,177.929 L 51.684,177.929 L 51.684,180.4 L 40.486000000000004,180.4 L 40.486000000000004,182.871 L 54.26899999999999,182.871 L 54.26899999999999,185.342 L 69.77400000000002,185.342 L 69.77400000000002,187.814 L 78.38799999999999,187.814 L 78.38799999999999,190.285 L 88.72500000000001,190.285 L 88.72500000000001,192.756 L 75.80399999999999,192.756 L 75.80399999999999,195.227 L 77.526,195.227 L 77.526,197.699 L 78.38799999999999,197.699 L 78.38799999999999,200.17 L 112.84400000000001,200.17 L 112.84400000000001,202.641 L 105.091,202.641 L 105.091,205.112 L 58.57600000000001,205.112 L 58.57600000000001,207.584 L 70.635,207.584 L 70.635,210.055 L 53.407,210.055 L 53.407,212.526 L 38.763000000000005,212.526 L 38.763000000000005,214.997 L 64.605,214.997 L 64.605,217.468 L 96.47699999999999,217.468 L 96.47699999999999,219.94 L 130.933,219.94 L 130.933,222.411 L 124.04200000000002,222.411 L 124.04200000000002,224.882 L 132.656,224.882 L 132.656,227.353 L 158.498,227.353 L 158.498,229.825 L 122.319,229.825 L 122.319,232.296 L 118.87400000000001,232.296 L 118.87400000000001,234.767 L 143.85399999999998,234.767 L 143.85399999999998,237.238 L 111.98200000000001,237.238 L 111.98200000000001,239.71 L 98.2,239.71 L 98.2,242.181 L 165.389,242.181 L 165.389,244.652 L 176.587,244.652 L 176.587,247.123 L 131.79500000000002,247.123 L 131.79500000000002,249.595 L 110.26,249.595 L 110.26,252.066 L 112.84400000000001,252.066 L 112.84400000000001,254.537 L 146.438,254.537 L 146.438,257.008 L 155.05200000000002,257.008 L 155.05200000000002,259.479 L 120.59599999999999,259.479 L 120.59599999999999,261.951 L 55.13000000000001,261.951 L 55.13000000000001,264.422 L 2.585000000000008,264.422 L 2.585000000000008,266.893 L 0,266.893 L 0,269.364 L 31.872,269.364 L 31.872,271.836 L 87.002,271.836 L 87.002,274.307 L 142.13100000000003,274.307 L 142.13100000000003,276.778 L 115.42800000000001,276.778 L 115.42800000000001,279.249 L 108.53699999999999,279.249 L 108.53699999999999,281.721 L 115.42800000000001,281.721 L 115.42800000000001,284.192 L 108.53699999999999,284.192 L 108.53699999999999,286.663 L 147.3,286.663 L 147.3,289.134 L 132.656,289.134 L 132.656,291.605 L 104.23,291.605 L 104.23,294.077 L 133.517,294.077 L 133.517,296.548 L 147.3,296.548 L 147.3,299.019 L 114.567,299.019 L 114.567,301.49 L 98.2,301.49 L 98.2,303.962 L 109.39800000000001,303.962 L 109.39800000000001,306.433 L 122.319,306.433 L 122.319,308.904 L 128.349,308.904 L 128.349,311.375 L 148.161,311.375 L 148.161,313.847 L 170.558,313.847 L 170.558,316.318 L 174.865,316.318 L 174.865,318.789 L 151.60700000000003,318.789 L 151.60700000000003,321.26 L 147.3,321.26 L 147.3,323.732 L 164.52800000000002,323.732 L 164.52800000000002,326.203 L 151.60700000000003,326.203 L 151.60700000000003,328.674 L 118.87400000000001,328.674 L 118.87400000000001,331.145 L 94.754,331.145 L 94.754,333.616 L 81.83300000000001,333.616 L 81.83300000000001,336.088 L 85.27900000000001,336.088 L 85.27900000000001,338.559 L 118.01200000000001,338.559 L 118.01200000000001,341.03 L 118.01200000000001,341.03 L 118.01200000000001,343.501 L 111.121,343.501 L 111.121,345.973 L 93.032,345.973 L 93.032,348.444 L 68.051,348.444 L 68.051,350.915 L 84.41799999999999,350.915 L 84.41799999999999,353.386 L 124.903,353.386 L 124.903,355.858 L 162.805,355.858 L 162.805,358.329 L 184.34000000000003,358.329 L 184.34000000000003,360.8 L 163.666,360.8 L 163.666,363.271 L 93.032,363.271 L 93.032,365.742 L 38.763000000000005,365.742 L 38.763000000000005,368.214 L 32.733999999999995,368.214 L 32.733999999999995,370.685 L 70.635,370.685 L 70.635,373.156 L 87.002,373.156 L 87.002,375.627 L 72.35799999999999,375.627 L 72.35799999999999,378.099 L 87.86300000000001,378.099 L 87.86300000000001,380.57 L 147.3,380.57 L 147.3,383.041 L 130.933,383.041 L 130.933,385.512 L 74.081,385.512 L 74.081,387.984 L 83.556,387.984 L 83.556,390.455 L 90.44699999999999,390.455 L 90.44699999999999,392.926 L 105.95299999999999,392.926 L 105.95299999999999,395.397 L 106.81400000000001,395.397 L 106.81400000000001,397.868 L 92.17,397.868 L 92.17,400.34 L 86.14,400.34 L 86.14,402.811 L 119.735,402.811 L 119.735,405.282 L 176.587,405.282 L 176.587,407.753 L 193.815,407.753 L 193.815,410.225 L 188.647,410.225 L 188.647,412.696 L 122.319,412.696 L 122.319,415.167 L 57.71400000000001,415.167 L 57.71400000000001,417.638 L 37.041,417.638 L 37.041,420.11 L 59.437,420.11 L 59.437,422.581 L 107.675,422.581 L 107.675,425.052 L 122.319,425.052 L 122.319,427.523 L 96.47699999999999,427.523 L 96.47699999999999,429.995 L 75.80399999999999,429.995 L 75.80399999999999,432.466 L 58.57600000000001,432.466 L 58.57600000000001,434.937 L 64.605,434.937 L 64.605,437.408 L 130.933,437.408 L 130.933,439.879 L 173.142,439.879 L 173.142,442.351 L 157.637,442.351 L 157.637,444.822 L 156.77499999999998,444.822 L 156.77499999999998,447.293 L 190.37,447.293 L 190.37,449.764 L 161.082,449.764 L 161.082,452.236 L 111.98200000000001,452.236 L 111.98200000000001,454.707 L 121.45800000000001,454.707 L 121.45800000000001,457.178 L 122.319,457.178 L 122.319,459.649 L 85.27900000000001,459.649 L 85.27900000000001,462.121 L 57.71400000000001,462.121 L 57.71400000000001,464.592 L 70.635,464.592 L 70.635,467.063 L 93.032,467.063 L 93.032,469.534 L 109.39800000000001,469.534 L 109.39800000000001,472.005 L 142.13100000000003,472.005 L 142.13100000000003,474.477 L 155.914,474.477 L 155.914,476.948 L 156.77499999999998,476.948 L 156.77499999999998,479.419 L 133.517,479.419 L 133.517,481.89 L 107.675,481.89 L 107.675,484.362 L 118.87400000000001,484.362 L 118.87400000000001,486.833 L 127.48800000000001,486.833 L 127.48800000000001,489.304 L 142.13100000000003,489.304 L 142.13100000000003,491.775 L 151.60700000000003,491.775 L 151.60700000000003,494.247 L 167.973,494.247 L 167.973,496.718 L 192.09300000000002,496.718 L 192.09300000000002,499.189 L 217.07300000000004,499.189 L 217.07300000000004,501.66 L 191.231,501.66 L 191.231,504.132 L 166.25099999999998,504.132 L 166.25099999999998,506.603 L 210.18200000000002,506.603 L 210.18200000000002,509.074 L 230.856,509.074 L 230.856,511.545 L 208.459,511.545 L 208.459,514.016 L 174.003,514.016 L 174.003,516.488 L 168.83499999999998,516.488 L 168.83499999999998,518.959 L 173.142,518.959 L 173.142,521.43 L 161.94400000000002,521.43 L 161.94400000000002,523.901 L 150.745,523.901 L 150.745,526.373 L 127.48800000000001,526.373 L 127.48800000000001,528.844 L 126.62599999999999,528.844 L 126.62599999999999,531.315 L 149.88400000000001,531.315 L 149.88400000000001,533.786 L 154.19099999999997,533.786 L 154.19099999999997,536.258 L 180.894,536.258 L 180.894,538.729 L 199.84500000000003,538.729 L 199.84500000000003,541.2 L 161.082,541.2 L 161.082,543.671 L 136.10199999999998,543.671 L 136.10199999999998,546.142 L 148.161,546.142 L 148.161,548.614 L 154.19099999999997,548.614 L 154.19099999999997,551.085 L 124.04200000000002,551.085 L 124.04200000000002,553.556 L 114.567,553.556 L 114.567,556.027 L 167.11200000000002,556.027 L 167.11200000000002,558.499 L 175.726,558.499 L 175.726,560.97 L 132.656,560.97 L 132.656,563.441 L 118.87400000000001,563.441 L 118.87400000000001,565.912 L 129.20999999999998,565.912 L 129.20999999999998,568.384 L 137.824,568.384 L 137.824,570.855 L 157.637,570.855 L 157.637,573.326 L 161.082,573.326 L 161.082,575.797 L 155.914,575.797 L 155.914,578.268 L 187.786,578.268 L 187.786,580.74 L 194.67700000000002,580.74 L 194.67700000000002,583.211 L 160.221,583.211 L 160.221,585.682 L 137.824,585.682 L 137.824,588.153 L 135.24,588.153 L 135.24,590.625 L 142.13100000000003,590.625 L 142.13100000000003,593.096 L 141.26999999999998,593.096 L 141.26999999999998,595.567 L 134.37900000000002,595.567 L 134.37900000000002,598.038 L 144.716,598.038 L 144.716,600.51 L 167.973,600.51 L 167.973,602.981 L 174.003,602.981 L 174.003,605.452 L 152.46800000000002,605.452 L 152.46800000000002,607.923 L 163.666,607.923 L 163.666,610.395 L 174.003,610.395 L 174.003,612.866 L 163.666,612.866 L 163.666,615.337 L 167.11200000000002,615.337 L 167.11200000000002,617.808 L 169.69600000000003,617.808 L 169.69600000000003,620.279 L 179.17200000000003,620.279 L 179.17200000000003,622.751 L 227.41000000000003,622.751 L 227.41000000000003,625.222 L 246.361,625.222 L 246.361,627.693 L 204.15200000000004,627.693 L 204.15200000000004,630.164 L 170.558,630.164 L 170.558,632.636 L 155.914,632.636 L 155.914,635.107 L 167.11200000000002,635.107 L 167.11200000000002,637.578 L 198.122,637.578 L 198.122,640.049 L 206.736,640.049 L 206.736,642.521 L 167.973,642.521 L 167.973,644.992 L 153.32999999999998,644.992 L 153.32999999999998,647.463 L 177.449,647.463 L 177.449,649.934 L 172.28000000000003,649.934 L 172.28000000000003,652.405 L 161.94400000000002,652.405 L 161.94400000000002,654.877 L 178.31,654.877 L 178.31,657.348 L 192.954,657.348 L 192.954,659.819 L 206.736,659.819 L 206.736,662.29 L 221.38,662.29 L 221.38,664.762 L 229.13300000000004,664.762 L 229.13300000000004,667.233 L 221.38,667.233 L 221.38,669.704 L 210.18200000000002,669.704 L 210.18200000000002,672.175 L 225.687,672.175 L 225.687,674.647 L 246.361,674.647 L 246.361,677.118 L 229.13300000000004,677.118 L 229.13300000000004,679.589 L 209.32100000000003,679.589 L 209.32100000000003,682.06 L 204.15200000000004,682.06 L 204.15200000000004,684.532 L 189.50800000000004,684.532 L 189.50800000000004,687.003 L 181.75600000000003,687.003 L 181.75600000000003,689.474 L 180.894,689.474 L 180.894,691.945 L 162.805,691.945 L 162.805,694.416 L 154.19099999999997,694.416 L 154.19099999999997,696.888 L 156.77499999999998,696.888 L 156.77499999999998,699.359 L 148.161,699.359 L 148.161,701.83 L 138.68599999999998,701.83 L 138.68599999999998,704.301 L 144.716,704.301 L 144.716,706.773 L 161.94400000000002,706.773 L 161.94400000000002,709.244 L 167.11200000000002,709.244 L 167.11200000000002,711.715 L 171.41899999999998,711.715 L 171.41899999999998,714.186 L 194.67700000000002,714.186 L 194.67700000000002,716.658 L 220.519,716.658 L 220.519,719.129 L 223.964,719.129 L 223.964,721.6 L 229.13300000000004,721.6 L 229.13300000000004,724.071 L 233.44,724.071 L 233.44,726.542 L 215.35000000000002,726.542 L 215.35000000000002,729.014 L 206.736,729.014 L 206.736,731.485 L 222.24200000000002,731.485 L 222.24200000000002,733.956 L 229.99400000000003,733.956 L 229.99400000000003,736.427 L 217.935,736.427 L 217.935,738.899 L 198.98400000000004,738.899 L 198.98400000000004,741.37 L 186.92400000000004,741.37 L 186.92400000000004,743.841 L 189.50800000000004,743.841 L 189.50800000000004,746.312 L 194.67700000000002,746.312 L 194.67700000000002,748.784 L 197.26100000000002,748.784 L 197.26100000000002,751.255 L 195.538,751.255 L 195.538,753.726 L 182.61700000000002,753.726 L 182.61700000000002,756.197 L 167.973,756.197 L 167.973,758.668 L 165.389,758.668 L 165.389,761.14 L 200.707,761.14 L 200.707,763.611 L 236.024,763.611 L 236.024,766.082 L 237.747,766.082 L 237.747,768.553 L 227.41000000000003,768.553 L 227.41000000000003,771.025 L 201.56800000000004,771.025 L 201.56800000000004,773.496 L 182.61700000000002,773.496 L 182.61700000000002,775.967 L 165.389,775.967 L 165.389,778.438 L 145.577,778.438 L 145.577,780.91 L 148.161,780.91 L 148.161,783.381 L 160.221,783.381 L 160.221,785.852 L 185.20100000000002,785.852 L 185.20100000000002,788.323 L 212.76600000000002,788.323 L 212.76600000000002,790.795 L 205.014,790.795 L 205.014,793.266 L 197.26100000000002,793.266 L 197.26100000000002,795.737 L 188.647,795.737 L 188.647,798.208 L 161.94400000000002,798.208 L 161.94400000000002,800.679 L 154.19099999999997,800.679 L 154.19099999999997,803.151 L 166.25099999999998,803.151 L 166.25099999999998,805.622 L 186.063,805.622 L 186.063,808.093 L 188.647,808.093 L 188.647,810.564 L 172.28000000000003,810.564 L 172.28000000000003,813.036 L 186.92400000000004,813.036 L 186.92400000000004,815.507 L 225.687,815.507 L 225.687,817.978 L 244.63800000000003,817.978 L 244.63800000000003,820.449 L 237.747,820.449 L 237.747,822.921 L 213.62800000000004,822.921 L 213.62800000000004,825.392 L 195.538,825.392 L 195.538,827.863 L 193.815,827.863 L 193.815,830.334 L 174.003,830.334 L 174.003,832.805 L 155.05200000000002,832.805 L 155.05200000000002,835.277 L 149.88400000000001,835.277 L 149.88400000000001,837.748 L 158.498,837.748 L 158.498,840.219 L 191.231,840.219 L 191.231,842.69 L 207.598,842.69 L 207.598,845.162 L 209.32100000000003,845.162 L 209.32100000000003,847.633 L 209.32100000000003,847.633 L 209.32100000000003,850.104 L 199.84500000000003,850.104 L 199.84500000000003,852.575 L 198.122,852.575 L 198.122,855.047 L 200.707,855.047 L 200.707,857.518 L 184.34000000000003,857.518 L 184.34000000000003,859.989 L 180.03300000000002,859.989 L 180.03300000000002,862.46 L 180.03300000000002,862.46 L 180.03300000000002,864.932 L 160.221,864.932 L 160.221,867.403 L 164.52800000000002,867.403 L 164.52800000000002,869.874 L 180.894,869.874 L 180.894,872.345 L 198.122,872.345 L 198.122,874.816 L 203.291,874.816 L 203.291,877.288 L 194.67700000000002,877.288 L 194.67700000000002,879.759 L 198.98400000000004,879.759 L 198.98400000000004,882.23 L 173.142,882.23 L 173.142,884.701 L 161.082,884.701 L 161.082,887.173 L 165.389,887.173 L 165.389,889.644 L 157.637,889.644 L 157.637,892.115 L 147.3,892.115 L 147.3,894.586 L 138.68599999999998,894.586 L 138.68599999999998,897.058 L 154.19099999999997,897.058 L 154.19099999999997,899.529 L 175.726,899.529 L 175.726,902 L 186.063,902"
+                stroke-linecap="round"
+                stroke="url(#g-pattern-0)"
+                stroke-width="2"
+                stroke-linejoin="round"
+                class="element"
+              />
+            </g>
+          </g>
+          <g
+            id="g-svg-104"
+            fill="none"
+            transform="matrix(1,0,0,1,0,0)"
+            class="label-layer"
+          />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/__tests__/integration/snapshots/static/temperatures3AreaBandGradientTranspose.svg
+++ b/__tests__/integration/snapshots/static/temperatures3AreaBandGradientTranspose.svg
@@ -1,0 +1,1852 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="640"
+  height="900"
+  style="background: transparent;"
+  color-interpolation-filters="sRGB"
+>
+  <defs>
+    <linearGradient
+      gradientUnits="userSpaceOnUse"
+      id="g-pattern-0"
+      x1="234.19299999999998"
+      y1="0"
+      x2="234.19300000000004"
+      y2="802"
+    >
+      <stop offset="0" stop-color="rgb(255,240,233)" />
+      <stop offset="0.0013679890560875513" stop-color="rgb(253,203,183)" />
+      <stop offset="0.0027359781121751026" stop-color="rgb(253,210,191)" />
+      <stop offset="0.004103967168262654" stop-color="rgb(254,220,206)" />
+      <stop offset="0.005471956224350205" stop-color="rgb(253,210,191)" />
+      <stop offset="0.0068399452804377555" stop-color="rgb(252,182,156)" />
+      <stop offset="0.008207934336525308" stop-color="rgb(252,185,160)" />
+      <stop offset="0.009575923392612859" stop-color="rgb(252,169,141)" />
+      <stop offset="0.01094391244870041" stop-color="rgb(252,154,124)" />
+      <stop offset="0.012311901504787962" stop-color="rgb(251,127,96)" />
+      <stop offset="0.013679890560875511" stop-color="rgb(236,63,48)" />
+      <stop offset="0.015047879616963064" stop-color="rgb(103,0,13)" />
+      <stop offset="0.016415868673050615" stop-color="rgb(202,28,30)" />
+      <stop offset="0.017783857729138167" stop-color="rgb(205,30,31)" />
+      <stop offset="0.019151846785225718" stop-color="rgb(246,89,64)" />
+      <stop offset="0.02051983584131327" stop-color="rgb(254,231,220)" />
+      <stop offset="0.02188782489740082" stop-color="rgb(255,240,233)" />
+      <stop offset="0.023255813953488372" stop-color="rgb(254,232,222)" />
+      <stop offset="0.024623803009575923" stop-color="rgb(254,223,208)" />
+      <stop offset="0.025991792065663474" stop-color="rgb(253,198,176)" />
+      <stop offset="0.027359781121751022" stop-color="rgb(252,188,164)" />
+      <stop offset="0.028727770177838577" stop-color="rgb(253,203,183)" />
+      <stop offset="0.030095759233926128" stop-color="rgb(252,147,116)" />
+      <stop offset="0.03146374829001368" stop-color="rgb(254,216,199)" />
+      <stop offset="0.03283173734610123" stop-color="rgb(254,226,213)" />
+      <stop offset="0.03419972640218878" stop-color="rgb(252,174,146)" />
+      <stop offset="0.03556771545827633" stop-color="rgb(252,153,122)" />
+      <stop offset="0.036935704514363885" stop-color="rgb(252,135,103)" />
+      <stop offset="0.038303693570451436" stop-color="rgb(251,121,90)" />
+      <stop offset="0.03967168262653899" stop-color="rgb(252,182,156)" />
+      <stop offset="0.04103967168262654" stop-color="rgb(252,188,164)" />
+      <stop offset="0.04240766073871409" stop-color="rgb(252,142,111)" />
+      <stop offset="0.04377564979480164" stop-color="rgb(251,118,87)" />
+      <stop offset="0.04514363885088919" stop-color="rgb(252,138,106)" />
+      <stop offset="0.046511627906976744" stop-color="rgb(252,135,103)" />
+      <stop offset="0.047879616963064295" stop-color="rgb(205,30,31)" />
+      <stop offset="0.049247606019151846" stop-color="rgb(253,207,188)" />
+      <stop offset="0.050615595075239404" stop-color="rgb(255,235,226)" />
+      <stop offset="0.0520405836753306" stop-color="rgb(254,226,213)" />
+      <stop offset="0.05340857273141815" stop-color="rgb(252,151,121)" />
+      <stop offset="0.0547765617875057" stop-color="rgb(253,201,179)" />
+      <stop offset="0.05614455084359325" stop-color="rgb(252,156,126)" />
+      <stop offset="0.057512539899680803" stop-color="rgb(252,153,122)" />
+      <stop offset="0.05888052895576836" stop-color="rgb(250,110,80)" />
+      <stop offset="0.060248518011855906" stop-color="rgb(238,67,50)" />
+      <stop offset="0.06161650706794346" stop-color="rgb(249,101,72)" />
+      <stop offset="0.06298449612403101" stop-color="rgb(252,151,121)" />
+      <stop offset="0.06435248518011856" stop-color="rgb(252,182,156)" />
+      <stop offset="0.06572047423620611" stop-color="rgb(253,194,171)" />
+      <stop offset="0.06708846329229366" stop-color="rgb(253,203,183)" />
+      <stop offset="0.06845645234838121" stop-color="rgb(252,154,124)" />
+      <stop offset="0.06982444140446877" stop-color="rgb(253,201,179)" />
+      <stop offset="0.07119243046055632" stop-color="rgb(253,201,179)" />
+      <stop offset="0.07256041951664387" stop-color="rgb(255,235,225)" />
+      <stop offset="0.07392840857273142" stop-color="rgb(252,187,162)" />
+      <stop offset="0.07529639762881897" stop-color="rgb(253,194,171)" />
+      <stop offset="0.07666438668490652" stop-color="rgb(253,198,176)" />
+      <stop offset="0.07803237574099407" stop-color="rgb(254,219,204)" />
+      <stop offset="0.07940036479708162" stop-color="rgb(253,206,186)" />
+      <stop offset="0.08076835385316918" stop-color="rgb(252,156,126)" />
+      <stop offset="0.08213634290925671" stop-color="rgb(252,182,156)" />
+      <stop offset="0.08350433196534429" stop-color="rgb(253,192,169)" />
+      <stop offset="0.08487232102143183" stop-color="rgb(254,227,214)" />
+      <stop offset="0.08624031007751938" stop-color="rgb(254,227,214)" />
+      <stop offset="0.08760829913360693" stop-color="rgb(254,219,204)" />
+      <stop offset="0.08897628818969448" stop-color="rgb(254,228,215)" />
+      <stop offset="0.09034427724578203" stop-color="rgb(253,212,195)" />
+      <stop offset="0.0917122663018696" stop-color="rgb(252,181,155)" />
+      <stop offset="0.09308025535795714" stop-color="rgb(254,228,215)" />
+      <stop offset="0.09444824441404469" stop-color="rgb(254,231,220)" />
+      <stop offset="0.09581623347013224" stop-color="rgb(254,223,208)" />
+      <stop offset="0.09718422252621979" stop-color="rgb(255,244,239)" />
+      <stop offset="0.09855221158230734" stop-color="rgb(254,228,215)" />
+      <stop offset="0.09992020063839488" stop-color="rgb(255,244,239)" />
+      <stop offset="0.10128818969448244" stop-color="rgb(254,228,215)" />
+      <stop offset="0.10265617875057" stop-color="rgb(253,210,191)" />
+      <stop offset="0.10402416780665755" stop-color="rgb(252,162,132)" />
+      <stop offset="0.1053921568627451" stop-color="rgb(253,205,185)" />
+      <stop offset="0.10676014591883265" stop-color="rgb(252,136,105)" />
+      <stop offset="0.10812813497492019" stop-color="rgb(253,207,188)" />
+      <stop offset="0.10949612403100777" stop-color="rgb(255,235,225)" />
+      <stop offset="0.1108641130870953" stop-color="rgb(252,168,139)" />
+      <stop offset="0.11223210214318285" stop-color="rgb(253,207,188)" />
+      <stop offset="0.1136000911992704" stop-color="rgb(252,159,129)" />
+      <stop offset="0.11496808025535796" stop-color="rgb(251,124,93)" />
+      <stop offset="0.11633606931144551" stop-color="rgb(252,135,103)" />
+      <stop offset="0.11770405836753305" stop-color="rgb(252,185,160)" />
+      <stop offset="0.11907204742362061" stop-color="rgb(252,141,109)" />
+      <stop offset="0.12044003647970816" stop-color="rgb(254,228,215)" />
+      <stop offset="0.12180802553579571" stop-color="rgb(253,192,169)" />
+      <stop offset="0.12317601459188326" stop-color="rgb(252,163,134)" />
+      <stop offset="0.12454400364797082" stop-color="rgb(252,182,156)" />
+      <stop offset="0.12591199270405837" stop-color="rgb(254,218,203)" />
+      <stop offset="0.12727998176014593" stop-color="rgb(254,228,217)" />
+      <stop offset="0.12864797081623347" stop-color="rgb(254,218,203)" />
+      <stop offset="0.13001595987232104" stop-color="rgb(252,182,156)" />
+      <stop offset="0.13138394892840857" stop-color="rgb(252,184,158)" />
+      <stop offset="0.13275193798449614" stop-color="rgb(250,114,83)" />
+      <stop offset="0.13411992704058368" stop-color="rgb(253,212,195)" />
+      <stop offset="0.13548791609667124" stop-color="rgb(255,240,232)" />
+      <stop offset="0.13685590515275878" stop-color="rgb(254,227,214)" />
+      <stop offset="0.13822389420884634" stop-color="rgb(252,191,167)" />
+      <stop offset="0.13959188326493388" stop-color="rgb(254,231,220)" />
+      <stop offset="0.14095987232102145" stop-color="rgb(254,219,204)" />
+      <stop offset="0.14232786137710898" stop-color="rgb(254,220,206)" />
+      <stop offset="0.14369585043319655" stop-color="rgb(255,239,231)" />
+      <stop offset="0.14506383948928409" stop-color="rgb(252,144,113)" />
+      <stop offset="0.14643182854537165" stop-color="rgb(246,89,64)" />
+      <stop offset="0.1477998176014592" stop-color="rgb(254,219,204)" />
+      <stop offset="0.14916780665754675" stop-color="rgb(253,203,183)" />
+      <stop offset="0.1505357957136343" stop-color="rgb(253,198,176)" />
+      <stop offset="0.15190378476972186" stop-color="rgb(252,162,132)" />
+      <stop offset="0.1532717738258094" stop-color="rgb(252,172,144)" />
+      <stop offset="0.15463976288189696" stop-color="rgb(252,175,148)" />
+      <stop offset="0.1560077519379845" stop-color="rgb(252,175,148)" />
+      <stop offset="0.15737574099407206" stop-color="rgb(251,118,87)" />
+      <stop offset="0.1587437300501596" stop-color="rgb(252,160,131)" />
+      <stop offset="0.1601117191062472" stop-color="rgb(252,178,151)" />
+      <stop offset="0.1614797081623347" stop-color="rgb(252,159,129)" />
+      <stop offset="0.16284769721842227" stop-color="rgb(235,60,46)" />
+      <stop offset="0.1642156862745098" stop-color="rgb(253,210,191)" />
+      <stop offset="0.16558367533059737" stop-color="rgb(254,232,222)" />
+      <stop offset="0.1669516643866849" stop-color="rgb(252,169,141)" />
+      <stop offset="0.16831965344277247" stop-color="rgb(245,84,61)" />
+      <stop offset="0.16968764249886" stop-color="rgb(252,162,132)" />
+      <stop offset="0.17105563155494757" stop-color="rgb(241,75,54)" />
+      <stop offset="0.1724236206110351" stop-color="rgb(252,142,111)" />
+      <stop offset="0.17379160966712268" stop-color="rgb(229,52,42)" />
+      <stop offset="0.17515959872321024" stop-color="rgb(234,59,45)" />
+      <stop offset="0.17652758777929775" stop-color="rgb(202,28,30)" />
+      <stop offset="0.17789557683538532" stop-color="rgb(253,207,188)" />
+      <stop offset="0.17926356589147288" stop-color="rgb(252,156,126)" />
+      <stop offset="0.18063155494756042" stop-color="rgb(239,70,51)" />
+      <stop offset="0.18199954400364798" stop-color="rgb(245,86,62)" />
+      <stop offset="0.18336753305973552" stop-color="rgb(252,132,100)" />
+      <stop offset="0.1847355221158231" stop-color="rgb(251,124,93)" />
+      <stop offset="0.18610351117191062" stop-color="rgb(252,162,132)" />
+      <stop offset="0.1874715002279982" stop-color="rgb(252,185,160)" />
+      <stop offset="0.18883948928408573" stop-color="rgb(252,160,131)" />
+      <stop offset="0.1902074783401733" stop-color="rgb(253,203,183)" />
+      <stop offset="0.1915754673962608" stop-color="rgb(252,181,155)" />
+      <stop offset="0.19294345645234837" stop-color="rgb(253,203,183)" />
+      <stop offset="0.19431144550843593" stop-color="rgb(252,142,111)" />
+      <stop offset="0.19567943456452352" stop-color="rgb(252,166,137)" />
+      <stop offset="0.19704742362061103" stop-color="rgb(252,188,164)" />
+      <stop offset="0.1984154126766986" stop-color="rgb(252,156,126)" />
+      <stop offset="0.19978340173278614" stop-color="rgb(253,192,169)" />
+      <stop offset="0.2011513907888737" stop-color="rgb(253,195,172)" />
+      <stop offset="0.20251937984496124" stop-color="rgb(252,165,136)" />
+      <stop offset="0.2038873689010488" stop-color="rgb(252,132,100)" />
+      <stop offset="0.20525535795713634" stop-color="rgb(253,209,190)" />
+      <stop offset="0.2066233470132239" stop-color="rgb(253,203,183)" />
+      <stop offset="0.20799133606931142" stop-color="rgb(252,181,155)" />
+      <stop offset="0.209359325125399" stop-color="rgb(254,233,223)" />
+      <stop offset="0.21072731418148657" stop-color="rgb(252,154,124)" />
+      <stop offset="0.21209530323757414" stop-color="rgb(252,138,106)" />
+      <stop offset="0.21346329229366165" stop-color="rgb(254,233,223)" />
+      <stop offset="0.21483128134974921" stop-color="rgb(253,201,179)" />
+      <stop offset="0.21619927040583675" stop-color="rgb(253,201,179)" />
+      <stop offset="0.21756725946192432" stop-color="rgb(252,185,160)" />
+      <stop offset="0.21893524851801185" stop-color="rgb(252,159,129)" />
+      <stop offset="0.22030323757409942" stop-color="rgb(252,162,132)" />
+      <stop offset="0.22167122663018696" stop-color="rgb(252,172,144)" />
+      <stop offset="0.22303921568627452" stop-color="rgb(252,138,106)" />
+      <stop offset="0.2243502051983584" stop-color="rgb(253,195,172)" />
+      <stop offset="0.22571819425444598" stop-color="rgb(254,218,203)" />
+      <stop offset="0.2270861833105335" stop-color="rgb(254,229,218)" />
+      <stop offset="0.22845417236662108" stop-color="rgb(252,156,126)" />
+      <stop offset="0.22982216142270862" stop-color="rgb(252,182,156)" />
+      <stop offset="0.23119015047879618" stop-color="rgb(254,220,206)" />
+      <stop offset="0.23255813953488372" stop-color="rgb(254,223,208)" />
+      <stop offset="0.23392612859097128" stop-color="rgb(253,210,191)" />
+      <stop offset="0.2352941176470588" stop-color="rgb(252,179,153)" />
+      <stop offset="0.23666210670314636" stop-color="rgb(253,202,181)" />
+      <stop offset="0.23803009575923395" stop-color="rgb(252,187,162)" />
+      <stop offset="0.23939808481532152" stop-color="rgb(252,185,160)" />
+      <stop offset="0.24076607387140903" stop-color="rgb(254,231,220)" />
+      <stop offset="0.2421340629274966" stop-color="rgb(252,172,144)" />
+      <stop offset="0.24350205198358413" stop-color="rgb(252,169,141)" />
+      <stop offset="0.2448700410396717" stop-color="rgb(252,141,109)" />
+      <stop offset="0.24623803009575923" stop-color="rgb(123,5,16)" />
+      <stop offset="0.2476060191518468" stop-color="rgb(237,65,49)" />
+      <stop offset="0.24897400820793433" stop-color="rgb(249,104,75)" />
+      <stop offset="0.2503419972640219" stop-color="rgb(252,190,165)" />
+      <stop offset="0.25170998632010944" stop-color="rgb(247,93,66)" />
+      <stop offset="0.253077975376197" stop-color="rgb(224,46,39)" />
+      <stop offset="0.25444596443228457" stop-color="rgb(249,104,75)" />
+      <stop offset="0.2558139534883721" stop-color="rgb(252,163,134)" />
+      <stop offset="0.25718194254445964" stop-color="rgb(252,175,148)" />
+      <stop offset="0.2585499316005472" stop-color="rgb(253,198,176)" />
+      <stop offset="0.25991792065663477" stop-color="rgb(252,169,141)" />
+      <stop offset="0.2612859097127223" stop-color="rgb(253,201,179)" />
+      <stop offset="0.26265389876880985" stop-color="rgb(254,216,199)" />
+      <stop offset="0.2640218878248974" stop-color="rgb(252,175,148)" />
+      <stop offset="0.265389876880985" stop-color="rgb(253,211,193)" />
+      <stop offset="0.2667578659370725" stop-color="rgb(252,178,151)" />
+      <stop offset="0.26812585499316005" stop-color="rgb(252,168,139)" />
+      <stop offset="0.2694938440492476" stop-color="rgb(253,192,169)" />
+      <stop offset="0.2708618331053352" stop-color="rgb(254,229,218)" />
+      <stop offset="0.2722298221614227" stop-color="rgb(254,219,204)" />
+      <stop offset="0.27359781121751026" stop-color="rgb(253,210,191)" />
+      <stop offset="0.2749658002735978" stop-color="rgb(252,159,129)" />
+      <stop offset="0.2763337893296854" stop-color="rgb(252,153,122)" />
+      <stop offset="0.2777017783857729" stop-color="rgb(252,184,158)" />
+      <stop offset="0.27906976744186046" stop-color="rgb(253,201,179)" />
+      <stop offset="0.280437756497948" stop-color="rgb(254,228,215)" />
+      <stop offset="0.2818057455540356" stop-color="rgb(254,228,217)" />
+      <stop offset="0.28317373461012313" stop-color="rgb(252,174,146)" />
+      <stop offset="0.28454172366621067" stop-color="rgb(252,191,167)" />
+      <stop offset="0.2859097127222982" stop-color="rgb(254,218,203)" />
+      <stop offset="0.2872777017783858" stop-color="rgb(252,144,113)" />
+      <stop offset="0.28864569083447333" stop-color="rgb(252,191,167)" />
+      <stop offset="0.29001367989056087" stop-color="rgb(235,60,46)" />
+      <stop offset="0.2913816689466484" stop-color="rgb(251,123,91)" />
+      <stop offset="0.292749658002736" stop-color="rgb(252,169,141)" />
+      <stop offset="0.29411764705882354" stop-color="rgb(198,26,29)" />
+      <stop offset="0.2954856361149111" stop-color="rgb(234,59,45)" />
+      <stop offset="0.2968536251709986" stop-color="rgb(252,182,156)" />
+      <stop offset="0.2982216142270862" stop-color="rgb(254,217,201)" />
+      <stop offset="0.29958960328317374" stop-color="rgb(255,235,225)" />
+      <stop offset="0.3009575923392613" stop-color="rgb(252,148,117)" />
+      <stop offset="0.3023255813953488" stop-color="rgb(253,195,172)" />
+      <stop offset="0.3036935704514364" stop-color="rgb(254,220,206)" />
+      <stop offset="0.30506155950752395" stop-color="rgb(253,212,195)" />
+      <stop offset="0.3064295485636115" stop-color="rgb(252,187,162)" />
+      <stop offset="0.307797537619699" stop-color="rgb(254,228,217)" />
+      <stop offset="0.3091655266757866" stop-color="rgb(252,148,117)" />
+      <stop offset="0.31053351573187415" stop-color="rgb(253,210,191)" />
+      <stop offset="0.3119015047879617" stop-color="rgb(253,215,198)" />
+      <stop offset="0.31326949384404923" stop-color="rgb(253,211,193)" />
+      <stop offset="0.3146374829001368" stop-color="rgb(253,205,185)" />
+      <stop offset="0.31600547195622436" stop-color="rgb(254,223,208)" />
+      <stop offset="0.3173734610123119" stop-color="rgb(253,207,188)" />
+      <stop offset="0.31874145006839943" stop-color="rgb(253,197,174)" />
+      <stop offset="0.320109439124487" stop-color="rgb(253,201,179)" />
+      <stop offset="0.32147742818057456" stop-color="rgb(253,192,169)" />
+      <stop offset="0.3228454172366621" stop-color="rgb(253,214,196)" />
+      <stop offset="0.32421340629274964" stop-color="rgb(253,210,191)" />
+      <stop offset="0.32558139534883723" stop-color="rgb(254,226,213)" />
+      <stop offset="0.32694938440492477" stop-color="rgb(254,223,208)" />
+      <stop offset="0.3283173734610123" stop-color="rgb(252,141,109)" />
+      <stop offset="0.32968536251709984" stop-color="rgb(252,191,167)" />
+      <stop offset="0.33105335157318744" stop-color="rgb(255,240,233)" />
+      <stop offset="0.332421340629275" stop-color="rgb(252,179,153)" />
+      <stop offset="0.33378932968536257" stop-color="rgb(254,225,211)" />
+      <stop offset="0.33515731874145005" stop-color="rgb(253,206,186)" />
+      <stop offset="0.3365253077975376" stop-color="rgb(252,185,160)" />
+      <stop offset="0.3378932968536252" stop-color="rgb(252,165,136)" />
+      <stop offset="0.3392612859097127" stop-color="rgb(254,228,215)" />
+      <stop offset="0.34062927496580025" stop-color="rgb(253,207,188)" />
+      <stop offset="0.34199726402188785" stop-color="rgb(254,225,211)" />
+      <stop offset="0.3433652530779754" stop-color="rgb(254,228,217)" />
+      <stop offset="0.3447332421340629" stop-color="rgb(253,206,186)" />
+      <stop offset="0.3461012311901504" stop-color="rgb(253,201,179)" />
+      <stop offset="0.34746922024623805" stop-color="rgb(254,233,223)" />
+      <stop offset="0.34883720930232553" stop-color="rgb(254,217,201)" />
+      <stop offset="0.35020519835841313" stop-color="rgb(253,195,172)" />
+      <stop offset="0.3515731874145007" stop-color="rgb(252,181,155)" />
+      <stop offset="0.35294117647058826" stop-color="rgb(253,203,183)" />
+      <stop offset="0.35430916552667585" stop-color="rgb(254,221,207)" />
+      <stop offset="0.35567715458276333" stop-color="rgb(254,220,206)" />
+      <stop offset="0.35704514363885087" stop-color="rgb(252,181,155)" />
+      <stop offset="0.35841313269493846" stop-color="rgb(218,40,36)" />
+      <stop offset="0.359781121751026" stop-color="rgb(252,175,148)" />
+      <stop offset="0.36114911080711354" stop-color="rgb(252,160,131)" />
+      <stop offset="0.3625170998632011" stop-color="rgb(253,215,198)" />
+      <stop offset="0.36388508891928867" stop-color="rgb(253,212,195)" />
+      <stop offset="0.3652530779753762" stop-color="rgb(254,218,203)" />
+      <stop offset="0.3666210670314637" stop-color="rgb(253,205,185)" />
+      <stop offset="0.3679890560875513" stop-color="rgb(253,197,174)" />
+      <stop offset="0.3693570451436388" stop-color="rgb(253,209,190)" />
+      <stop offset="0.3707250341997264" stop-color="rgb(254,229,218)" />
+      <stop offset="0.37209302325581395" stop-color="rgb(252,191,167)" />
+      <stop offset="0.3734610123119015" stop-color="rgb(252,191,167)" />
+      <stop offset="0.37482900136798913" stop-color="rgb(252,160,131)" />
+      <stop offset="0.3761969904240766" stop-color="rgb(250,107,78)" />
+      <stop offset="0.37756497948016415" stop-color="rgb(252,181,155)" />
+      <stop offset="0.3789329685362517" stop-color="rgb(253,206,186)" />
+      <stop offset="0.3803009575923393" stop-color="rgb(254,223,208)" />
+      <stop offset="0.3816689466484268" stop-color="rgb(253,211,193)" />
+      <stop offset="0.38303693570451436" stop-color="rgb(254,218,203)" />
+      <stop offset="0.38440492476060195" stop-color="rgb(255,239,231)" />
+      <stop offset="0.3857729138166895" stop-color="rgb(253,206,186)" />
+      <stop offset="0.38714090287277697" stop-color="rgb(253,198,176)" />
+      <stop offset="0.38850889192886456" stop-color="rgb(254,217,201)" />
+      <stop offset="0.3898768809849521" stop-color="rgb(255,239,231)" />
+      <stop offset="0.3912448700410397" stop-color="rgb(254,223,208)" />
+      <stop offset="0.39261285909712723" stop-color="rgb(254,231,220)" />
+      <stop offset="0.39398084815321477" stop-color="rgb(254,223,208)" />
+      <stop offset="0.3953488372093023" stop-color="rgb(253,214,196)" />
+      <stop offset="0.3967168262653899" stop-color="rgb(253,214,196)" />
+      <stop offset="0.39808481532147744" stop-color="rgb(254,229,218)" />
+      <stop offset="0.3994528043775649" stop-color="rgb(253,207,188)" />
+      <stop offset="0.4008207934336525" stop-color="rgb(253,206,186)" />
+      <stop offset="0.4021887824897401" stop-color="rgb(253,203,183)" />
+      <stop offset="0.40355677154582764" stop-color="rgb(253,199,178)" />
+      <stop offset="0.40492476060191523" stop-color="rgb(254,233,223)" />
+      <stop offset="0.4062927496580027" stop-color="rgb(253,203,183)" />
+      <stop offset="0.40766073871409036" stop-color="rgb(253,206,186)" />
+      <stop offset="0.40902872777017785" stop-color="rgb(254,220,206)" />
+      <stop offset="0.4103967168262654" stop-color="rgb(254,221,207)" />
+      <stop offset="0.4117647058823529" stop-color="rgb(254,228,215)" />
+      <stop offset="0.4131326949384405" stop-color="rgb(255,236,228)" />
+      <stop offset="0.41450068399452805" stop-color="rgb(254,231,220)" />
+      <stop offset="0.4158686730506156" stop-color="rgb(254,227,214)" />
+      <stop offset="0.41723666210670307" stop-color="rgb(254,218,203)" />
+      <stop offset="0.4186046511627907" stop-color="rgb(254,216,199)" />
+      <stop offset="0.4199726402188782" stop-color="rgb(254,231,220)" />
+      <stop offset="0.4213406292749658" stop-color="rgb(254,218,203)" />
+      <stop offset="0.42270861833105333" stop-color="rgb(254,225,211)" />
+      <stop offset="0.4240766073871409" stop-color="rgb(254,228,215)" />
+      <stop offset="0.4254445964432285" stop-color="rgb(253,207,188)" />
+      <stop offset="0.426812585499316" stop-color="rgb(254,218,203)" />
+      <stop offset="0.42818057455540354" stop-color="rgb(254,220,206)" />
+      <stop offset="0.42954856361149113" stop-color="rgb(254,232,222)" />
+      <stop offset="0.43091655266757867" stop-color="rgb(254,231,220)" />
+      <stop offset="0.4322845417236662" stop-color="rgb(253,207,188)" />
+      <stop offset="0.43365253077975374" stop-color="rgb(253,210,191)" />
+      <stop offset="0.43502051983584133" stop-color="rgb(254,218,203)" />
+      <stop offset="0.4363885088919289" stop-color="rgb(252,185,160)" />
+      <stop offset="0.43775649794801635" stop-color="rgb(254,229,218)" />
+      <stop offset="0.43912448700410395" stop-color="rgb(254,220,206)" />
+      <stop offset="0.4404924760601915" stop-color="rgb(255,235,226)" />
+      <stop offset="0.4418604651162791" stop-color="rgb(253,194,171)" />
+      <stop offset="0.4432284541723666" stop-color="rgb(254,223,208)" />
+      <stop offset="0.44459644322845415" stop-color="rgb(255,243,238)" />
+      <stop offset="0.44596443228454175" stop-color="rgb(254,220,206)" />
+      <stop offset="0.4473324213406293" stop-color="rgb(253,212,195)" />
+      <stop offset="0.4487004103967168" stop-color="rgb(254,220,206)" />
+      <stop offset="0.4500683994528043" stop-color="rgb(255,237,229)" />
+      <stop offset="0.45143638850889195" stop-color="rgb(254,223,208)" />
+      <stop offset="0.4528043775649795" stop-color="rgb(254,223,208)" />
+      <stop offset="0.454172366621067" stop-color="rgb(253,201,179)" />
+      <stop offset="0.4555403556771546" stop-color="rgb(253,212,195)" />
+      <stop offset="0.45690834473324216" stop-color="rgb(252,172,144)" />
+      <stop offset="0.45827633378932975" stop-color="rgb(254,225,211)" />
+      <stop offset="0.45964432284541723" stop-color="rgb(253,207,188)" />
+      <stop offset="0.46101231190150477" stop-color="rgb(254,231,220)" />
+      <stop offset="0.46238030095759236" stop-color="rgb(254,233,223)" />
+      <stop offset="0.4637482900136799" stop-color="rgb(254,230,219)" />
+      <stop offset="0.46511627906976744" stop-color="rgb(252,179,153)" />
+      <stop offset="0.466484268125855" stop-color="rgb(252,188,164)" />
+      <stop offset="0.46785225718194257" stop-color="rgb(253,206,186)" />
+      <stop offset="0.4692202462380301" stop-color="rgb(254,223,208)" />
+      <stop offset="0.4705882352941176" stop-color="rgb(253,212,195)" />
+      <stop offset="0.4719562243502052" stop-color="rgb(252,191,167)" />
+      <stop offset="0.4733242134062927" stop-color="rgb(254,220,206)" />
+      <stop offset="0.4746922024623803" stop-color="rgb(253,203,183)" />
+      <stop offset="0.4760601915184679" stop-color="rgb(255,238,230)" />
+      <stop offset="0.4774281805745554" stop-color="rgb(255,239,231)" />
+      <stop offset="0.47879616963064303" stop-color="rgb(254,229,218)" />
+      <stop offset="0.4801641586867305" stop-color="rgb(253,212,195)" />
+      <stop offset="0.48153214774281805" stop-color="rgb(252,165,136)" />
+      <stop offset="0.4829001367989056" stop-color="rgb(248,99,71)" />
+      <stop offset="0.4842681258549932" stop-color="rgb(251,127,96)" />
+      <stop offset="0.4856361149110807" stop-color="rgb(251,121,90)" />
+      <stop offset="0.48700410396716826" stop-color="rgb(254,228,215)" />
+      <stop offset="0.48837209302325574" stop-color="rgb(254,225,211)" />
+      <stop offset="0.4897400820793434" stop-color="rgb(254,220,206)" />
+      <stop offset="0.49110807113543087" stop-color="rgb(254,231,220)" />
+      <stop offset="0.49247606019151846" stop-color="rgb(252,178,151)" />
+      <stop offset="0.493844049247606" stop-color="rgb(252,162,132)" />
+      <stop offset="0.4952120383036936" stop-color="rgb(225,48,40)" />
+      <stop offset="0.49658002735978113" stop-color="rgb(212,35,33)" />
+      <stop offset="0.49794801641586867" stop-color="rgb(253,205,185)" />
+      <stop offset="0.4993160054719562" stop-color="rgb(252,175,148)" />
+      <stop offset="0.5006839945280438" stop-color="rgb(252,162,132)" />
+      <stop offset="0.5020519835841313" stop-color="rgb(253,207,188)" />
+      <stop offset="0.5034199726402189" stop-color="rgb(254,217,201)" />
+      <stop offset="0.5047879616963065" stop-color="rgb(254,221,207)" />
+      <stop offset="0.506155950752394" stop-color="rgb(254,226,213)" />
+      <stop offset="0.5075239398084815" stop-color="rgb(252,191,167)" />
+      <stop offset="0.5088919288645691" stop-color="rgb(252,184,158)" />
+      <stop offset="0.5102599179206566" stop-color="rgb(254,223,208)" />
+      <stop offset="0.5116279069767442" stop-color="rgb(254,229,218)" />
+      <stop offset="0.5129958960328317" stop-color="rgb(255,244,239)" />
+      <stop offset="0.5143638850889193" stop-color="rgb(251,121,90)" />
+      <stop offset="0.5157318741450069" stop-color="rgb(233,57,45)" />
+      <stop offset="0.5170998632010944" stop-color="rgb(241,73,53)" />
+      <stop offset="0.518467852257182" stop-color="rgb(245,86,62)" />
+      <stop offset="0.5198358413132695" stop-color="rgb(255,238,230)" />
+      <stop offset="0.521203830369357" stop-color="rgb(217,39,35)" />
+      <stop offset="0.5225718194254446" stop-color="rgb(251,121,90)" />
+      <stop offset="0.5239398084815321" stop-color="rgb(254,231,220)" />
+      <stop offset="0.5253077975376197" stop-color="rgb(254,224,210)" />
+      <stop offset="0.5266757865937073" stop-color="rgb(253,198,176)" />
+      <stop offset="0.5280437756497948" stop-color="rgb(217,39,35)" />
+      <stop offset="0.5294117647058824" stop-color="rgb(237,65,49)" />
+      <stop offset="0.53077975376197" stop-color="rgb(205,30,31)" />
+      <stop offset="0.5321477428180574" stop-color="rgb(254,231,220)" />
+      <stop offset="0.533515731874145" stop-color="rgb(246,89,64)" />
+      <stop offset="0.5348837209302325" stop-color="rgb(243,78,56)" />
+      <stop offset="0.5362517099863201" stop-color="rgb(252,139,108)" />
+      <stop offset="0.5376196990424077" stop-color="rgb(251,118,87)" />
+      <stop offset="0.5389876880984952" stop-color="rgb(252,159,129)" />
+      <stop offset="0.5403556771545828" stop-color="rgb(252,182,156)" />
+      <stop offset="0.5417236662106704" stop-color="rgb(231,55,43)" />
+      <stop offset="0.5430916552667578" stop-color="rgb(252,138,106)" />
+      <stop offset="0.5444596443228454" stop-color="rgb(147,11,19)" />
+      <stop offset="0.5458276333789329" stop-color="rgb(252,191,167)" />
+      <stop offset="0.5471956224350205" stop-color="rgb(252,191,167)" />
+      <stop offset="0.5485636114911081" stop-color="rgb(254,228,217)" />
+      <stop offset="0.5499886000911993" stop-color="rgb(252,185,160)" />
+      <stop offset="0.5513565891472868" stop-color="rgb(252,148,117)" />
+      <stop offset="0.5527245782033744" stop-color="rgb(252,181,155)" />
+      <stop offset="0.5540925672594619" stop-color="rgb(252,159,129)" />
+      <stop offset="0.5554605563155495" stop-color="rgb(252,172,144)" />
+      <stop offset="0.5568285453716371" stop-color="rgb(254,219,204)" />
+      <stop offset="0.5581965344277245" stop-color="rgb(254,221,207)" />
+      <stop offset="0.5595645234838121" stop-color="rgb(252,179,153)" />
+      <stop offset="0.5609325125398997" stop-color="rgb(252,135,103)" />
+      <stop offset="0.5623005015959872" stop-color="rgb(252,168,139)" />
+      <stop offset="0.5636684906520748" stop-color="rgb(252,182,156)" />
+      <stop offset="0.5650364797081623" stop-color="rgb(254,220,206)" />
+      <stop offset="0.5664044687642499" stop-color="rgb(252,178,151)" />
+      <stop offset="0.5677724578203375" stop-color="rgb(253,198,176)" />
+      <stop offset="0.569140446876425" stop-color="rgb(254,218,203)" />
+      <stop offset="0.5705084359325125" stop-color="rgb(252,141,109)" />
+      <stop offset="0.5718764249886001" stop-color="rgb(252,175,148)" />
+      <stop offset="0.5732444140446876" stop-color="rgb(253,203,183)" />
+      <stop offset="0.5746124031007752" stop-color="rgb(253,203,183)" />
+      <stop offset="0.5759803921568627" stop-color="rgb(253,206,186)" />
+      <stop offset="0.5773483812129503" stop-color="rgb(253,209,190)" />
+      <stop offset="0.5787163702690379" stop-color="rgb(252,172,144)" />
+      <stop offset="0.5800843593251254" stop-color="rgb(252,165,136)" />
+      <stop offset="0.581452348381213" stop-color="rgb(228,50,41)" />
+      <stop offset="0.5828203374373006" stop-color="rgb(253,206,186)" />
+      <stop offset="0.584188326493388" stop-color="rgb(253,198,176)" />
+      <stop offset="0.5855563155494756" stop-color="rgb(250,107,78)" />
+      <stop offset="0.5869243046055631" stop-color="rgb(249,101,72)" />
+      <stop offset="0.5882922936616507" stop-color="rgb(252,138,106)" />
+      <stop offset="0.5896602827177383" stop-color="rgb(251,117,86)" />
+      <stop offset="0.5910282717738258" stop-color="rgb(252,151,121)" />
+      <stop offset="0.5923962608299134" stop-color="rgb(252,141,109)" />
+      <stop offset="0.593764249886001" stop-color="rgb(252,156,126)" />
+      <stop offset="0.5951322389420884" stop-color="rgb(252,165,136)" />
+      <stop offset="0.596500227998176" stop-color="rgb(252,185,160)" />
+      <stop offset="0.5978682170542635" stop-color="rgb(253,210,191)" />
+      <stop offset="0.5992362061103511" stop-color="rgb(252,179,153)" />
+      <stop offset="0.6006041951664387" stop-color="rgb(252,185,160)" />
+      <stop offset="0.6019721842225262" stop-color="rgb(254,217,201)" />
+      <stop offset="0.6033401732786138" stop-color="rgb(248,99,71)" />
+      <stop offset="0.6047081623347014" stop-color="rgb(252,172,144)" />
+      <stop offset="0.6060761513907889" stop-color="rgb(252,157,127)" />
+      <stop offset="0.6074441404468764" stop-color="rgb(252,184,158)" />
+      <stop offset="0.6088121295029639" stop-color="rgb(249,102,74)" />
+      <stop offset="0.6101801185590515" stop-color="rgb(248,96,69)" />
+      <stop offset="0.6115481076151391" stop-color="rgb(252,162,132)" />
+      <stop offset="0.6129160966712266" stop-color="rgb(235,60,46)" />
+      <stop offset="0.6142840857273142" stop-color="rgb(252,160,131)" />
+      <stop offset="0.6156520747834018" stop-color="rgb(252,166,137)" />
+      <stop offset="0.6170200638394893" stop-color="rgb(252,162,132)" />
+      <stop offset="0.6183880528955769" stop-color="rgb(252,163,134)" />
+      <stop offset="0.6197560419516643" stop-color="rgb(252,159,129)" />
+      <stop offset="0.6211240310077519" stop-color="rgb(253,201,179)" />
+      <stop offset="0.6224920200638395" stop-color="rgb(255,237,229)" />
+      <stop offset="0.623860009119927" stop-color="rgb(252,165,136)" />
+      <stop offset="0.6252279981760146" stop-color="rgb(253,206,186)" />
+      <stop offset="0.6265959872321022" stop-color="rgb(253,201,179)" />
+      <stop offset="0.6279639762881897" stop-color="rgb(252,178,151)" />
+      <stop offset="0.6293319653442773" stop-color="rgb(252,144,113)" />
+      <stop offset="0.6306999544003647" stop-color="rgb(251,121,90)" />
+      <stop offset="0.6320679434564523" stop-color="rgb(252,135,103)" />
+      <stop offset="0.6334359325125399" stop-color="rgb(184,20,25)" />
+      <stop offset="0.6348039215686274" stop-color="rgb(248,96,69)" />
+      <stop offset="0.636171910624715" stop-color="rgb(247,94,68)" />
+      <stop offset="0.6375398996808026" stop-color="rgb(251,129,97)" />
+      <stop offset="0.6389078887368901" stop-color="rgb(244,81,59)" />
+      <stop offset="0.6402758777929776" stop-color="rgb(252,135,103)" />
+      <stop offset="0.6416438668490652" stop-color="rgb(251,118,87)" />
+      <stop offset="0.6430118559051528" stop-color="rgb(250,110,80)" />
+      <stop offset="0.6443798449612403" stop-color="rgb(252,179,153)" />
+      <stop offset="0.6457478340173278" stop-color="rgb(253,194,171)" />
+      <stop offset="0.6471158230734154" stop-color="rgb(252,145,114)" />
+      <stop offset="0.648483812129503" stop-color="rgb(251,121,90)" />
+      <stop offset="0.6498518011855904" stop-color="rgb(253,201,179)" />
+      <stop offset="0.6512197902416781" stop-color="rgb(252,172,144)" />
+      <stop offset="0.6525877792977656" stop-color="rgb(252,165,136)" />
+      <stop offset="0.6539557683538532" stop-color="rgb(253,215,198)" />
+      <stop offset="0.6553237574099406" stop-color="rgb(254,223,208)" />
+      <stop offset="0.6566917464660282" stop-color="rgb(252,178,151)" />
+      <stop offset="0.6580597355221158" stop-color="rgb(252,188,164)" />
+      <stop offset="0.6594277245782034" stop-color="rgb(253,210,191)" />
+      <stop offset="0.660795713634291" stop-color="rgb(250,114,83)" />
+      <stop offset="0.6621637026903785" stop-color="rgb(251,117,86)" />
+      <stop offset="0.663531691746466" stop-color="rgb(252,159,129)" />
+      <stop offset="0.6648996808025536" stop-color="rgb(252,168,139)" />
+      <stop offset="0.6662676698586413" stop-color="rgb(254,225,211)" />
+      <stop offset="0.6676356589147286" stop-color="rgb(252,166,137)" />
+      <stop offset="0.6690036479708162" stop-color="rgb(250,107,78)" />
+      <stop offset="0.6703716370269038" stop-color="rgb(251,117,86)" />
+      <stop offset="0.6717396260829913" stop-color="rgb(252,156,126)" />
+      <stop offset="0.6731076151390789" stop-color="rgb(252,138,106)" />
+      <stop offset="0.6744756041951664" stop-color="rgb(252,154,124)" />
+      <stop offset="0.6758435932512541" stop-color="rgb(253,201,179)" />
+      <stop offset="0.6772115823073416" stop-color="rgb(252,159,129)" />
+      <stop offset="0.6785795713634291" stop-color="rgb(252,169,141)" />
+      <stop offset="0.6799475604195167" stop-color="rgb(235,60,46)" />
+      <stop offset="0.6813155494756044" stop-color="rgb(253,212,195)" />
+      <stop offset="0.6826835385316917" stop-color="rgb(253,192,169)" />
+      <stop offset="0.6840515275877793" stop-color="rgb(253,198,176)" />
+      <stop offset="0.6854195166438669" stop-color="rgb(252,154,124)" />
+      <stop offset="0.6867875056999544" stop-color="rgb(251,127,96)" />
+      <stop offset="0.688155494756042" stop-color="rgb(252,156,126)" />
+      <stop offset="0.6895234838121295" stop-color="rgb(252,188,164)" />
+      <stop offset="0.690891472868217" stop-color="rgb(254,225,211)" />
+      <stop offset="0.6922594619243047" stop-color="rgb(252,148,117)" />
+      <stop offset="0.6936274509803921" stop-color="rgb(253,201,179)" />
+      <stop offset="0.6949954400364797" stop-color="rgb(252,185,160)" />
+      <stop offset="0.6963634290925672" stop-color="rgb(249,102,74)" />
+      <stop offset="0.6977314181486548" stop-color="rgb(251,120,89)" />
+      <stop offset="0.6990994072047424" stop-color="rgb(252,148,117)" />
+      <stop offset="0.7004673962608298" stop-color="rgb(254,223,208)" />
+      <stop offset="0.7018353853169175" stop-color="rgb(250,115,84)" />
+      <stop offset="0.7032033743730051" stop-color="rgb(252,162,132)" />
+      <stop offset="0.7045713634290925" stop-color="rgb(252,160,131)" />
+      <stop offset="0.70593935248518" stop-color="rgb(254,226,213)" />
+      <stop offset="0.7073073415412676" stop-color="rgb(254,233,223)" />
+      <stop offset="0.7086753305973552" stop-color="rgb(251,121,90)" />
+      <stop offset="0.7100433196534428" stop-color="rgb(217,39,35)" />
+      <stop offset="0.7114113087095304" stop-color="rgb(249,104,75)" />
+      <stop offset="0.7127792977656179" stop-color="rgb(231,55,43)" />
+      <stop offset="0.7141472868217055" stop-color="rgb(254,216,199)" />
+      <stop offset="0.715515275877793" stop-color="rgb(252,185,160)" />
+      <stop offset="0.7168832649338807" stop-color="rgb(212,35,33)" />
+      <stop offset="0.718251253989968" stop-color="rgb(208,32,32)" />
+      <stop offset="0.7196192430460556" stop-color="rgb(252,175,148)" />
+      <stop offset="0.7209872321021432" stop-color="rgb(253,211,193)" />
+      <stop offset="0.7222982216142271" stop-color="rgb(252,135,103)" />
+      <stop offset="0.7236662106703148" stop-color="rgb(255,235,226)" />
+      <stop offset="0.7250341997264022" stop-color="rgb(255,240,232)" />
+      <stop offset="0.7264021887824897" stop-color="rgb(255,245,240)" />
+      <stop offset="0.7277701778385773" stop-color="rgb(255,243,238)" />
+      <stop offset="0.7291381668946648" stop-color="rgb(252,135,103)" />
+      <stop offset="0.7305061559507524" stop-color="rgb(253,210,191)" />
+      <stop offset="0.7318741450068399" stop-color="rgb(252,184,158)" />
+      <stop offset="0.7332421340629274" stop-color="rgb(254,225,211)" />
+      <stop offset="0.7346101231190151" stop-color="rgb(252,168,139)" />
+      <stop offset="0.7359781121751026" stop-color="rgb(254,223,208)" />
+      <stop offset="0.7373461012311902" stop-color="rgb(252,157,127)" />
+      <stop offset="0.7387140902872776" stop-color="rgb(252,135,103)" />
+      <stop offset="0.7400820793433652" stop-color="rgb(253,198,176)" />
+      <stop offset="0.7414500683994528" stop-color="rgb(251,127,96)" />
+      <stop offset="0.7428180574555402" stop-color="rgb(253,203,183)" />
+      <stop offset="0.7441860465116279" stop-color="rgb(255,235,225)" />
+      <stop offset="0.7455540355677155" stop-color="rgb(254,218,203)" />
+      <stop offset="0.746922024623803" stop-color="rgb(253,202,181)" />
+      <stop offset="0.7482900136798905" stop-color="rgb(252,132,100)" />
+      <stop offset="0.7496580027359783" stop-color="rgb(252,188,164)" />
+      <stop offset="0.7510259917920656" stop-color="rgb(252,172,144)" />
+      <stop offset="0.7523939808481532" stop-color="rgb(252,188,164)" />
+      <stop offset="0.7537619699042408" stop-color="rgb(252,159,129)" />
+      <stop offset="0.7551299589603283" stop-color="rgb(252,168,139)" />
+      <stop offset="0.7564979480164159" stop-color="rgb(252,163,134)" />
+      <stop offset="0.7578659370725034" stop-color="rgb(251,123,91)" />
+      <stop offset="0.7592339261285911" stop-color="rgb(249,101,72)" />
+      <stop offset="0.7606019151846786" stop-color="rgb(250,107,78)" />
+      <stop offset="0.761969904240766" stop-color="rgb(252,184,158)" />
+      <stop offset="0.7633378932968536" stop-color="rgb(253,197,174)" />
+      <stop offset="0.7647058823529411" stop-color="rgb(252,185,160)" />
+      <stop offset="0.7660738714090287" stop-color="rgb(252,157,127)" />
+      <stop offset="0.7674418604651163" stop-color="rgb(252,187,162)" />
+      <stop offset="0.7688098495212039" stop-color="rgb(254,218,203)" />
+      <stop offset="0.7701778385772914" stop-color="rgb(254,217,201)" />
+      <stop offset="0.771545827633379" stop-color="rgb(255,235,225)" />
+      <stop offset="0.7729138166894665" stop-color="rgb(253,212,195)" />
+      <stop offset="0.7742818057455539" stop-color="rgb(253,207,188)" />
+      <stop offset="0.7756497948016415" stop-color="rgb(252,157,127)" />
+      <stop offset="0.7770177838577291" stop-color="rgb(252,133,102)" />
+      <stop offset="0.7783857729138167" stop-color="rgb(252,162,132)" />
+      <stop offset="0.7797537619699042" stop-color="rgb(252,188,164)" />
+      <stop offset="0.7811217510259918" stop-color="rgb(254,220,206)" />
+      <stop offset="0.7824897400820794" stop-color="rgb(254,233,223)" />
+      <stop offset="0.7838577291381668" stop-color="rgb(253,197,174)" />
+      <stop offset="0.7852257181942545" stop-color="rgb(252,139,108)" />
+      <stop offset="0.786593707250342" stop-color="rgb(252,184,158)" />
+      <stop offset="0.7879616963064295" stop-color="rgb(253,192,169)" />
+      <stop offset="0.789329685362517" stop-color="rgb(252,191,167)" />
+      <stop offset="0.7906976744186046" stop-color="rgb(252,169,141)" />
+      <stop offset="0.7920656634746922" stop-color="rgb(252,188,164)" />
+      <stop offset="0.7934336525307798" stop-color="rgb(252,153,122)" />
+      <stop offset="0.7948016415868673" stop-color="rgb(252,169,141)" />
+      <stop offset="0.7961696306429549" stop-color="rgb(252,141,109)" />
+      <stop offset="0.7975376196990424" stop-color="rgb(187,21,26)" />
+      <stop offset="0.7989056087551298" stop-color="rgb(247,93,66)" />
+      <stop offset="0.8002735978112177" stop-color="rgb(250,115,84)" />
+      <stop offset="0.801641586867305" stop-color="rgb(253,206,186)" />
+      <stop offset="0.8030095759233926" stop-color="rgb(249,104,75)" />
+      <stop offset="0.8043775649794802" stop-color="rgb(252,185,160)" />
+      <stop offset="0.8057455540355677" stop-color="rgb(253,209,190)" />
+      <stop offset="0.8071135430916553" stop-color="rgb(252,181,155)" />
+      <stop offset="0.8084815321477428" stop-color="rgb(253,215,198)" />
+      <stop offset="0.8098495212038305" stop-color="rgb(252,168,139)" />
+      <stop offset="0.811217510259918" stop-color="rgb(254,223,208)" />
+      <stop offset="0.8125854993160054" stop-color="rgb(253,210,191)" />
+      <stop offset="0.813953488372093" stop-color="rgb(252,171,143)" />
+      <stop offset="0.8153214774281807" stop-color="rgb(252,175,148)" />
+      <stop offset="0.8166894664842681" stop-color="rgb(252,191,167)" />
+      <stop offset="0.8180574555403557" stop-color="rgb(252,182,156)" />
+      <stop offset="0.8194254445964433" stop-color="rgb(253,201,179)" />
+      <stop offset="0.8207934336525308" stop-color="rgb(253,210,191)" />
+      <stop offset="0.8221614227086184" stop-color="rgb(252,185,160)" />
+      <stop offset="0.8235294117647058" stop-color="rgb(253,194,171)" />
+      <stop offset="0.8248974008207935" stop-color="rgb(253,202,181)" />
+      <stop offset="0.826265389876881" stop-color="rgb(254,226,213)" />
+      <stop offset="0.8276333789329685" stop-color="rgb(254,217,201)" />
+      <stop offset="0.8290013679890561" stop-color="rgb(253,201,179)" />
+      <stop offset="0.8303693570451436" stop-color="rgb(253,205,185)" />
+      <stop offset="0.8317373461012312" stop-color="rgb(253,203,183)" />
+      <stop offset="0.8331053351573188" stop-color="rgb(252,181,155)" />
+      <stop offset="0.8344733242134061" stop-color="rgb(253,205,185)" />
+      <stop offset="0.8358413132694938" stop-color="rgb(253,192,169)" />
+      <stop offset="0.8372093023255814" stop-color="rgb(254,231,220)" />
+      <stop offset="0.8385772913816689" stop-color="rgb(253,203,183)" />
+      <stop offset="0.8399452804377564" stop-color="rgb(252,175,148)" />
+      <stop offset="0.841313269493844" stop-color="rgb(252,169,141)" />
+      <stop offset="0.8426812585499316" stop-color="rgb(252,188,164)" />
+      <stop offset="0.8440492476060192" stop-color="rgb(252,150,119)" />
+      <stop offset="0.8454172366621067" stop-color="rgb(246,88,63)" />
+      <stop offset="0.8467852257181943" stop-color="rgb(252,153,122)" />
+      <stop offset="0.8481532147742818" stop-color="rgb(252,145,114)" />
+      <stop offset="0.8495212038303692" stop-color="rgb(252,153,122)" />
+      <stop offset="0.850889192886457" stop-color="rgb(253,201,179)" />
+      <stop offset="0.8522571819425444" stop-color="rgb(252,171,143)" />
+      <stop offset="0.853625170998632" stop-color="rgb(244,81,59)" />
+      <stop offset="0.8549931600547196" stop-color="rgb(252,178,151)" />
+      <stop offset="0.8563611491108071" stop-color="rgb(254,228,215)" />
+      <stop offset="0.8577291381668947" stop-color="rgb(254,223,208)" />
+      <stop offset="0.8590971272229823" stop-color="rgb(252,191,167)" />
+      <stop offset="0.8604651162790699" stop-color="rgb(252,190,165)" />
+      <stop offset="0.8618331053351573" stop-color="rgb(253,209,190)" />
+      <stop offset="0.8632010943912448" stop-color="rgb(253,210,191)" />
+      <stop offset="0.8645690834473324" stop-color="rgb(253,201,179)" />
+      <stop offset="0.8659370725034201" stop-color="rgb(252,181,155)" />
+      <stop offset="0.8673050615595075" stop-color="rgb(252,159,129)" />
+      <stop offset="0.8686730506155951" stop-color="rgb(252,156,126)" />
+      <stop offset="0.8700410396716827" stop-color="rgb(253,215,198)" />
+      <stop offset="0.8714090287277702" stop-color="rgb(253,207,188)" />
+      <stop offset="0.8727770177838577" stop-color="rgb(253,201,179)" />
+      <stop offset="0.8741450068399452" stop-color="rgb(253,206,186)" />
+      <stop offset="0.8755129958960327" stop-color="rgb(254,219,204)" />
+      <stop offset="0.8768809849521204" stop-color="rgb(252,175,148)" />
+      <stop offset="0.8782489740082079" stop-color="rgb(253,215,198)" />
+      <stop offset="0.8796169630642955" stop-color="rgb(253,198,176)" />
+      <stop offset="0.880984952120383" stop-color="rgb(253,198,176)" />
+      <stop offset="0.8823529411764706" stop-color="rgb(253,192,169)" />
+      <stop offset="0.8837209302325582" stop-color="rgb(254,221,207)" />
+      <stop offset="0.8850889192886455" stop-color="rgb(254,231,220)" />
+      <stop offset="0.8864569083447332" stop-color="rgb(252,182,156)" />
+      <stop offset="0.8878248974008208" stop-color="rgb(254,233,223)" />
+      <stop offset="0.8891928864569083" stop-color="rgb(253,215,198)" />
+      <stop offset="0.8905608755129958" stop-color="rgb(254,224,210)" />
+      <stop offset="0.8919288645690835" stop-color="rgb(254,220,206)" />
+      <stop offset="0.893296853625171" stop-color="rgb(254,221,207)" />
+      <stop offset="0.8946648426812586" stop-color="rgb(253,210,191)" />
+      <stop offset="0.896032831737346" stop-color="rgb(254,218,203)" />
+      <stop offset="0.8974008207934336" stop-color="rgb(254,223,208)" />
+      <stop offset="0.8987688098495212" stop-color="rgb(253,195,172)" />
+      <stop offset="0.9001367989056086" stop-color="rgb(253,202,181)" />
+      <stop offset="0.9015047879616964" stop-color="rgb(253,195,172)" />
+      <stop offset="0.9028727770177839" stop-color="rgb(252,188,164)" />
+      <stop offset="0.9042407660738714" stop-color="rgb(254,225,211)" />
+      <stop offset="0.905608755129959" stop-color="rgb(253,212,195)" />
+      <stop offset="0.9069767441860465" stop-color="rgb(255,240,233)" />
+      <stop offset="0.908344733242134" stop-color="rgb(253,215,198)" />
+      <stop offset="0.9097127222982216" stop-color="rgb(253,210,191)" />
+      <stop offset="0.9110807113543092" stop-color="rgb(253,195,172)" />
+      <stop offset="0.9124487004103967" stop-color="rgb(252,191,167)" />
+      <stop offset="0.9138166894664843" stop-color="rgb(253,201,179)" />
+      <stop offset="0.9151846785225718" stop-color="rgb(253,210,191)" />
+      <stop offset="0.9165526675786595" stop-color="rgb(254,229,218)" />
+      <stop offset="0.9179206566347469" stop-color="rgb(254,223,208)" />
+      <stop offset="0.9192886456908345" stop-color="rgb(254,231,220)" />
+      <stop offset="0.920656634746922" stop-color="rgb(253,201,179)" />
+      <stop offset="0.9220246238030095" stop-color="rgb(254,226,213)" />
+      <stop offset="0.9233926128590971" stop-color="rgb(253,203,183)" />
+      <stop offset="0.9247606019151847" stop-color="rgb(253,195,172)" />
+      <stop offset="0.9261285909712723" stop-color="rgb(253,194,171)" />
+      <stop offset="0.9274965800273598" stop-color="rgb(252,175,148)" />
+      <stop offset="0.9288645690834473" stop-color="rgb(253,212,195)" />
+      <stop offset="0.9302325581395349" stop-color="rgb(254,231,220)" />
+      <stop offset="0.9316005471956224" stop-color="rgb(254,223,208)" />
+      <stop offset="0.93296853625171" stop-color="rgb(254,224,210)" />
+      <stop offset="0.9343365253077975" stop-color="rgb(253,210,191)" />
+      <stop offset="0.9357045143638851" stop-color="rgb(254,231,220)" />
+      <stop offset="0.9370725034199726" stop-color="rgb(255,239,231)" />
+      <stop offset="0.9384404924760602" stop-color="rgb(253,210,191)" />
+      <stop offset="0.9398084815321477" stop-color="rgb(254,223,208)" />
+      <stop offset="0.9411764705882352" stop-color="rgb(254,218,203)" />
+      <stop offset="0.9425444596443229" stop-color="rgb(253,215,198)" />
+      <stop offset="0.9439124487004104" stop-color="rgb(254,233,223)" />
+      <stop offset="0.945280437756498" stop-color="rgb(253,205,185)" />
+      <stop offset="0.9466484268125854" stop-color="rgb(255,243,238)" />
+      <stop offset="0.948016415868673" stop-color="rgb(252,188,164)" />
+      <stop offset="0.9493844049247606" stop-color="rgb(254,228,215)" />
+      <stop offset="0.950752393980848" stop-color="rgb(252,181,155)" />
+      <stop offset="0.9521203830369358" stop-color="rgb(253,198,176)" />
+      <stop offset="0.9534883720930233" stop-color="rgb(252,187,162)" />
+      <stop offset="0.9548563611491108" stop-color="rgb(252,159,129)" />
+      <stop offset="0.9562243502051984" stop-color="rgb(252,174,146)" />
+      <stop offset="0.9575923392612861" stop-color="rgb(254,223,208)" />
+      <stop offset="0.9589603283173734" stop-color="rgb(254,217,201)" />
+      <stop offset="0.960328317373461" stop-color="rgb(255,235,226)" />
+      <stop offset="0.9616963064295486" stop-color="rgb(254,219,204)" />
+      <stop offset="0.9630642954856361" stop-color="rgb(254,223,208)" />
+      <stop offset="0.9644322845417237" stop-color="rgb(254,230,219)" />
+      <stop offset="0.9658002735978112" stop-color="rgb(255,237,229)" />
+      <stop offset="0.9671682626538989" stop-color="rgb(252,188,164)" />
+      <stop offset="0.9685362517099864" stop-color="rgb(254,220,206)" />
+      <stop offset="0.9699042407660738" stop-color="rgb(252,172,144)" />
+      <stop offset="0.9712722298221614" stop-color="rgb(252,188,164)" />
+      <stop offset="0.9726402188782489" stop-color="rgb(253,212,195)" />
+      <stop offset="0.9740082079343365" stop-color="rgb(254,220,206)" />
+      <stop offset="0.9753761969904241" stop-color="rgb(253,210,191)" />
+      <stop offset="0.9767441860465115" stop-color="rgb(254,220,206)" />
+      <stop offset="0.9781121751025992" stop-color="rgb(252,190,165)" />
+      <stop offset="0.9794801641586868" stop-color="rgb(253,207,188)" />
+      <stop offset="0.9808481532147743" stop-color="rgb(254,217,201)" />
+      <stop offset="0.9822161422708617" stop-color="rgb(252,188,164)" />
+      <stop offset="0.9835841313269493" stop-color="rgb(254,224,210)" />
+      <stop offset="0.9849521203830369" stop-color="rgb(252,172,144)" />
+      <stop offset="0.9863201094391245" stop-color="rgb(252,162,132)" />
+      <stop offset="0.987688098495212" stop-color="rgb(252,172,144)" />
+      <stop offset="0.9890560875512996" stop-color="rgb(252,181,155)" />
+      <stop offset="0.9904240766073872" stop-color="rgb(254,223,208)" />
+      <stop offset="0.9917920656634746" stop-color="rgb(254,218,203)" />
+      <stop offset="0.9931600547195623" stop-color="rgb(255,240,232)" />
+      <stop offset="0.9945280437756497" stop-color="rgb(254,231,220)" />
+      <stop offset="0.9958960328317373" stop-color="rgb(253,202,181)" />
+      <stop offset="0.9972640218878248" stop-color="rgb(255,235,226)" />
+      <stop offset="0.9986320109439124" stop-color="rgb(238,67,50)" />
+      <stop offset="1" stop-color="rgb(123,5,16)" />
+    </linearGradient>
+  </defs>
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-16" fill="none" transform="matrix(1,0,0,1,0,0)" class="view">
+        <g transform="matrix(1,0,0,1,0,0)">
+          <path
+            id="g-svg-17"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 640,0 l 0,900 l-640 0 z"
+            width="640"
+            height="900"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,16,16)">
+          <path
+            id="g-svg-18"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 608,0 l 0,868 l-608 0 z"
+            width="608"
+            height="868"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,107.160004,16)">
+          <path
+            id="g-svg-19"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 516.8399998699315,0 l 0,802 l-516.8399998699315 0 z"
+            width="516.8399998699315"
+            height="802"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,107.160004,16)">
+          <path
+            id="g-svg-20"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 516.8399998699315,0 l 0,802 l-516.8399998699315 0 z"
+            width="516.8399998699315"
+            height="802"
+          />
+        </g>
+        <g
+          id="g-svg-21"
+          fill="none"
+          transform="matrix(1,0,0,1,0,0)"
+          class="component"
+        >
+          <g
+            id="g-svg-23"
+            fill="none"
+            class="axis"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <g
+              id="g-svg-24"
+              fill="none"
+              transform="matrix(1,0,0,1,0,0)"
+              class="axis-grid-group"
+            >
+              <g
+                id="g-svg-25"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-grid"
+              >
+                <g
+                  id="g-svg-26"
+                  fill="none"
+                  transform="matrix(1,0,0,1,0,0)"
+                  class="grid-line-group"
+                >
+                  <g transform="matrix(1,0,0,1,107.160004,116.250000)">
+                    <path
+                      id="g-svg-28"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,107.160004,214.991455)">
+                    <path
+                      id="g-svg-29"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,107.160004,314.830017)">
+                    <path
+                      id="g-svg-30"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,107.160004,415.765747)">
+                    <path
+                      id="g-svg-31"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,107.160004,516.701416)">
+                    <path
+                      id="g-svg-32"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,107.160004,616.540039)">
+                    <path
+                      id="g-svg-33"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,107.160004,716.378601)">
+                    <path
+                      id="g-svg-34"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,107.160004,817.314270)">
+                    <path
+                      id="g-svg-35"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,0 L 516.8399998699315,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-27"
+                  fill="none"
+                  transform="matrix(1,0,0,1,0,0)"
+                  class="grid-region-group"
+                />
+              </g>
+            </g>
+            <g
+              id="g-svg-36"
+              fill="none"
+              transform="matrix(1,0,0,1,0,0)"
+              class="axis-main-group"
+            >
+              <g
+                id="g-svg-37"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,107.160004,16)">
+                  <line
+                    id="g-svg-38"
+                    fill="none"
+                    x1="0"
+                    y1="802"
+                    x2="0"
+                    y2="0"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-39"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-40"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,116.250000)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-48"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-41"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,214.991455)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-49"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-42"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,314.830017)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-50"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-43"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,415.765747)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-51"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-44"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,516.701416)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-52"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-45"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,616.540039)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-53"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-46"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,716.378601)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-54"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-47"
+                  fill="none"
+                  transform="matrix(1,0,0,1,107.160004,817.314270)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-55"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-56"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-57"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,116.250000)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-65"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      2011
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-58"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,214.991455)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-66"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      April
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-59"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,314.830017)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-67"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      July
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-60"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,415.765747)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-68"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      October
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-61"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,516.701416)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-69"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      2012
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-62"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,616.540039)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-70"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      April
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-63"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,716.378601)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-71"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      July
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-64"
+                  fill="none"
+                  transform="matrix(1,0,0,1,99.160004,817.314270)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-72"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      class="axis-label-item"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      October
+                    </text>
+                  </g>
+                </g>
+              </g>
+            </g>
+            <g
+              id="g-svg-73"
+              fill="none"
+              transform="matrix(1,0,0,1,17.000004,422.407135)"
+              class="axis-title-group"
+            >
+              <g transform="matrix(0,-1,1,0,11.500000,0)">
+                <text
+                  id="g-svg-74"
+                  fill="rgba(29,33,41,1)"
+                  dominant-baseline="central"
+                  paint-order="stroke"
+                  dx="0.5"
+                  font-family="sans-serif"
+                  font-size="12"
+                  font-style="normal"
+                  font-variant="normal"
+                  font-weight="normal"
+                  stroke-width="1"
+                  text-anchor="middle"
+                  class="axis-title"
+                  opacity="0.9"
+                >
+                  date
+                </text>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+          id="g-svg-22"
+          fill="none"
+          transform="matrix(1,0,0,1,0,0)"
+          class="component"
+        >
+          <g
+            id="g-svg-76"
+            fill="none"
+            class="axis"
+            transform="matrix(1,0,0,1,0,0)"
+          >
+            <g
+              id="g-svg-77"
+              fill="none"
+              transform="matrix(1,0,0,1,0,0)"
+              class="axis-grid-group"
+            >
+              <g
+                id="g-svg-78"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-grid"
+              >
+                <g
+                  id="g-svg-79"
+                  fill="none"
+                  transform="matrix(1,0,0,1,0,0)"
+                  class="grid-line-group"
+                >
+                  <g transform="matrix(1,0,0,1,137.155182,16)">
+                    <path
+                      id="g-svg-81"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,802 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,252.521255,16)">
+                    <path
+                      id="g-svg-82"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,802 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,367.887329,16)">
+                    <path
+                      id="g-svg-83"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,802 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,483.253387,16)">
+                    <path
+                      id="g-svg-84"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,802 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                  <g transform="matrix(1,0,0,1,598.619446,16)">
+                    <path
+                      id="g-svg-85"
+                      fill="none"
+                      class="grid-line"
+                      stroke="rgba(29,33,41,1)"
+                      stroke-width="0.5"
+                      stroke-dasharray="3,4"
+                      d="M 0,802 L 0,0"
+                      stroke-opacity="0.1"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-80"
+                  fill="none"
+                  transform="matrix(1,0,0,1,0,0)"
+                  class="grid-region-group"
+                />
+              </g>
+            </g>
+            <g
+              id="g-svg-86"
+              fill="none"
+              transform="matrix(1,0,0,1,0,0)"
+              class="axis-main-group"
+            >
+              <g
+                id="g-svg-87"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,107.160004,818)">
+                  <line
+                    id="g-svg-88"
+                    fill="none"
+                    x1="0"
+                    y1="0"
+                    x2="516.8399998699315"
+                    y2="0"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-89"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-90"
+                  fill="none"
+                  transform="matrix(1,0,0,1,137.155182,818)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-95"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-91"
+                  fill="none"
+                  transform="matrix(1,0,0,1,252.521255,818)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-96"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-92"
+                  fill="none"
+                  transform="matrix(1,0,0,1,367.887329,818)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-97"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-93"
+                  fill="none"
+                  transform="matrix(1,0,0,1,483.253387,818)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-98"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-94"
+                  fill="none"
+                  transform="matrix(1,0,0,1,598.619446,818)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-99"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-100"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-101"
+                  fill="none"
+                  transform="matrix(1,0,0,1,137.155182,826)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-106"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      40
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-102"
+                  fill="none"
+                  transform="matrix(1,0,0,1,252.521255,826)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-107"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      50
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-103"
+                  fill="none"
+                  transform="matrix(1,0,0,1,367.887329,826)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-108"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      60
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-104"
+                  fill="none"
+                  transform="matrix(1,0,0,1,483.253387,826)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-109"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      70
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-105"
+                  fill="none"
+                  transform="matrix(1,0,0,1,598.619446,826)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-110"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                      visibility="visible"
+                    >
+                      80
+                    </text>
+                  </g>
+                </g>
+              </g>
+            </g>
+            <g
+              id="g-svg-111"
+              fill="none"
+              transform="matrix(1,0,0,1,365.580017,884)"
+              class="axis-title-group"
+            >
+              <g transform="matrix(1,0,0,1,0,0)">
+                <text
+                  id="g-svg-112"
+                  fill="rgba(29,33,41,1)"
+                  dominant-baseline="central"
+                  paint-order="stroke"
+                  dx="0.5"
+                  font-family="sans-serif"
+                  font-size="12"
+                  font-style="normal"
+                  font-variant="normal"
+                  font-weight="normal"
+                  stroke-width="1"
+                  text-anchor="middle"
+                  class="axis-title"
+                  dy="-11.5px"
+                  opacity="0.9"
+                >
+                  low, high
+                </text>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g transform="matrix(1,0,0,1,107.160004,16)">
+          <path
+            id="g-svg-114"
+            fill="rgba(0,0,0,0)"
+            class="plot"
+            d="M 0,0 l 516.8399998699315,0 l 0,802 l-516.8399998699315 0 z"
+            width="516.8399998699315"
+            height="802"
+          />
+          <g
+            id="g-svg-115"
+            fill="none"
+            transform="matrix(1,0,0,1,0,0)"
+            class="main-layer"
+          >
+            <g transform="matrix(1,0,0,1,10.383000,0)">
+              <path
+                id="g-svg-117"
+                fill="url(#g-pattern-0)"
+                d="M 215.73399999999998,0 L 194.969,0 L 194.969,1.097 L 174.203,1.097 L 174.203,2.194 L 181.702,2.194 L 181.702,3.291 L 177.664,3.291 L 177.664,4.389 L 176.51,4.389 L 176.51,5.486 L 180.548,5.486 L 180.548,6.583 L 169.011,6.583 L 169.011,7.68 L 166.12699999999998,7.68 L 166.12699999999998,8.777 L 174.78,8.777 L 174.78,9.874 L 186.893,9.874 L 186.893,10.971 L 213.427,10.971 L 213.427,12.068 L 227.271,12.068 L 227.271,13.166 L 222.07999999999998,13.166 L 222.07999999999998,14.263 L 206.505,14.263 L 206.505,15.36 L 177.664,15.36 L 177.664,16.457 L 160.93599999999998,16.457 L 160.93599999999998,17.554 L 153.43699999999998,17.554 L 153.43699999999998,18.651 L 144.208,18.651 L 144.208,19.748 L 136.13199999999998,19.748 L 136.13199999999998,20.845 L 166.12699999999998,20.845 L 166.12699999999998,21.943 L 188.047,21.943 L 188.047,23.04 L 169.588,23.04 L 169.588,24.137 L 193.238,24.137 L 193.238,25.234 L 205.352,25.234 L 205.352,26.331 L 167.28099999999998,26.331 L 167.28099999999998,27.428 L 141.32299999999998,27.428 L 141.32299999999998,28.525 L 167.28099999999998,28.525 L 167.28099999999998,29.622 L 186.893,29.622 L 186.893,30.72 L 166.70399999999998,30.72 L 166.70399999999998,31.817 L 166.70399999999998,31.817 L 166.70399999999998,32.914 L 177.087,32.914 L 177.087,34.011 L 185.739,34.011 L 185.739,35.108 L 203.62099999999998,35.108 L 203.62099999999998,36.205 L 248.037,36.205 L 248.037,37.302 L 230.155,37.302 L 230.155,38.399 L 177.087,38.399 L 177.087,39.497 L 188.623,39.497 L 188.623,40.594 L 188.623,40.594 L 188.623,41.737 L 136.709,41.737 L 136.709,42.834 L 136.13199999999998,42.834 L 136.13199999999998,43.931 L 163.243,43.931 L 163.243,45.028 L 143.054,45.028 L 143.054,46.125 L 136.709,46.125 L 136.709,47.222 L 179.39399999999998,47.222 L 179.39399999999998,48.319 L 246.883,48.319 L 246.883,49.416 L 239.96099999999998,49.416 L 239.96099999999998,50.514 L 182.855,50.514 L 182.855,51.611 L 139.016,51.611 L 139.016,52.708 L 118.25000000000001,52.708 L 118.25000000000001,53.805 L 98.638,53.805 L 98.638,54.902 L 92.293,54.902 L 92.293,55.999 L 111.905,55.999 L 111.905,57.096 L 125.74900000000001,57.096 L 125.74900000000001,58.193 L 91.71600000000001,58.193 L 91.71600000000001,59.291 L 50.184,59.291 L 50.184,60.388 L 62.298,60.388 L 62.298,61.485 L 89.409,61.485 L 89.409,62.582 L 90.562,62.582 L 90.562,63.679 L 57.10600000000001,63.679 L 57.10600000000001,64.776 L 54.79900000000001,64.776 L 54.79900000000001,65.873 L 74.411,65.873 L 74.411,66.97 L 103.82900000000001,66.97 L 103.82900000000001,68.068 L 125.74900000000001,68.068 L 125.74900000000001,69.165 L 132.094,69.165 L 132.094,70.262 L 150.553,70.262 L 150.553,71.359 L 171.89499999999998,71.359 L 171.89499999999998,72.456 L 155.744,72.456 L 155.744,73.553 L 134.97799999999998,73.553 L 134.97799999999998,74.65 L 154.59,74.65 L 154.59,75.747 L 171.319,75.747 L 171.319,76.845 L 178.24099999999999,76.845 L 178.24099999999999,77.942 L 167.858,77.942 L 167.858,79.039 L 166.12699999999998,79.039 L 166.12699999999998,80.136 L 176.51,80.136 L 176.51,81.233 L 139.016,81.233 L 139.016,82.33 L 80.179,82.33 L 80.179,83.427 L 73.834,83.427 L 73.834,84.525 L 95.177,84.525 L 95.177,85.622 L 127.479,85.622 L 127.479,86.719 L 146.515,86.719 L 146.515,87.816 L 128.05599999999998,87.816 L 128.05599999999998,88.913 L 137.286,88.913 L 137.286,90.01 L 113.059,90.01 L 113.059,91.107 L 81.91000000000001,91.107 L 81.91000000000001,92.204 L 95.754,92.204 L 95.754,93.302 L 112.482,93.302 L 112.482,94.399 L 107.29,94.399 L 107.29,95.496 L 109.021,95.496 L 109.021,96.593 L 125.17200000000001,96.593 L 125.17200000000001,97.69 L 78.449,97.69 L 78.449,98.787 L 43.262,98.787 L 43.262,99.884 L 53.64500000000001,99.884 L 53.64500000000001,100.981 L 62.298,100.981 L 62.298,102.079 L 80.179,102.079 L 80.179,103.176 L 75.565,103.176 L 75.565,104.273 L 66.33500000000001,104.273 L 66.33500000000001,105.37 L 49.031000000000006,105.37 L 49.031000000000006,106.467 L 19.612000000000002,106.467 L 19.612000000000002,107.564 L 21.343,107.564 L 21.343,108.661 L 25.957000000000004,108.661 L 25.957000000000004,109.758 L 23.073000000000004,109.758 L 23.073000000000004,110.856 L 40.378,110.856 L 40.378,111.953 L 79.02600000000001,111.953 L 79.02600000000001,113.05 L 109.021,113.05 L 109.021,114.147 L 134.97799999999998,114.147 L 134.97799999999998,115.244 L 139.593,115.244 L 139.593,116.341 L 112.482,116.341 L 112.482,117.438 L 102.099,117.438 L 102.099,118.535 L 106.137,118.535 L 106.137,119.633 L 127.479,119.633 L 127.479,120.73 L 137.862,120.73 L 137.862,121.827 L 130.94,121.827 L 130.94,122.924 L 142.477,122.924 L 142.477,124.021 L 151.706,124.021 L 151.706,125.118 L 140.17,125.118 L 140.17,126.215 L 126.903,126.215 L 126.903,127.312 L 138.439,127.312 L 138.439,128.41 L 147.66899999999998,128.41 L 147.66899999999998,129.507 L 99.792,129.507 L 99.792,130.604 L 83.06400000000001,130.604 L 83.06400000000001,131.701 L 127.479,131.701 L 127.479,132.798 L 106.714,132.798 L 106.714,133.895 L 80.179,133.895 L 80.179,134.992 L 121.711,134.992 L 121.711,136.089 L 114.212,136.089 L 114.212,137.187 L 72.681,137.187 L 72.681,138.284 L 96.331,138.284 L 96.331,139.381 L 171.319,139.381 L 171.319,140.478 L 185.16199999999998,140.478 L 185.16199999999998,141.575 L 151.706,141.575 L 151.706,142.672 L 139.016,142.672 L 139.016,143.769 L 98.638,143.769 L 98.638,144.867 L 77.872,144.867 L 77.872,145.964 L 103.82900000000001,145.964 L 103.82900000000001,147.061 L 98.638,147.061 L 98.638,148.158 L 91.13900000000001,148.158 L 91.13900000000001,149.255 L 129.78699999999998,149.255 L 129.78699999999998,150.352 L 133.248,150.352 L 133.248,151.449 L 95.754,151.449 L 95.754,152.546 L 59.41300000000001,152.546 L 59.41300000000001,153.644 L 32.30200000000001,153.644 L 32.30200000000001,154.741 L 17.305,154.741 L 17.305,155.838 L 26.534000000000002,155.838 L 26.534000000000002,156.935 L 54.79900000000001,156.935 L 54.79900000000001,158.032 L 59.99000000000001,158.032 L 59.99000000000001,159.129 L 58.837,159.129 L 58.837,160.226 L 70.373,160.226 L 70.373,161.323 L 29.995,161.323 L 29.995,162.421 L 0,162.421 L 0,163.518 L 33.456,163.518 L 33.456,164.615 L 90.562,164.615 L 90.562,165.712 L 121.711,165.712 L 121.711,166.809 L 133.248,166.809 L 133.248,167.906 L 121.711,167.906 L 121.711,169.003 L 102.099,169.003 L 102.099,170.1 L 138.439,170.1 L 138.439,171.198 L 147.66899999999998,171.198 L 147.66899999999998,172.295 L 124.59500000000001,172.295 L 124.59500000000001,173.392 L 121.134,173.392 L 121.134,174.489 L 117.09700000000001,174.489 L 117.09700000000001,175.586 L 98.638,175.586 L 98.638,176.683 L 89.409,176.683 L 89.409,177.78 L 121.711,177.78 L 121.711,178.877 L 156.898,178.877 L 156.898,179.929 L 171.319,179.929 L 171.319,181.026 L 170.165,181.026 L 170.165,182.123 L 122.288,182.123 L 122.288,183.22 L 89.985,183.22 L 89.985,184.317 L 96.331,184.317 L 96.331,185.415 L 106.137,185.415 L 106.137,186.512 L 109.021,186.512 L 109.021,187.609 L 100.36800000000001,187.609 L 100.36800000000001,188.706 L 110.751,188.706 L 110.751,189.803 L 109.021,189.803 L 109.021,190.9 L 99.792,190.9 L 99.792,191.997 L 115.943,191.997 L 115.943,193.094 L 109.598,193.094 L 109.598,194.192 L 89.985,194.192 L 89.985,195.289 L 94.60000000000001,195.289 L 94.60000000000001,196.386 L 124.59500000000001,196.386 L 124.59500000000001,197.483 L 177.087,197.483 L 177.087,198.58 L 211.697,198.58 L 211.697,199.677 L 196.12199999999999,199.677 L 196.12199999999999,200.774 L 129.78699999999998,200.774 L 129.78699999999998,201.871 L 108.444,201.871 L 108.444,202.969 L 138.439,202.969 L 138.439,204.066 L 128.63299999999998,204.066 L 128.63299999999998,205.163 L 98.638,205.163 L 98.638,206.26 L 80.179,206.26 L 80.179,207.357 L 77.872,207.357 L 77.872,208.454 L 97.48400000000001,208.454 L 97.48400000000001,209.551 L 122.288,209.551 L 122.288,210.648 L 107.867,210.648 L 107.867,211.746 L 95.754,211.746 L 95.754,212.843 L 96.90700000000001,212.843 L 96.90700000000001,213.94 L 99.792,213.94 L 99.792,215.037 L 128.63299999999998,215.037 L 128.63299999999998,216.134 L 147.09199999999998,216.134 L 147.09199999999998,217.231 L 150.553,217.231 L 150.553,218.328 L 146.515,218.328 L 146.515,219.425 L 140.17,219.425 L 140.17,220.523 L 129.78699999999998,220.523 L 129.78699999999998,221.62 L 115.366,221.62 L 115.366,222.717 L 118.82700000000001,222.717 L 118.82700000000001,223.814 L 147.66899999999998,223.814 L 147.66899999999998,224.911 L 168.434,224.911 L 168.434,226.008 L 139.593,226.008 L 139.593,227.105 L 116.52000000000001,227.105 L 116.52000000000001,228.202 L 128.63299999999998,228.202 L 128.63299999999998,229.3 L 114.212,229.3 L 114.212,230.397 L 145.361,230.397 L 145.361,231.494 L 159.78199999999998,231.494 L 159.78199999999998,232.591 L 122.288,232.591 L 122.288,233.688 L 121.134,233.688 L 121.134,234.785 L 133.825,234.785 L 133.825,235.882 L 147.66899999999998,235.882 L 147.66899999999998,236.979 L 145.361,236.979 L 145.361,238.077 L 134.97799999999998,238.077 L 134.97799999999998,239.174 L 133.248,239.174 L 133.248,240.271 L 115.366,240.271 L 115.366,241.368 L 107.867,241.368 L 107.867,242.465 L 126.32600000000001,242.465 L 126.32600000000001,243.562 L 140.17,243.562 L 140.17,244.659 L 129.20999999999998,244.659 L 129.20999999999998,245.756 L 122.865,245.756 L 122.865,246.854 L 107.867,246.854 L 107.867,247.951 L 106.714,247.951 L 106.714,249.048 L 136.13199999999998,249.048 L 136.13199999999998,250.145 L 143.631,250.145 L 143.631,251.242 L 141.32299999999998,251.242 L 141.32299999999998,252.339 L 141.32299999999998,252.339 L 141.32299999999998,253.436 L 147.66899999999998,253.436 L 147.66899999999998,254.534 L 137.286,254.534 L 137.286,255.631 L 136.13199999999998,255.631 L 136.13199999999998,256.728 L 131.517,256.728 L 131.517,257.825 L 130.364,257.825 L 130.364,258.922 L 145.938,258.922 L 145.938,260.019 L 161.512,260.019 L 161.512,261.116 L 166.70399999999998,261.116 L 166.70399999999998,262.213 L 128.63299999999998,262.213 L 128.63299999999998,263.311 L 111.328,263.311 L 111.328,264.408 L 147.66899999999998,264.408 L 147.66899999999998,265.505 L 145.361,265.505 L 145.361,266.602 L 141.32299999999998,266.602 L 141.32299999999998,267.699 L 149.976,267.699 L 149.976,268.796 L 158.051,268.796 L 158.051,269.893 L 172.47199999999998,269.893 L 172.47199999999998,270.99 L 177.664,270.99 L 177.664,272.088 L 175.356,272.088 L 175.356,273.185 L 170.165,273.185 L 170.165,274.282 L 172.47199999999998,274.282 L 172.47199999999998,275.379 L 167.28099999999998,275.379 L 167.28099999999998,276.476 L 158.051,276.476 L 158.051,277.573 L 155.167,277.573 L 155.167,278.67 L 164.397,278.67 L 164.397,279.767 L 156.898,279.767 L 156.898,280.865 L 158.051,280.865 L 158.051,281.962 L 163.243,281.962 L 163.243,283.059 L 152.85999999999999,283.059 L 152.85999999999999,284.156 L 155.744,284.156 L 155.744,285.253 L 159.78199999999998,285.253 L 159.78199999999998,286.35 L 180.548,286.35 L 180.548,287.447 L 196.12199999999999,287.447 L 196.12199999999999,288.544 L 169.588,288.544 L 169.588,289.642 L 156.898,289.642 L 156.898,290.739 L 160.93599999999998,290.739 L 160.93599999999998,291.836 L 156.898,291.836 L 156.898,292.933 L 158.628,292.933 L 158.628,294.03 L 150.553,294.03 L 150.553,295.127 L 148.822,295.127 L 148.822,296.224 L 166.12699999999998,296.224 L 166.12699999999998,297.321 L 170.165,297.321 L 170.165,298.419 L 173.62599999999998,298.419 L 173.62599999999998,299.516 L 170.742,299.516 L 170.742,300.613 L 174.78,300.613 L 174.78,301.71 L 184.009,301.71 L 184.009,302.807 L 158.051,302.807 L 158.051,303.904 L 144.208,303.904 L 144.208,305.001 L 150.553,305.001 L 150.553,306.098 L 151.706,306.098 L 151.706,307.196 L 157.475,307.196 L 157.475,308.293 L 166.12699999999998,308.293 L 166.12699999999998,309.39 L 163.243,309.39 L 163.243,310.487 L 158.051,310.487 L 158.051,311.584 L 172.47199999999998,311.584 L 172.47199999999998,312.681 L 180.548,312.681 L 180.548,313.778 L 177.664,313.778 L 177.664,314.876 L 185.739,314.876 L 185.739,315.973 L 192.661,315.973 L 192.661,317.07 L 192.661,317.07 L 192.661,318.167 L 199.006,318.167 L 199.006,319.264 L 205.352,319.264 L 205.352,320.361 L 198.42999999999998,320.361 L 198.42999999999998,321.458 L 184.009,321.458 L 184.009,322.555 L 178.81699999999998,322.555 L 178.81699999999998,323.653 L 198.42999999999998,323.653 L 198.42999999999998,324.75 L 201.314,324.75 L 201.314,325.847 L 181.702,325.847 L 181.702,326.944 L 175.356,326.944 L 175.356,328.041 L 172.47199999999998,328.041 L 172.47199999999998,329.138 L 181.702,329.138 L 181.702,330.235 L 206.505,330.235 L 206.505,331.332 L 216.88799999999998,331.332 L 216.88799999999998,332.43 L 210.54299999999998,332.43 L 210.54299999999998,333.527 L 200.16,333.527 L 200.16,334.624 L 187.47,334.624 L 187.47,335.721 L 190.93099999999998,335.721 L 190.93099999999998,336.818 L 193.238,336.818 L 193.238,337.915 L 186.893,337.915 L 186.893,339.012 L 184.58599999999998,339.012 L 184.58599999999998,340.109 L 174.203,340.109 L 174.203,341.207 L 171.319,341.207 L 171.319,342.304 L 182.855,342.304 L 182.855,343.401 L 180.548,343.401 L 180.548,344.498 L 171.89499999999998,344.498 L 171.89499999999998,345.595 L 174.203,345.595 L 174.203,346.692 L 180.548,346.692 L 180.548,347.789 L 188.623,347.789 L 188.623,348.886 L 179.39399999999998,348.886 L 179.39399999999998,349.984 L 170.165,349.984 L 170.165,351.081 L 170.165,351.081 L 170.165,352.178 L 169.011,352.178 L 169.011,353.275 L 175.356,353.275 L 175.356,354.372 L 181.702,354.372 L 181.702,355.469 L 198.42999999999998,355.469 L 198.42999999999998,356.566 L 199.583,356.566 L 199.583,357.663 L 180.548,357.663 L 180.548,358.761 L 178.24099999999999,358.761 L 178.24099999999999,359.858 L 187.47,359.858 L 187.47,360.955 L 178.24099999999999,360.955 L 178.24099999999999,362.052 L 163.82,362.052 L 163.82,363.149 L 171.319,363.149 L 171.319,364.246 L 180.548,364.246 L 180.548,365.343 L 175.356,365.343 L 175.356,366.44 L 174.78,366.44 L 174.78,367.538 L 177.664,367.538 L 177.664,368.635 L 175.356,368.635 L 175.356,369.732 L 181.702,369.732 L 181.702,370.829 L 184.009,370.829 L 184.009,371.926 L 160.93599999999998,371.926 L 160.93599999999998,373.023 L 143.054,373.023 L 143.054,374.12 L 151.706,374.12 L 151.706,375.218 L 166.12699999999998,375.218 L 166.12699999999998,376.315 L 175.356,376.315 L 175.356,377.412 L 203.62099999999998,377.412 L 203.62099999999998,378.509 L 230.732,378.509 L 230.732,379.606 L 221.503,379.606 L 221.503,380.703 L 201.891,380.703 L 201.891,381.8 L 193.238,381.8 L 193.238,382.897 L 193.815,382.897 L 193.815,383.995 L 186.893,383.995 L 186.893,385.092 L 189.2,385.092 L 189.2,386.189 L 198.42999999999998,386.189 L 198.42999999999998,387.286 L 211.11999999999998,387.286 L 211.11999999999998,388.383 L 197.27599999999998,388.383 L 197.27599999999998,389.48 L 173.04899999999998,389.48 L 173.04899999999998,390.577 L 174.203,390.577 L 174.203,391.674 L 183.432,391.674 L 183.432,392.772 L 214.581,392.772 L 214.581,393.869 L 208.813,393.869 L 208.813,394.966 L 192.084,394.966 L 192.084,396.063 L 227.271,396.063 L 227.271,397.16 L 223.233,397.16 L 223.233,398.257 L 219.772,398.257 L 219.772,399.354 L 248.037,399.354 L 248.037,400.451 L 234.76999999999998,400.451 L 234.76999999999998,401.549 L 218.042,401.549 L 218.042,402.646 L 214.004,402.646 L 214.004,403.743 L 211.11999999999998,403.743 L 211.11999999999998,404.84 L 202.46699999999998,404.84 L 202.46699999999998,405.937 L 180.548,405.937 L 180.548,407.034 L 174.78,407.034 L 174.78,408.131 L 186.893,408.131 L 186.893,409.228 L 214.581,409.228 L 214.581,410.326 L 243.999,410.326 L 243.999,411.423 L 235.92399999999998,411.423 L 235.92399999999998,412.52 L 228.42499999999998,412.52 L 228.42499999999998,413.617 L 259.574,413.617 L 259.574,414.714 L 253.22799999999998,414.714 L 253.22799999999998,415.811 L 238.808,415.811 L 238.808,416.908 L 226.694,416.908 L 226.694,418.005 L 196.12199999999999,418.005 L 196.12199999999999,419.103 L 204.19799999999998,419.103 L 204.19799999999998,420.2 L 209.38899999999998,420.2 L 209.38899999999998,421.297 L 187.47,421.297 L 187.47,422.394 L 190.93099999999998,422.394 L 190.93099999999998,423.491 L 237.654,423.491 L 237.654,424.588 L 229.00199999999998,424.588 L 229.00199999999998,425.685 L 188.623,425.685 L 188.623,426.782 L 157.475,426.782 L 157.475,427.88 L 139.016,427.88 L 139.016,428.977 L 164.97299999999998,428.977 L 164.97299999999998,430.074 L 173.04899999999998,430.074 L 173.04899999999998,431.171 L 170.165,431.171 L 170.165,432.268 L 169.011,432.268 L 169.011,433.365 L 161.512,433.365 L 161.512,434.462 L 192.084,434.462 L 192.084,435.56 L 186.316,435.56 L 186.316,436.657 L 118.82700000000001,436.657 L 118.82700000000001,437.754 L 98.061,437.754 L 98.061,438.851 L 124.01800000000001,438.851 L 124.01800000000001,439.948 L 119.40400000000001,439.948 L 119.40400000000001,441.091 L 97.48400000000001,441.091 L 97.48400000000001,442.188 L 120.557,442.188 L 120.557,443.285 L 143.054,443.285 L 143.054,444.382 L 136.709,444.382 L 136.709,445.479 L 145.361,445.479 L 145.361,446.576 L 159.20499999999998,446.576 L 159.20499999999998,447.674 L 146.515,447.674 L 146.515,448.771 L 127.479,448.771 L 127.479,449.868 L 125.74900000000001,449.868 L 125.74900000000001,450.965 L 124.59500000000001,450.965 L 124.59500000000001,452.062 L 132.671,452.062 L 132.671,453.159 L 110.17500000000001,453.159 L 110.17500000000001,454.256 L 88.25500000000001,454.256 L 88.25500000000001,455.354 L 113.059,455.354 L 113.059,456.451 L 120.557,456.451 L 120.557,457.548 L 133.825,457.548 L 133.825,458.645 L 157.475,458.645 L 157.475,459.742 L 141.32299999999998,459.742 L 141.32299999999998,460.839 L 129.20999999999998,460.839 L 129.20999999999998,461.936 L 139.593,461.936 L 139.593,463.033 L 122.865,463.033 L 122.865,464.131 L 96.90700000000001,464.131 L 96.90700000000001,465.228 L 88.25500000000001,465.228 L 88.25500000000001,466.325 L 158.628,466.325 L 158.628,467.422 L 233.61599999999999,467.422 L 233.61599999999999,468.519 L 209.96599999999998,468.519 L 209.96599999999998,469.616 L 140.17,469.616 L 140.17,470.713 L 93.446,470.713 L 93.446,471.81 L 87.67800000000001,471.81 L 87.67800000000001,472.908 L 81.333,472.908 L 81.333,474.005 L 59.41300000000001,474.005 L 59.41300000000001,475.102 L 72.681,475.102 L 72.681,476.199 L 106.714,476.199 L 106.714,477.296 L 98.638,477.296 L 98.638,478.393 L 83.06400000000001,478.393 L 83.06400000000001,479.49 L 74.411,479.49 L 74.411,480.587 L 62.87400000000001,480.587 L 62.87400000000001,481.685 L 76.718,481.685 L 76.718,482.782 L 76.14200000000001,482.782 L 76.14200000000001,483.879 L 72.681,483.879 L 72.681,484.976 L 92.293,484.976 L 92.293,486.073 L 85.37100000000001,486.073 L 85.37100000000001,487.17 L 65.759,487.17 L 65.759,488.267 L 58.260000000000005,488.267 L 58.260000000000005,489.364 L 88.25500000000001,489.364 L 88.25500000000001,490.462 L 84.217,490.462 L 84.217,491.559 L 59.41300000000001,491.559 L 59.41300000000001,492.656 L 73.834,492.656 L 73.834,493.753 L 70.373,493.753 L 70.373,494.85 L 58.837,494.85 L 58.837,495.947 L 70.373,495.947 L 70.373,497.044 L 98.638,497.044 L 98.638,498.141 L 134.97799999999998,498.141 L 134.97799999999998,499.239 L 123.442,499.239 L 123.442,500.336 L 120.557,500.336 L 120.557,501.433 L 140.17,501.433 L 140.17,502.53 L 110.751,502.53 L 110.751,503.627 L 110.17500000000001,503.627 L 110.17500000000001,504.724 L 115.366,504.724 L 115.366,505.821 L 92.293,505.821 L 92.293,506.918 L 81.91000000000001,506.918 L 81.91000000000001,508.016 L 117.09700000000001,508.016 L 117.09700000000001,509.113 L 131.517,509.113 L 131.517,510.21 L 105.56,510.21 L 105.56,511.307 L 87.101,511.307 L 87.101,512.404 L 83.06400000000001,512.404 L 83.06400000000001,513.501 L 99.792,513.501 L 99.792,514.598 L 106.137,514.598 L 106.137,515.696 L 109.021,515.696 L 109.021,516.793 L 77.872,516.793 L 77.872,517.89 L 23.073000000000004,517.89 L 23.073000000000004,518.987 L 13.844000000000001,518.987 L 13.844000000000001,520.084 L 51.915000000000006,520.084 L 51.915000000000006,521.181 L 102.676,521.181 L 102.676,522.278 L 125.74900000000001,522.278 L 125.74900000000001,523.375 L 107.867,523.375 L 107.867,524.473 L 117.09700000000001,524.473 L 117.09700000000001,525.57 L 114.212,525.57 L 114.212,526.667 L 109.021,526.667 L 109.021,527.764 L 145.361,527.764 L 145.361,528.861 L 121.711,528.861 L 121.711,529.958 L 86.524,529.958 L 86.524,531.055 L 112.482,531.055 L 112.482,532.152 L 126.903,532.152 L 126.903,533.25 L 114.212,533.25 L 114.212,534.347 L 101.522,534.347 L 101.522,535.444 L 91.13900000000001,535.444 L 91.13900000000001,536.541 L 94.60000000000001,536.541 L 94.60000000000001,537.638 L 110.17500000000001,537.638 L 110.17500000000001,538.735 L 125.74900000000001,538.735 L 125.74900000000001,539.832 L 132.094,539.832 L 132.094,540.929 L 144.208,540.929 L 144.208,542.027 L 133.825,542.027 L 133.825,543.124 L 127.479,543.124 L 127.479,544.221 L 131.517,544.221 L 131.517,545.318 L 131.517,545.318 L 131.517,546.415 L 114.789,546.415 L 114.789,547.512 L 91.13900000000001,547.512 L 91.13900000000001,548.609 L 79.02600000000001,548.609 L 79.02600000000001,549.706 L 64.605,549.706 L 64.605,550.804 L 88.25500000000001,550.804 L 88.25500000000001,551.901 L 102.676,551.901 L 102.676,552.998 L 115.366,552.998 L 115.366,554.095 L 95.754,554.095 L 95.754,555.192 L 74.988,555.192 L 74.988,556.289 L 100.94500000000001,556.289 L 100.94500000000001,557.386 L 116.52000000000001,557.386 L 116.52000000000001,558.483 L 128.05599999999998,558.483 L 128.05599999999998,559.581 L 140.17,559.581 L 140.17,560.678 L 140.17,560.678 L 140.17,561.775 L 80.179,561.775 L 80.179,562.872 L 27.111,562.872 L 27.111,563.969 L 29.418000000000003,563.969 L 29.418000000000003,565.066 L 73.834,565.066 L 73.834,566.163 L 107.867,566.163 L 107.867,567.26 L 81.91000000000001,567.26 L 81.91000000000001,568.358 L 70.373,568.358 L 70.373,569.455 L 107.867,569.455 L 107.867,570.552 L 101.522,570.552 L 101.522,571.649 L 79.60300000000001,571.649 L 79.60300000000001,572.746 L 93.446,572.746 L 93.446,573.843 L 81.91000000000001,573.843 L 81.91000000000001,574.94 L 72.681,574.94 L 72.681,576.038 L 87.67800000000001,576.038 L 87.67800000000001,577.135 L 108.444,577.135 L 108.444,578.232 L 93.446,578.232 L 93.446,579.283 L 115.943,579.283 L 115.943,580.38 L 173.04899999999998,580.38 L 173.04899999999998,581.477 L 186.893,581.477 L 186.893,582.575 L 185.16199999999998,582.575 L 185.16199999999998,583.672 L 119.40400000000001,583.672 L 119.40400000000001,584.769 L 67.489,584.769 L 67.489,585.866 L 60.56700000000001,585.866 L 60.56700000000001,586.963 L 81.333,586.963 L 81.333,588.06 L 117.67300000000002,588.06 L 117.67300000000002,589.157 L 121.711,589.157 L 121.711,590.254 L 94.60000000000001,590.254 L 94.60000000000001,591.352 L 59.41300000000001,591.352 L 59.41300000000001,592.449 L 63.45100000000001,592.449 L 63.45100000000001,593.546 L 68.643,593.546 L 68.643,594.643 L 112.482,594.643 L 112.482,595.74 L 163.243,595.74 L 163.243,596.837 L 150.553,596.837 L 150.553,597.934 L 148.24499999999998,597.934 L 148.24499999999998,599.031 L 139.016,599.031 L 139.016,600.129 L 118.25000000000001,600.129 L 118.25000000000001,601.226 L 107.867,601.226 L 107.867,602.323 L 114.212,602.323 L 114.212,603.42 L 109.021,603.42 L 109.021,604.517 L 70.95,604.517 L 70.95,605.614 L 51.915000000000006,605.614 L 51.915000000000006,606.711 L 62.87400000000001,606.711 L 62.87400000000001,607.808 L 73.257,607.808 L 73.257,608.906 L 84.79400000000001,608.906 L 84.79400000000001,610.003 L 130.94,610.003 L 130.94,611.1 L 149.976,611.1 L 149.976,612.197 L 133.248,612.197 L 133.248,613.294 L 111.328,613.294 L 111.328,614.391 L 102.099,614.391 L 102.099,615.488 L 119.40400000000001,615.488 L 119.40400000000001,616.585 L 128.63299999999998,616.585 L 128.63299999999998,617.683 L 141.32299999999998,617.683 L 141.32299999999998,618.78 L 149.399,618.78 L 149.399,619.877 L 157.475,619.877 L 157.475,620.974 L 164.97299999999998,620.974 L 164.97299999999998,622.071 L 169.588,622.071 L 169.588,623.168 L 156.898,623.168 L 156.898,624.265 L 149.399,624.265 L 149.399,625.363 L 185.739,625.363 L 185.739,626.46 L 206.505,626.46 L 206.505,627.557 L 184.009,627.557 L 184.009,628.654 L 134.97799999999998,628.654 L 134.97799999999998,629.751 L 128.63299999999998,629.751 L 128.63299999999998,630.848 L 144.208,630.848 L 144.208,631.945 L 139.016,631.945 L 139.016,633.042 L 129.78699999999998,633.042 L 129.78699999999998,634.14 L 113.059,634.14 L 113.059,635.237 L 118.25000000000001,635.237 L 118.25000000000001,636.334 L 133.825,636.334 L 133.825,637.431 L 124.59500000000001,637.431 L 124.59500000000001,638.528 L 128.63299999999998,638.528 L 128.63299999999998,639.625 L 136.709,639.625 L 136.709,640.722 L 126.32600000000001,640.722 L 126.32600000000001,641.819 L 129.78699999999998,641.819 L 129.78699999999998,642.917 L 124.59500000000001,642.917 L 124.59500000000001,644.014 L 122.288,644.014 L 122.288,645.111 L 120.557,645.111 L 120.557,646.208 L 118.82700000000001,646.208 L 118.82700000000001,647.305 L 154.01399999999998,647.305 L 154.01399999999998,648.402 L 154.01399999999998,648.402 L 154.01399999999998,649.499 L 130.94,649.499 L 130.94,650.596 L 131.517,650.596 L 131.517,651.694 L 123.442,651.694 L 123.442,652.791 L 118.25000000000001,652.791 L 118.25000000000001,653.888 L 133.825,653.888 L 133.825,654.985 L 141.32299999999998,654.985 L 141.32299999999998,656.082 L 144.208,656.082 L 144.208,657.179 L 162.666,657.179 L 162.666,658.276 L 153.43699999999998,658.276 L 153.43699999999998,659.373 L 132.094,659.373 L 132.094,660.471 L 124.59500000000001,660.471 L 124.59500000000001,661.568 L 131.517,661.568 L 131.517,662.665 L 141.32299999999998,662.665 L 141.32299999999998,663.762 L 136.13199999999998,663.762 L 136.13199999999998,664.859 L 132.671,664.859 L 132.671,665.956 L 140.17,665.956 L 140.17,667.053 L 148.822,667.053 L 148.822,668.15 L 150.553,668.15 L 150.553,669.248 L 140.74699999999999,669.248 L 140.74699999999999,670.345 L 155.744,670.345 L 155.744,671.442 L 163.243,671.442 L 163.243,672.539 L 136.13199999999998,672.539 L 136.13199999999998,673.636 L 129.78699999999998,673.636 L 129.78699999999998,674.733 L 136.13199999999998,674.733 L 136.13199999999998,675.83 L 134.97799999999998,675.83 L 134.97799999999998,676.927 L 160.93599999999998,676.927 L 160.93599999999998,678.025 L 182.855,678.025 L 182.855,679.122 L 162.666,679.122 L 162.666,680.219 L 140.74699999999999,680.219 L 140.74699999999999,681.316 L 134.97799999999998,681.316 L 134.97799999999998,682.413 L 139.593,682.413 L 139.593,683.51 L 151.706,683.51 L 151.706,684.607 L 163.82,684.607 L 163.82,685.705 L 152.283,685.705 L 152.283,686.802 L 148.24499999999998,686.802 L 148.24499999999998,687.899 L 159.78199999999998,687.899 L 159.78199999999998,688.996 L 152.283,688.996 L 152.283,690.093 L 150.553,690.093 L 150.553,691.19 L 162.089,691.19 L 162.089,692.287 L 162.089,692.287 L 162.089,693.384 L 163.243,693.384 L 163.243,694.482 L 163.82,694.482 L 163.82,695.579 L 167.858,695.579 L 167.858,696.676 L 180.548,696.676 L 180.548,697.773 L 186.893,697.773 L 186.893,698.87 L 194.392,698.87 L 194.392,699.967 L 204.77499999999998,699.967 L 204.77499999999998,701.064 L 194.392,701.064 L 194.392,702.161 L 171.319,702.161 L 171.319,703.259 L 169.011,703.259 L 169.011,704.356 L 170.165,704.356 L 170.165,705.453 L 162.666,705.453 L 162.666,706.55 L 157.475,706.55 L 157.475,707.647 L 151.706,707.647 L 151.706,708.744 L 155.167,708.744 L 155.167,709.841 L 145.361,709.841 L 145.361,710.938 L 136.709,710.938 L 136.709,712.036 L 141.32299999999998,712.036 L 141.32299999999998,713.133 L 145.361,713.133 L 145.361,714.23 L 153.43699999999998,714.23 L 153.43699999999998,715.327 L 158.051,715.327 L 158.051,716.424 L 159.20499999999998,716.424 L 159.20499999999998,717.521 L 176.51,717.521 L 176.51,718.618 L 199.006,718.618 L 199.006,719.715 L 188.623,719.715 L 188.623,720.813 L 183.432,720.813 L 183.432,721.91 L 189.777,721.91 L 189.777,723.007 L 178.81699999999998,723.007 L 178.81699999999998,724.104 L 181.125,724.104 L 181.125,725.201 L 195.545,725.201 L 195.545,726.298 L 203.62099999999998,726.298 L 203.62099999999998,727.395 L 197.27599999999998,727.395 L 197.27599999999998,728.492 L 175.356,728.492 L 175.356,729.59 L 169.011,729.59 L 169.011,730.687 L 171.319,730.687 L 171.319,731.784 L 170.165,731.784 L 170.165,732.881 L 173.04899999999998,732.881 L 173.04899999999998,733.978 L 173.04899999999998,733.978 L 173.04899999999998,735.075 L 169.011,735.075 L 169.011,736.172 L 163.243,736.172 L 163.243,737.269 L 158.051,737.269 L 158.051,738.367 L 184.58599999999998,738.367 L 184.58599999999998,739.464 L 207.659,739.464 L 207.659,740.561 L 197.27599999999998,740.561 L 197.27599999999998,741.658 L 185.739,741.658 L 185.739,742.755 L 166.12699999999998,742.755 L 166.12699999999998,743.852 L 158.628,743.852 L 158.628,744.949 L 158.628,744.949 L 158.628,746.047 L 148.24499999999998,746.047 L 148.24499999999998,747.144 L 147.09199999999998,747.144 L 147.09199999999998,748.241 L 153.43699999999998,748.241 L 153.43699999999998,749.338 L 174.203,749.338 L 174.203,750.435 L 197.85299999999998,750.435 L 197.85299999999998,751.532 L 190.93099999999998,751.532 L 190.93099999999998,752.629 L 184.009,752.629 L 184.009,753.726 L 175.356,753.726 L 175.356,754.824 L 155.744,754.824 L 155.744,755.921 L 154.01399999999998,755.921 L 154.01399999999998,757.018 L 155.744,757.018 L 155.744,758.115 L 172.47199999999998,758.115 L 172.47199999999998,759.212 L 170.742,759.212 L 170.742,760.309 L 152.85999999999999,760.309 L 152.85999999999999,761.406 L 163.243,761.406 L 163.243,762.503 L 186.893,762.503 L 186.893,763.601 L 202.46699999999998,763.601 L 202.46699999999998,764.698 L 188.047,764.698 L 188.047,765.795 L 172.47199999999998,765.795 L 172.47199999999998,766.892 L 173.62599999999998,766.892 L 173.62599999999998,767.989 L 171.319,767.989 L 171.319,769.086 L 159.78199999999998,769.086 L 159.78199999999998,770.183 L 150.553,770.183 L 150.553,771.28 L 145.361,771.28 L 145.361,772.378 L 156.898,772.378 L 156.898,773.475 L 181.702,773.475 L 181.702,774.572 L 180.548,774.572 L 180.548,775.669 L 178.81699999999998,775.669 L 178.81699999999998,776.766 L 178.81699999999998,776.766 L 178.81699999999998,777.863 L 169.588,777.863 L 169.588,778.96 L 175.933,778.96 L 175.933,780.057 L 179.971,780.057 L 179.971,781.155 L 168.434,781.155 L 168.434,782.252 L 167.28099999999998,782.252 L 167.28099999999998,783.349 L 163.82,783.349 L 163.82,784.446 L 147.09199999999998,784.446 L 147.09199999999998,785.543 L 155.744,785.543 L 155.744,786.64 L 163.243,786.64 L 163.243,787.737 L 175.356,787.737 L 175.356,788.834 L 169.011,788.834 L 169.011,789.932 L 145.361,789.932 L 145.361,791.029 L 153.43699999999998,791.029 L 153.43699999999998,792.126 L 148.24499999999998,792.126 L 148.24499999999998,793.223 L 150.553,793.223 L 150.553,794.32 L 155.744,794.32 L 155.744,795.417 L 153.43699999999998,795.417 L 153.43699999999998,796.514 L 152.283,796.514 L 152.283,797.611 L 136.709,797.611 L 136.709,798.709 L 147.09199999999998,798.709 L 147.09199999999998,799.806 L 151.706,799.806 L 151.706,800.903 L 169.588,800.903 L 169.588,802 L 199.583,802 L 461.464,802 L 387.63,802 L 387.63,800.903 L 256.689,800.903 L 256.689,799.806 L 200.737,799.806 L 200.737,798.709 L 193.238,798.709 L 193.238,797.611 L 188.047,797.611 L 188.047,796.514 L 196.69899999999998,796.514 L 196.69899999999998,795.417 L 209.96599999999998,795.417 L 209.96599999999998,794.32 L 220.926,794.32 L 220.926,793.223 L 240.53799999999998,793.223 L 240.53799999999998,792.126 L 253.22799999999998,792.126 L 253.22799999999998,791.029 L 245.153,791.029 L 245.153,789.932 L 242.26899999999998,789.932 L 242.26899999999998,788.834 L 242.26899999999998,788.834 L 242.26899999999998,787.737 L 233.61599999999999,787.737 L 233.61599999999999,786.64 L 218.042,786.64 L 218.042,785.543 L 221.503,785.543 L 221.503,784.446 L 231.886,784.446 L 231.886,783.349 L 226.694,783.349 L 226.694,782.252 L 227.84799999999998,782.252 L 227.84799999999998,781.155 L 238.231,781.155 L 238.231,780.057 L 248.614,780.057 L 248.614,778.96 L 258.997,778.96 L 258.997,777.863 L 253.80499999999998,777.863 L 253.80499999999998,776.766 L 247.46,776.766 L 247.46,775.669 L 238.808,775.669 L 238.808,774.572 L 219.772,774.572 L 219.772,773.475 L 204.19799999999998,773.475 L 204.19799999999998,772.378 L 199.006,772.378 L 199.006,771.28 L 196.12199999999999,771.28 L 196.12199999999999,770.183 L 206.505,770.183 L 206.505,769.086 L 226.117,769.086 L 226.117,767.989 L 246.883,767.989 L 246.883,766.892 L 272.841,766.892 L 272.841,765.795 L 283.22400000000005,765.795 L 283.22400000000005,764.698 L 282.07,764.698 L 282.07,763.601 L 268.803,763.601 L 268.803,762.503 L 230.732,762.503 L 230.732,761.406 L 217.465,761.406 L 217.465,760.309 L 224.387,760.309 L 224.387,759.212 L 219.195,759.212 L 219.195,758.115 L 209.96599999999998,758.115 L 209.96599999999998,757.018 L 203.62099999999998,757.018 L 203.62099999999998,755.921 L 214.004,755.921 L 214.004,754.824 L 229.578,754.824 L 229.578,753.726 L 242.26899999999998,753.726 L 242.26899999999998,752.629 L 238.808,752.629 L 238.808,751.532 L 234.19299999999998,751.532 L 234.19299999999998,750.435 L 227.271,750.435 L 227.271,749.338 L 211.11999999999998,749.338 L 211.11999999999998,748.241 L 198.42999999999998,748.241 L 198.42999999999998,747.144 L 194.969,747.144 L 194.969,746.047 L 210.54299999999998,746.047 L 210.54299999999998,744.949 L 236.5,744.949 L 236.5,743.852 L 252.07500000000002,743.852 L 252.07500000000002,742.755 L 263.61100000000005,742.755 L 263.61100000000005,741.658 L 271.11,741.658 L 271.11,740.561 L 267.072,740.561 L 267.072,739.464 L 245.153,739.464 L 245.153,738.367 L 215.158,738.367 L 215.158,737.269 L 209.96599999999998,737.269 L 209.96599999999998,736.172 L 216.88799999999998,736.172 L 216.88799999999998,735.075 L 227.271,735.075 L 227.271,733.978 L 241.69199999999998,733.978 L 241.69199999999998,732.881 L 246.883,732.881 L 246.883,731.784 L 250.34399999999997,731.784 L 250.34399999999997,730.687 L 239.96099999999998,730.687 L 239.96099999999998,729.59 L 237.654,729.59 L 237.654,728.492 L 241.69199999999998,728.492 L 241.69199999999998,727.395 L 249.191,727.395 L 249.191,726.298 L 251.49799999999996,726.298 L 251.49799999999996,725.201 L 247.46,725.201 L 247.46,724.104 L 258.997,724.104 L 258.997,723.007 L 264.18800000000005,723.007 L 264.18800000000005,721.91 L 257.843,721.91 L 257.843,720.813 L 253.22799999999998,720.813 L 253.22799999999998,719.715 L 253.22799999999998,719.715 L 253.22799999999998,718.618 L 237.077,718.618 L 237.077,717.521 L 218.042,717.521 L 218.042,716.424 L 211.697,716.424 L 211.697,715.327 L 205.928,715.327 L 205.928,714.23 L 200.737,714.23 L 200.737,713.133 L 190.93099999999998,713.133 L 190.93099999999998,712.036 L 200.16,712.036 L 200.16,710.938 L 209.96599999999998,710.938 L 209.96599999999998,709.841 L 202.46699999999998,709.841 L 202.46699999999998,708.744 L 218.042,708.744 L 218.042,707.647 L 234.76999999999998,707.647 L 234.76999999999998,706.55 L 237.654,706.55 L 237.654,705.453 L 237.654,705.453 L 237.654,704.356 L 245.73,704.356 L 245.73,703.259 L 245.73,703.259 L 245.73,702.161 L 256.113,702.161 L 256.113,701.064 L 275.148,701.064 L 275.148,699.967 L 264.18800000000005,699.967 L 264.18800000000005,698.87 L 250.34399999999997,698.87 L 250.34399999999997,697.773 L 264.76500000000004,697.773 L 264.76500000000004,696.676 L 275.148,696.676 L 275.148,695.579 L 261.30400000000003,695.579 L 261.30400000000003,694.482 L 243.999,694.482 L 243.999,693.384 L 230.732,693.384 L 230.732,692.287 L 227.271,692.287 L 227.271,691.19 L 224.387,691.19 L 224.387,690.093 L 233.61599999999999,690.093 L 233.61599999999999,688.996 L 226.117,688.996 L 226.117,687.899 L 197.27599999999998,687.899 L 197.27599999999998,686.802 L 220.926,686.802 L 220.926,685.705 L 291.29900000000004,685.705 L 291.29900000000004,684.607 L 282.07,684.607 L 282.07,683.51 L 224.387,683.51 L 224.387,682.413 L 226.694,682.413 L 226.694,681.316 L 254.38199999999998,681.316 L 254.38199999999998,680.219 L 276.302,680.219 L 276.302,679.122 L 317.833,679.122 L 317.833,678.025 L 297.06800000000004,678.025 L 297.06800000000004,676.927 L 233.039,676.927 L 233.039,675.83 L 226.694,675.83 L 226.694,674.733 L 225.541,674.733 L 225.541,673.636 L 218.042,673.636 L 218.042,672.539 L 219.195,672.539 L 219.195,671.442 L 216.31099999999998,671.442 L 216.31099999999998,670.345 L 215.158,670.345 L 215.158,669.248 L 229.578,669.248 L 229.578,668.15 L 228.42499999999998,668.15 L 228.42499999999998,667.053 L 209.96599999999998,667.053 L 209.96599999999998,665.956 L 203.62099999999998,665.956 L 203.62099999999998,664.859 L 201.314,664.859 L 201.314,663.762 L 194.392,663.762 L 194.392,662.665 L 191.50799999999998,662.665 L 191.50799999999998,661.568 L 199.583,661.568 L 199.583,660.471 L 214.004,660.471 L 214.004,659.373 L 228.42499999999998,659.373 L 228.42499999999998,658.276 L 231.309,658.276 L 231.309,657.179 L 224.387,657.179 L 224.387,656.082 L 225.541,656.082 L 225.541,654.985 L 220.926,654.985 L 220.926,653.888 L 213.427,653.888 L 213.427,652.791 L 204.19799999999998,652.791 L 204.19799999999998,651.694 L 189.777,651.694 L 189.777,650.596 L 206.505,650.596 L 206.505,649.499 L 233.61599999999999,649.499 L 233.61599999999999,648.402 L 228.42499999999998,648.402 L 228.42499999999998,647.305 L 196.12199999999999,647.305 L 196.12199999999999,646.208 L 196.12199999999999,646.208 L 196.12199999999999,645.111 L 238.808,645.111 L 238.808,644.014 L 232.463,644.014 L 232.463,642.917 L 233.61599999999999,642.917 L 233.61599999999999,641.819 L 273.994,641.819 L 273.994,640.722 L 325.909,640.722 L 325.909,639.625 L 299.952,639.625 L 299.952,638.528 L 233.61599999999999,638.528 L 233.61599999999999,637.431 L 238.231,637.431 L 238.231,636.334 L 215.158,636.334 L 215.158,635.237 L 203.62099999999998,635.237 L 203.62099999999998,634.14 L 219.195,634.14 L 219.195,633.042 L 219.195,633.042 L 219.195,631.945 L 227.271,631.945 L 227.271,630.848 L 232.463,630.848 L 232.463,629.751 L 233.61599999999999,629.751 L 233.61599999999999,628.654 L 241.69199999999998,628.654 L 241.69199999999998,627.557 L 253.22799999999998,627.557 L 253.22799999999998,626.46 L 254.38199999999998,626.46 L 254.38199999999998,625.363 L 242.846,625.363 L 242.846,624.265 L 271.687,624.265 L 271.687,623.168 L 286.108,623.168 L 286.108,622.071 L 252.07500000000002,622.071 L 252.07500000000002,620.974 L 222.07999999999998,620.974 L 222.07999999999998,619.877 L 199.006,619.877 L 199.006,618.78 L 188.623,618.78 L 188.623,617.683 L 185.739,617.683 L 185.739,616.585 L 189.777,616.585 L 189.777,615.488 L 197.85299999999998,615.488 L 197.85299999999998,614.391 L 207.659,614.391 L 207.659,613.294 L 214.004,613.294 L 214.004,612.197 L 231.309,612.197 L 231.309,611.1 L 246.883,611.1 L 246.883,610.003 L 232.463,610.003 L 232.463,608.906 L 215.158,608.906 L 215.158,607.808 L 181.125,607.808 L 181.125,606.711 L 152.85999999999999,606.711 L 152.85999999999999,605.614 L 173.62599999999998,605.614 L 173.62599999999998,604.517 L 203.62099999999998,604.517 L 203.62099999999998,603.42 L 203.62099999999998,603.42 L 203.62099999999998,602.323 L 197.27599999999998,602.323 L 197.27599999999998,601.226 L 223.233,601.226 L 223.233,600.129 L 238.231,600.129 L 238.231,599.031 L 212.274,599.031 L 212.274,597.934 L 197.27599999999998,597.934 L 197.27599999999998,596.837 L 216.88799999999998,596.837 L 216.88799999999998,595.74 L 212.85,595.74 L 212.85,594.643 L 171.319,594.643 L 171.319,593.546 L 163.243,593.546 L 163.243,592.449 L 175.356,592.449 L 175.356,591.352 L 174.203,591.352 L 174.203,590.254 L 197.27599999999998,590.254 L 197.27599999999998,589.157 L 192.084,589.157 L 192.084,588.06 L 149.399,588.06 L 149.399,586.963 L 136.13199999999998,586.963 L 136.13199999999998,585.866 L 162.089,585.866 L 162.089,584.769 L 193.815,584.769 L 193.815,583.672 L 208.236,583.672 L 208.236,582.575 L 212.85,582.575 L 212.85,581.477 L 205.928,581.477 L 205.928,580.38 L 196.12199999999999,580.38 L 196.12199999999999,579.283 L 187.47,579.283 L 187.47,578.232 L 186.893,578.232 L 186.893,577.135 L 237.077,577.135 L 237.077,576.038 L 276.302,576.038 L 276.302,574.94 L 225.541,574.94 L 225.541,573.843 L 165.54999999999998,573.843 L 165.54999999999998,572.746 L 200.737,572.746 L 200.737,571.649 L 267.072,571.649 L 267.072,570.552 L 280.339,570.552 L 280.339,569.455 L 236.5,569.455 L 236.5,568.358 L 169.011,568.358 L 169.011,567.26 L 151.706,567.26 L 151.706,566.163 L 150.553,566.163 L 150.553,565.066 L 133.825,565.066 L 133.825,563.969 L 148.822,563.969 L 148.822,562.872 L 175.933,562.872 L 175.933,561.775 L 223.233,561.775 L 223.233,560.678 L 265.34200000000004,560.678 L 265.34200000000004,559.581 L 270.533,559.581 L 270.533,558.483 L 233.61599999999999,558.483 L 233.61599999999999,557.386 L 179.971,557.386 L 179.971,556.289 L 168.434,556.289 L 168.434,555.192 L 177.664,555.192 L 177.664,554.095 L 181.702,554.095 L 181.702,552.998 L 198.42999999999998,552.998 L 198.42999999999998,551.901 L 207.659,551.901 L 207.659,550.804 L 184.58599999999998,550.804 L 184.58599999999998,549.706 L 171.319,549.706 L 171.319,548.609 L 168.434,548.609 L 168.434,547.512 L 185.739,547.512 L 185.739,546.415 L 252.07500000000002,546.415 L 252.07500000000002,545.318 L 269.957,545.318 L 269.957,544.221 L 229.578,544.221 L 229.578,543.124 L 223.233,543.124 L 223.233,542.027 L 235.34699999999998,542.027 L 235.34699999999998,540.929 L 248.037,540.929 L 248.037,539.832 L 241.11499999999998,539.832 L 241.11499999999998,538.735 L 233.61599999999999,538.735 L 233.61599999999999,537.638 L 236.5,537.638 L 236.5,536.541 L 214.004,536.541 L 214.004,535.444 L 176.51,535.444 L 176.51,534.347 L 188.623,534.347 L 188.623,533.25 L 229.578,533.25 L 229.578,532.152 L 234.76999999999998,532.152 L 234.76999999999998,531.055 L 226.117,531.055 L 226.117,529.958 L 224.387,529.958 L 224.387,528.861 L 219.195,528.861 L 219.195,527.764 L 196.12199999999999,527.764 L 196.12199999999999,526.667 L 185.739,526.667 L 185.739,525.57 L 173.04899999999998,525.57 L 173.04899999999998,524.473 L 188.623,524.473 L 188.623,523.375 L 224.387,523.375 L 224.387,522.278 L 186.893,522.278 L 186.893,521.181 L 155.744,521.181 L 155.744,520.084 L 139.593,520.084 L 139.593,518.987 L 120.557,518.987 L 120.557,517.89 L 162.089,517.89 L 162.089,516.793 L 225.541,516.793 L 225.541,515.696 L 246.307,515.696 L 246.307,514.598 L 230.732,514.598 L 230.732,513.501 L 227.271,513.501 L 227.271,512.404 L 233.61599999999999,512.404 L 233.61599999999999,511.307 L 247.46,511.307 L 247.46,510.21 L 285.531,510.21 L 285.531,509.113 L 306.297,509.113 L 306.297,508.016 L 256.689,508.016 L 256.689,506.918 L 222.07999999999998,506.918 L 222.07999999999998,505.821 L 241.69199999999998,505.821 L 241.69199999999998,504.724 L 214.581,504.724 L 214.581,503.627 L 192.661,503.627 L 192.661,502.53 L 210.54299999999998,502.53 L 210.54299999999998,501.433 L 205.352,501.433 L 205.352,500.336 L 190.93099999999998,500.336 L 190.93099999999998,499.239 L 188.047,499.239 L 188.047,498.141 L 188.047,498.141 L 188.047,497.044 L 174.78,497.044 L 174.78,495.947 L 162.089,495.947 L 162.089,494.85 L 172.47199999999998,494.85 L 172.47199999999998,493.753 L 176.51,493.753 L 176.51,492.656 L 201.314,492.656 L 201.314,491.559 L 225.541,491.559 L 225.541,490.462 L 216.88799999999998,490.462 L 216.88799999999998,489.364 L 209.38899999999998,489.364 L 209.38899999999998,488.267 L 183.432,488.267 L 183.432,487.17 L 182.278,487.17 L 182.278,486.073 L 193.815,486.073 L 193.815,484.976 L 196.12199999999999,484.976 L 196.12199999999999,483.879 L 180.548,483.879 L 180.548,482.782 L 148.24499999999998,482.782 L 148.24499999999998,481.685 L 150.553,481.685 L 150.553,480.587 L 151.706,480.587 L 151.706,479.49 L 158.051,479.49 L 158.051,478.393 L 192.084,478.393 L 192.084,477.296 L 211.697,477.296 L 211.697,476.199 L 186.893,476.199 L 186.893,475.102 L 175.356,475.102 L 175.356,474.005 L 206.505,474.005 L 206.505,472.908 L 218.042,472.908 L 218.042,471.81 L 229.578,471.81 L 229.578,470.713 L 287.838,470.713 L 287.838,469.616 L 320.141,469.616 L 320.141,468.519 L 305.14300000000003,468.519 L 305.14300000000003,467.422 L 286.108,467.422 L 286.108,466.325 L 232.463,466.325 L 232.463,465.228 L 195.545,465.228 L 195.545,464.131 L 203.62099999999998,464.131 L 203.62099999999998,463.033 L 206.505,463.033 L 206.505,461.936 L 198.42999999999998,461.936 L 198.42999999999998,460.839 L 211.697,460.839 L 211.697,459.742 L 239.385,459.742 L 239.385,458.645 L 240.53799999999998,458.645 L 240.53799999999998,457.548 L 208.813,457.548 L 208.813,456.451 L 178.81699999999998,456.451 L 178.81699999999998,455.354 L 171.319,455.354 L 171.319,454.256 L 182.855,454.256 L 182.855,453.159 L 203.62099999999998,453.159 L 203.62099999999998,452.062 L 218.042,452.062 L 218.042,450.965 L 237.654,450.965 L 237.654,449.868 L 234.76999999999998,449.868 L 234.76999999999998,448.771 L 218.042,448.771 L 218.042,447.674 L 213.427,447.674 L 213.427,446.576 L 220.926,446.576 L 220.926,445.479 L 237.654,445.479 L 237.654,444.382 L 240.53799999999998,444.382 L 240.53799999999998,443.285 L 222.07999999999998,443.285 L 222.07999999999998,442.188 L 197.27599999999998,442.188 L 197.27599999999998,441.091 L 184.58599999999998,441.091 L 184.58599999999998,439.948 L 186.893,439.948 L 186.893,438.851 L 178.81699999999998,438.851 L 178.81699999999998,437.754 L 283.8,437.754 L 283.8,436.657 L 372.05600000000004,436.657 L 372.05600000000004,435.56 L 344.944,435.56 L 344.944,434.462 L 297.06800000000004,434.462 L 297.06800000000004,433.365 L 265.91900000000004,433.365 L 265.91900000000004,432.268 L 291.87600000000003,432.268 L 291.87600000000003,431.171 L 302.259,431.171 L 302.259,430.074 L 308.60400000000004,430.074 L 308.60400000000004,428.977 L 301.105,428.977 L 301.105,427.88 L 257.266,427.88 L 257.266,426.782 L 313.219,426.782 L 313.219,425.685 L 420.509,425.685 L 420.509,424.588 L 423.97,424.588 L 423.97,423.491 L 327.06300000000005,423.491 L 327.06300000000005,422.394 L 250.34399999999997,422.394 L 250.34399999999997,421.297 L 255.53599999999997,421.297 L 255.53599999999997,420.2 L 292.45300000000003,420.2 L 292.45300000000003,419.103 L 362.249,419.103 L 362.249,418.005 L 341.48400000000004,418.005 L 341.48400000000004,416.908 L 335.13800000000003,416.908 L 335.13800000000003,415.811 L 418.202,415.811 L 418.202,414.714 L 434.93,414.714 L 434.93,413.617 L 386.476,413.617 L 386.476,412.52 L 314.949,412.52 L 314.949,411.423 L 277.45500000000004,411.423 L 277.45500000000004,410.326 L 262.458,410.326 L 262.458,409.228 L 256.113,409.228 L 256.113,408.131 L 258.42,408.131 L 258.42,407.034 L 245.153,407.034 L 245.153,405.937 L 253.22799999999998,405.937 L 253.22799999999998,404.84 L 266.49600000000004,404.84 L 266.49600000000004,403.743 L 276.302,403.743 L 276.302,402.646 L 303.413,402.646 L 303.413,401.549 L 333.408,401.549 L 333.408,400.451 L 329.37,400.451 L 329.37,399.354 L 355.327,399.354 L 355.327,398.257 L 418.779,398.257 L 418.779,397.16 L 373.786,397.16 L 373.786,396.063 L 289.569,396.063 L 289.569,394.966 L 275.148,394.966 L 275.148,393.869 L 262.458,393.869 L 262.458,392.772 L 235.34699999999998,392.772 L 235.34699999999998,391.674 L 222.07999999999998,391.674 L 222.07999999999998,390.577 L 263.61100000000005,390.577 L 263.61100000000005,389.48 L 329.947,389.48 L 329.947,388.383 L 351.86600000000004,388.383 L 351.86600000000004,387.286 L 324.755,387.286 L 324.755,386.189 L 271.11,386.189 L 271.11,385.092 L 239.96099999999998,385.092 L 239.96099999999998,383.995 L 231.309,383.995 L 231.309,382.897 L 224.964,382.897 L 224.964,381.8 L 253.22799999999998,381.8 L 253.22799999999998,380.703 L 283.8,380.703 L 283.8,379.606 L 298.221,379.606 L 298.221,378.509 L 275.148,378.509 L 275.148,377.412 L 232.463,377.412 L 232.463,376.315 L 226.117,376.315 L 226.117,375.218 L 227.271,375.218 L 227.271,374.12 L 229.578,374.12 L 229.578,373.023 L 227.271,373.023 L 227.271,371.926 L 224.964,371.926 L 224.964,370.829 L 222.07999999999998,370.829 L 222.07999999999998,369.732 L 229.578,369.732 L 229.578,368.635 L 235.92399999999998,368.635 L 235.92399999999998,367.538 L 247.46,367.538 L 247.46,366.44 L 254.38199999999998,366.44 L 254.38199999999998,365.343 L 248.037,365.343 L 248.037,364.246 L 233.61599999999999,364.246 L 233.61599999999999,363.149 L 215.73399999999998,363.149 L 215.73399999999998,362.052 L 220.926,362.052 L 220.926,360.955 L 231.309,360.955 L 231.309,359.858 L 236.5,359.858 L 236.5,358.761 L 238.808,358.761 L 238.808,357.663 L 238.808,357.663 L 238.808,356.566 L 236.5,356.566 L 236.5,355.469 L 246.883,355.469 L 246.883,354.372 L 232.463,354.372 L 232.463,353.275 L 214.004,353.275 L 214.004,352.178 L 219.195,352.178 L 219.195,351.081 L 234.76999999999998,351.081 L 234.76999999999998,349.984 L 250.34399999999997,349.984 L 250.34399999999997,348.886 L 249.191,348.886 L 249.191,347.789 L 246.307,347.789 L 246.307,346.692 L 228.42499999999998,346.692 L 228.42499999999998,345.595 L 212.85,345.595 L 212.85,344.498 L 227.84799999999998,344.498 L 227.84799999999998,343.401 L 238.231,343.401 L 238.231,342.304 L 233.039,342.304 L 233.039,341.207 L 230.732,341.207 L 230.732,340.109 L 232.463,340.109 L 232.463,339.012 L 239.96099999999998,339.012 L 239.96099999999998,337.915 L 242.26899999999998,337.915 L 242.26899999999998,336.818 L 241.11499999999998,336.818 L 241.11499999999998,335.721 L 245.153,335.721 L 245.153,334.624 L 252.07500000000002,334.624 L 252.07500000000002,333.527 L 254.95899999999997,333.527 L 254.95899999999997,332.43 L 254.95899999999997,332.43 L 254.95899999999997,331.332 L 246.883,331.332 L 246.883,330.235 L 231.309,330.235 L 231.309,329.138 L 226.117,329.138 L 226.117,328.041 L 236.5,328.041 L 236.5,326.944 L 250.92099999999996,326.944 L 250.92099999999996,325.847 L 256.113,325.847 L 256.113,324.75 L 254.95899999999997,324.75 L 254.95899999999997,323.653 L 250.92099999999996,323.653 L 250.92099999999996,322.555 L 253.22799999999998,322.555 L 253.22799999999998,321.458 L 265.91900000000004,321.458 L 265.91900000000004,320.361 L 260.72700000000003,320.361 L 260.72700000000003,319.264 L 251.49799999999996,319.264 L 251.49799999999996,318.167 L 253.80499999999998,318.167 L 253.80499999999998,317.07 L 249.191,317.07 L 249.191,315.973 L 232.463,315.973 L 232.463,314.876 L 224.387,314.876 L 224.387,313.778 L 222.07999999999998,313.778 L 222.07999999999998,312.681 L 216.88799999999998,312.681 L 216.88799999999998,311.584 L 224.387,311.584 L 224.387,310.487 L 234.76999999999998,310.487 L 234.76999999999998,309.39 L 215.73399999999998,309.39 L 215.73399999999998,308.293 L 201.314,308.293 L 201.314,307.196 L 211.697,307.196 L 211.697,306.098 L 208.236,306.098 L 208.236,305.001 L 204.19799999999998,305.001 L 204.19799999999998,303.904 L 236.5,303.904 L 236.5,302.807 L 301.105,302.807 L 301.105,301.71 L 299.952,301.71 L 299.952,300.613 L 263.61100000000005,300.613 L 263.61100000000005,299.516 L 254.38199999999998,299.516 L 254.38199999999998,298.419 L 232.463,298.419 L 232.463,297.321 L 220.926,297.321 L 220.926,296.224 L 219.772,296.224 L 219.772,295.127 L 223.233,295.127 L 223.233,294.03 L 221.503,294.03 L 221.503,292.933 L 216.31099999999998,292.933 L 216.31099999999998,291.836 L 222.07999999999998,291.836 L 222.07999999999998,290.739 L 239.385,290.739 L 239.385,289.642 L 268.803,289.642 L 268.803,288.544 L 340.90700000000004,288.544 L 340.90700000000004,287.447 L 323.02500000000003,287.447 L 323.02500000000003,286.35 L 231.309,286.35 L 231.309,285.253 L 209.38899999999998,285.253 L 209.38899999999998,284.156 L 214.581,284.156 L 214.581,283.059 L 242.846,283.059 L 242.846,281.962 L 241.11499999999998,281.962 L 241.11499999999998,280.865 L 224.387,280.865 L 224.387,279.767 L 212.85,279.767 L 212.85,278.67 L 211.11999999999998,278.67 L 211.11999999999998,277.573 L 228.42499999999998,277.573 L 228.42499999999998,276.476 L 223.81,276.476 L 223.81,275.379 L 219.772,275.379 L 219.772,274.282 L 228.42499999999998,274.282 L 228.42499999999998,273.185 L 231.886,273.185 L 231.886,272.088 L 251.49799999999996,272.088 L 251.49799999999996,270.99 L 265.91900000000004,270.99 L 265.91900000000004,269.893 L 234.76999999999998,269.893 L 234.76999999999998,268.796 L 208.813,268.796 L 208.813,267.699 L 211.11999999999998,267.699 L 211.11999999999998,266.602 L 204.77499999999998,266.602 L 204.77499999999998,265.505 L 202.46699999999998,265.505 L 202.46699999999998,264.408 L 211.697,264.408 L 211.697,263.311 L 214.581,263.311 L 214.581,262.213 L 216.88799999999998,262.213 L 216.88799999999998,261.116 L 218.042,261.116 L 218.042,260.019 L 208.813,260.019 L 208.813,258.922 L 200.737,258.922 L 200.737,257.825 L 207.659,257.825 L 207.659,256.728 L 210.54299999999998,256.728 L 210.54299999999998,255.631 L 208.813,255.631 L 208.813,254.534 L 207.082,254.534 L 207.082,253.436 L 201.891,253.436 L 201.891,252.339 L 207.659,252.339 L 207.659,251.242 L 205.352,251.242 L 205.352,250.145 L 198.42999999999998,250.145 L 198.42999999999998,249.048 L 196.12199999999999,249.048 L 196.12199999999999,247.951 L 187.47,247.951 L 187.47,246.854 L 187.47,246.854 L 187.47,245.756 L 202.46699999999998,245.756 L 202.46699999999998,244.659 L 198.42999999999998,244.659 L 198.42999999999998,243.562 L 192.084,243.562 L 192.084,242.465 L 203.62099999999998,242.465 L 203.62099999999998,241.368 L 190.93099999999998,241.368 L 190.93099999999998,240.271 L 180.548,240.271 L 180.548,239.174 L 207.659,239.174 L 207.659,238.077 L 279.18600000000004,238.077 L 279.18600000000004,236.979 L 344.368,236.979 L 344.368,235.882 L 289.569,235.882 L 289.569,234.785 L 237.077,234.785 L 237.077,233.688 L 278.60900000000004,233.688 L 278.60900000000004,232.591 L 289.569,232.591 L 289.569,231.494 L 244.576,231.494 L 244.576,230.397 L 201.314,230.397 L 201.314,229.3 L 197.27599999999998,229.3 L 197.27599999999998,228.202 L 204.19799999999998,228.202 L 204.19799999999998,227.105 L 209.38899999999998,227.105 L 209.38899999999998,226.008 L 214.004,226.008 L 214.004,224.911 L 207.082,224.911 L 207.082,223.814 L 198.42999999999998,223.814 L 198.42999999999998,222.717 L 214.004,222.717 L 214.004,221.62 L 238.231,221.62 L 238.231,220.523 L 225.541,220.523 L 225.541,219.425 L 206.505,219.425 L 206.505,218.328 L 200.16,218.328 L 200.16,217.231 L 208.813,217.231 L 208.813,216.134 L 218.042,216.134 L 218.042,215.037 L 194.969,215.037 L 194.969,213.94 L 174.203,213.94 L 174.203,212.843 L 174.203,212.843 L 174.203,211.746 L 184.009,211.746 L 184.009,210.648 L 188.047,210.648 L 188.047,209.551 L 182.855,209.551 L 182.855,208.454 L 164.397,208.454 L 164.397,207.357 L 164.397,207.357 L 164.397,206.26 L 196.69899999999998,206.26 L 196.69899999999998,205.163 L 253.80499999999998,205.163 L 253.80499999999998,204.066 L 307.451,204.066 L 307.451,202.969 L 281.493,202.969 L 281.493,201.871 L 248.614,201.871 L 248.614,200.774 L 310.91200000000003,200.774 L 310.91200000000003,199.677 L 373.209,199.677 L 373.209,198.58 L 395.706,198.58 L 395.706,197.483 L 315.526,197.483 L 315.526,196.386 L 203.62099999999998,196.386 L 203.62099999999998,195.289 L 186.893,195.289 L 186.893,194.192 L 178.24099999999999,194.192 L 178.24099999999999,193.094 L 179.39399999999998,193.094 L 179.39399999999998,191.997 L 184.58599999999998,191.997 L 184.58599999999998,190.9 L 186.893,190.9 L 186.893,189.803 L 191.50799999999998,189.803 L 191.50799999999998,188.706 L 177.664,188.706 L 177.664,187.609 L 167.28099999999998,187.609 L 167.28099999999998,186.512 L 159.20499999999998,186.512 L 159.20499999999998,185.415 L 167.28099999999998,185.415 L 167.28099999999998,184.317 L 188.047,184.317 L 188.047,183.22 L 198.42999999999998,183.22 L 198.42999999999998,182.123 L 220.349,182.123 L 220.349,181.026 L 238.231,181.026 L 238.231,179.929 L 256.689,179.929 L 256.689,178.877 L 230.732,178.877 L 230.732,177.78 L 189.2,177.78 L 189.2,176.683 L 203.62099999999998,176.683 L 203.62099999999998,175.586 L 212.85,175.586 L 212.85,174.489 L 200.16,174.489 L 200.16,173.392 L 197.27599999999998,173.392 L 197.27599999999998,172.295 L 203.62099999999998,172.295 L 203.62099999999998,171.198 L 219.195,171.198 L 219.195,170.1 L 218.042,170.1 L 218.042,169.003 L 196.12199999999999,169.003 L 196.12199999999999,167.906 L 197.27599999999998,167.906 L 197.27599999999998,166.809 L 201.314,166.809 L 201.314,165.712 L 158.628,165.712 L 158.628,164.615 L 129.78699999999998,164.615 L 129.78699999999998,163.518 L 114.212,163.518 L 114.212,162.421 L 119.40400000000001,162.421 L 119.40400000000001,161.323 L 148.822,161.323 L 148.822,160.226 L 152.85999999999999,160.226 L 152.85999999999999,159.129 L 155.744,159.129 L 155.744,158.032 L 146.515,158.032 L 146.515,156.935 L 136.13199999999998,156.935 L 136.13199999999998,155.838 L 111.905,155.838 L 111.905,154.741 L 111.905,154.741 L 111.905,153.644 L 139.016,153.644 L 139.016,152.546 L 183.432,152.546 L 183.432,151.449 L 228.42499999999998,151.449 L 228.42499999999998,150.352 L 224.387,150.352 L 224.387,149.255 L 209.38899999999998,149.255 L 209.38899999999998,148.158 L 228.42499999999998,148.158 L 228.42499999999998,147.061 L 247.46,147.061 L 247.46,145.964 L 243.999,145.964 L 243.999,144.867 L 238.808,144.867 L 238.808,143.769 L 226.694,143.769 L 226.694,142.672 L 290.146,142.672 L 290.146,141.575 L 380.13100000000003,141.575 L 380.13100000000003,140.478 L 354.17400000000004,140.478 L 354.17400000000004,139.381 L 248.614,139.381 L 248.614,138.284 L 216.31099999999998,138.284 L 216.31099999999998,137.187 L 250.34399999999997,137.187 L 250.34399999999997,136.089 L 254.38199999999998,136.089 L 254.38199999999998,134.992 L 209.96599999999998,134.992 L 209.96599999999998,133.895 L 175.933,133.895 L 175.933,132.798 L 179.971,132.798 L 179.971,131.701 L 204.77499999999998,131.701 L 204.77499999999998,130.604 L 242.26899999999998,130.604 L 242.26899999999998,129.507 L 246.307,129.507 L 246.307,128.41 L 236.5,128.41 L 236.5,127.312 L 248.037,127.312 L 248.037,126.215 L 255.53599999999997,126.215 L 255.53599999999997,125.118 L 245.153,125.118 L 245.153,124.021 L 237.077,124.021 L 237.077,122.924 L 230.732,122.924 L 230.732,121.827 L 227.271,121.827 L 227.271,120.73 L 200.16,120.73 L 200.16,119.633 L 169.011,119.633 L 169.011,118.535 L 208.813,118.535 L 208.813,117.438 L 250.34399999999997,117.438 L 250.34399999999997,116.341 L 214.004,116.341 L 214.004,115.244 L 177.664,115.244 L 177.664,114.147 L 163.82,114.147 L 163.82,113.05 L 127.479,113.05 L 127.479,111.953 L 101.522,111.953 L 101.522,110.856 L 87.101,110.856 L 87.101,109.758 L 64.605,109.758 L 64.605,108.661 L 67.489,108.661 L 67.489,107.564 L 121.134,107.564 L 121.134,106.467 L 162.666,106.467 L 162.666,105.37 L 153.43699999999998,105.37 L 153.43699999999998,104.273 L 147.66899999999998,104.273 L 147.66899999999998,103.176 L 130.94,103.176 L 130.94,102.079 L 113.059,102.079 L 113.059,100.981 L 125.74900000000001,100.981 L 125.74900000000001,99.884 L 138.439,99.884 L 138.439,98.787 L 169.588,98.787 L 169.588,97.69 L 188.047,97.69 L 188.047,96.593 L 192.084,96.593 L 192.084,95.496 L 209.96599999999998,95.496 L 209.96599999999998,94.399 L 217.465,94.399 L 217.465,93.302 L 224.387,93.302 L 224.387,92.204 L 201.314,92.204 L 201.314,91.107 L 199.583,91.107 L 199.583,90.01 L 220.349,90.01 L 220.349,88.913 L 196.12199999999999,88.913 L 196.12199999999999,87.816 L 198.42999999999998,87.816 L 198.42999999999998,86.719 L 222.65599999999998,86.719 L 222.65599999999998,85.622 L 191.50799999999998,85.622 L 191.50799999999998,84.525 L 160.35899999999998,84.525 L 160.35899999999998,83.427 L 164.397,83.427 L 164.397,82.33 L 194.392,82.33 L 194.392,81.233 L 211.11999999999998,81.233 L 211.11999999999998,80.136 L 200.737,80.136 L 200.737,79.039 L 202.46699999999998,79.039 L 202.46699999999998,77.942 L 215.73399999999998,77.942 L 215.73399999999998,76.845 L 218.042,76.845 L 218.042,75.747 L 198.42999999999998,75.747 L 198.42999999999998,74.65 L 202.46699999999998,74.65 L 202.46699999999998,73.553 L 231.309,73.553 L 231.309,72.456 L 226.117,72.456 L 226.117,71.359 L 201.314,71.359 L 201.314,70.262 L 183.432,70.262 L 183.432,69.165 L 173.04899999999998,69.165 L 173.04899999999998,68.068 L 167.28099999999998,68.068 L 167.28099999999998,66.97 L 158.051,66.97 L 158.051,65.873 L 152.85999999999999,65.873 L 152.85999999999999,64.776 L 145.361,64.776 L 145.361,63.679 L 152.283,63.679 L 152.283,62.582 L 154.59,62.582 L 154.59,61.485 L 139.016,61.485 L 139.016,60.388 L 131.517,60.388 L 131.517,59.291 L 152.283,59.291 L 152.283,58.193 L 180.548,58.193 L 180.548,57.096 L 184.58599999999998,57.096 L 184.58599999999998,55.999 L 183.432,55.999 L 183.432,54.902 L 188.623,54.902 L 188.623,53.805 L 192.661,53.805 L 192.661,52.708 L 222.07999999999998,52.708 L 222.07999999999998,51.611 L 282.647,51.611 L 282.647,50.514 L 370.90200000000004,50.514 L 370.90200000000004,49.416 L 408.973,49.416 L 408.973,48.319 L 338.023,48.319 L 338.023,47.222 L 263.61100000000005,47.222 L 263.61100000000005,46.125 L 252.65200000000002,46.125 L 252.65200000000002,45.028 L 253.80499999999998,45.028 L 253.80499999999998,43.931 L 228.42499999999998,43.931 L 228.42499999999998,42.834 L 216.88799999999998,42.834 L 216.88799999999998,41.737 L 230.732,41.737 L 230.732,40.594 L 239.96099999999998,40.594 L 239.96099999999998,39.497 L 314.372,39.497 L 314.372,38.399 L 396.28200000000004,38.399 L 396.28200000000004,37.302 L 371.47900000000004,37.302 L 371.47900000000004,36.205 L 333.408,36.205 L 333.408,35.108 L 313.796,35.108 L 313.796,34.011 L 278.03200000000004,34.011 L 278.03200000000004,32.914 L 252.07500000000002,32.914 L 252.07500000000002,31.817 L 278.03200000000004,31.817 L 278.03200000000004,30.72 L 316.68,30.72 L 316.68,29.622 L 284.954,29.622 L 284.954,28.525 L 243.999,28.525 L 243.999,27.428 L 238.808,27.428 L 238.808,26.331 L 258.997,26.331 L 258.997,25.234 L 280.339,25.234 L 280.339,24.137 L 262.458,24.137 L 262.458,23.04 L 264.76500000000004,23.04 L 264.76500000000004,21.943 L 245.153,21.943 L 245.153,20.845 L 199.583,20.845 L 199.583,19.748 L 190.35399999999998,19.748 L 190.35399999999998,18.651 L 188.047,18.651 L 188.047,17.554 L 196.12199999999999,17.554 L 196.12199999999999,16.457 L 277.45500000000004,16.457 L 277.45500000000004,15.36 L 389.36,15.36 L 389.36,14.263 L 430.892,14.263 L 430.892,13.166 L 468.386,13.166 L 468.386,12.068 L 437.814,12.068 L 437.814,10.971 L 340.33000000000004,10.971 L 340.33000000000004,9.874 L 294.76,9.874 L 294.76,8.777 L 269.957,8.777 L 269.957,7.68 L 260.72700000000003,7.68 L 260.72700000000003,6.583 L 267.072,6.583 L 267.072,5.486 L 252.65200000000002,5.486 L 252.65200000000002,4.389 L 237.077,4.389 L 237.077,3.291 L 241.11499999999998,3.291 L 241.11499999999998,2.194 L 241.69199999999998,2.194 L 241.69199999999998,1.097 L 244.576,1.097 L 244.576,0 L 244.576,0 Z"
+                fill-opacity="0.85"
+                stroke-width="0"
+                stroke="url(#g-pattern-0)"
+                class="element"
+              />
+            </g>
+          </g>
+          <g
+            id="g-svg-116"
+            fill="none"
+            transform="matrix(1,0,0,1,0,0)"
+            class="label-layer"
+          />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/__tests__/plots/static/index.ts
+++ b/__tests__/plots/static/index.ts
@@ -79,6 +79,7 @@ export { temperatureCompareAreaDifference } from './temperature-compare-area-dif
 export { populationByStateAreaNormalizeStacked } from './population-by-state-area-normalize-stacked';
 export { temperature1LineVarColor } from './temperature1-line-var-color';
 export { temperature2LineGradientColor } from './temperature2-line-gradient-color';
+export { temperature2LineGradientColorTranspose } from './temperature2-line-gradient-color-transpose';
 export { temperature2LineThreshold } from './temperature2-line-threshold';
 export { aapl2CandlestickChart } from './aapl2-candlestick-chart';
 export { tranLineMultiAxes } from './train-line-multi-axes';
@@ -89,6 +90,7 @@ export { seasonalWeatherAreaRadial } from './seasonal-weather-area-radial';
 export { worldHistoryIntervalMultiTickCount } from './world-history-interval-multi-tick-count';
 export { stocksAreaGradient } from './stocks-area-gradient';
 export { temperatures3AreaBandGradient } from './temperatures3-area-band-gradient';
+export { temperatures3AreaBandGradientTranspose } from './temperatures3-area-band-gradient-transpose';
 export { vaccinesCellScaleRelation } from './vaccines-cell-scale-relation';
 export { settleWeatherCellGrouped } from './seattle-weather-cell-grouped';
 export { commitsPointGrouped } from './commits-point-grouped';

--- a/__tests__/plots/static/temperature2-line-gradient-color-transpose.ts
+++ b/__tests__/plots/static/temperature2-line-gradient-color-transpose.ts
@@ -1,0 +1,31 @@
+import { G2Spec } from '../../../src';
+
+export function temperature2LineGradientColorTranspose(): G2Spec {
+  return {
+    type: 'line',
+    height: 1000,
+    data: {
+      type: 'fetch',
+      value: 'data/temperatures2.csv',
+    },
+    scale: {
+      y: { nice: true },
+      x: { utc: true },
+      color: { palette: 'turbo' },
+    },
+    legend: false,
+    coordinate: { transform: [{ type: 'transpose' }] },
+    encode: {
+      x: 'date',
+      y: 'value',
+      shape: 'hvh',
+      color: 'value',
+      series: () => undefined,
+    },
+    style: {
+      gradient: 'y',
+      lineWidth: 2,
+      lineJoin: 'round',
+    },
+  };
+}

--- a/__tests__/plots/static/temperatures3-area-band-gradient-transpose.ts
+++ b/__tests__/plots/static/temperatures3-area-band-gradient-transpose.ts
@@ -1,0 +1,27 @@
+import { G2Spec } from '../../../src';
+
+export function temperatures3AreaBandGradientTranspose(): G2Spec {
+  return {
+    type: 'area',
+    height: 900,
+    data: {
+      type: 'fetch',
+      value: 'data/temperatures3.csv',
+    },
+    scale: {
+      color: { palette: 'reds' },
+    },
+    coordinate: { transform: [{ type: 'transpose' }] },
+    legend: false,
+    encode: {
+      x: 'date',
+      y: ['low', 'high'],
+      shape: 'hvh',
+      color: (d) => d.high - d.low,
+      series: () => undefined,
+    },
+    style: {
+      gradient: 'x',
+    },
+  };
+}

--- a/src/shape/area/curve.ts
+++ b/src/shape/area/curve.ts
@@ -89,8 +89,12 @@ export const Curve: SC<CurveOptions> = (options, context) => {
       seriesX: sx,
       seriesY: sy,
     } = value;
+    const tpShape = isTranspose(coordinate);
     const transform = getTransform(coordinate, value);
-    const fill = gradient && sc ? computeGradient(sc, sx, sy, gradient) : color;
+    const fill =
+      gradient && sc
+        ? computeGradient(sc, sx, sy, gradient, undefined, tpShape)
+        : color;
 
     const finalStyle = {
       ...defaults,
@@ -119,7 +123,7 @@ export const Curve: SC<CurveOptions> = (options, context) => {
       const areaPath = (points) => {
         const Y1 = points.slice(0, points.length / 2);
         const Y0 = points.slice(points.length / 2);
-        return isTranspose(coordinate)
+        return tpShape
           ? area()
               .y((_, idx) => Y1[idx][1])
               .x1((_, idx) => Y1[idx][0])

--- a/src/shape/line/curve.ts
+++ b/src/shape/line/curve.ts
@@ -1,6 +1,6 @@
 import { line, lineRadial, CurveFactory, CurveFactoryLineOnly } from 'd3-shape';
 import { Vector2 } from '@antv/coord';
-import { isPolar } from '../../utils/coordinate';
+import { isPolar, isTranspose } from '../../utils/coordinate';
 import { select } from '../../utils/selection';
 import { ShapeComponent as SC } from '../../runtime';
 import { applyStyle, computeGradient, getTransform } from '../utils';
@@ -89,11 +89,14 @@ export const Curve: SC<CurveOptions> = (options, context) => {
       seriesX: sx,
       seriesY: sy,
     } = value;
+
+    const transform = getTransform(coordinate, value);
+    const tpShape = isTranspose(coordinate);
     const stroke =
       gradient && sc
-        ? computeGradient(sc, sx, sy, gradient, gradientColor)
+        ? computeGradient(sc, sx, sy, gradient, gradientColor, tpShape)
         : color;
-    const transform = getTransform(coordinate, value);
+
     const finalStyle = {
       ...rest,
       ...(stroke && { stroke }),

--- a/src/shape/utils.ts
+++ b/src/shape/utils.ts
@@ -118,10 +118,12 @@ export function computeGradient(
   Y: number[],
   from: string | boolean = 'y',
   mode: 'between' | 'start' | 'end' = 'between',
+  tpShape = false,
 ): string {
-  const P = from === 'y' || from === true ? Y : X;
+  const P = (from === 'y' || from === true) && !tpShape ? Y : X;
   const theta = from === 'y' || from === true ? 90 : 0;
   const I = indexOf(P);
+
   const [min, max] = extent(I, (i) => P[i]);
   // This need to improve for non-uniform distributed colors.
   const p = new Linear({

--- a/src/shape/utils.ts
+++ b/src/shape/utils.ts
@@ -120,8 +120,25 @@ export function computeGradient(
   mode: 'between' | 'start' | 'end' = 'between',
   tpShape = false,
 ): string {
-  const P = (from === 'y' || from === true) && !tpShape ? Y : X;
-  const theta = from === 'y' || from === true ? 90 : 0;
+  // The angles of gradients rendering are varies when 'from' and 'tpShape' are different.
+  const getTheta = (from: string | boolean, tpShape: boolean) => {
+    if (from === 'y' || from === true) {
+      if (tpShape) {
+        return 180;
+      } else {
+        return 90;
+      }
+    } else {
+      if (tpShape) {
+        return 90;
+      } else {
+        return 0;
+      }
+    }
+  };
+
+  const P = from === 'y' || from === true ? Y : X;
+  const theta = getTheta(from, tpShape);
   const I = indexOf(P);
 
   const [min, max] = extent(I, (i) => P[i]);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] benchmarks are included
- [x] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change
* 修复transpose下折线图和面积图渐变颜色的渲染问题。
* 在`style('gradient', 'y')`的情况下，如果设置了`transpose`，渐变的渲染方向应该是从右往左渲染，对应的角度为`180deg`；如果是`style('gradient', 'x')`的情况下，如果设置了`transpose`，则渲染方向是从上往下渲染，对应的角度为`90deg`。
#5361 
![1098109031](https://github.com/antvis/G2/assets/48038769/e68bbe5d-2927-4be3-af0a-05450e5fb98c)
![1098109031](https://github.com/antvis/G2/assets/48038769/5f50c25e-5463-4511-8846-dcb74a6b2949)
![877001303](https://github.com/antvis/G2/assets/48038769/ea20b093-3b2b-4269-93e9-18a2a8ff0d0f)
![2313053411](https://github.com/antvis/G2/assets/48038769/00d58140-e74f-4806-95fb-837aff50598a)

<!-- Provide a description of the change below this comment. -->
