### PR TITLE
fix: dumi-theme-antv footerTheme light

### DIFF
--- a/site/.dumirc.ts
+++ b/site/.dumirc.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     description: 'The Grammar of Visualization in JavaScript',
     defaultLanguage: 'zh', // 默认语言
     isAntVSite: false, // 是否是 AntV 的大官网
+    footerTheme: 'light', // 白色 底部主题
     siteUrl: 'https://antv.antgroup.com/', // 官网首页地址
     githubUrl: repository.url, // GitHub 地址
     showSearch: true, // 是否显示搜索框


### PR DESCRIPTION
修改主页底部 footer 为白色主题 和 官网对齐。
