### PR TITLE
fix: fix subLayoutFacetCircle cal center y problem

### DIFF
--- a/__tests__/integration/snapshots/api/viewFacetCircle.svg
+++ b/__tests__/integration/snapshots/api/viewFacetCircle.svg
@@ -1248,7 +1248,7 @@
       <g
         id="g-svg-19"
         fill="none"
-        transform="matrix(1,0,0,1,332.134460,361.029938)"
+        transform="matrix(1,0,0,1,332.134460,125.954292)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1370,7 +1370,7 @@
       <g
         id="g-svg-20"
         fill="none"
-        transform="matrix(1,0,0,1,390.675415,333.600891)"
+        transform="matrix(1,0,0,1,390.675415,159.219788)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1492,7 +1492,7 @@
       <g
         id="g-svg-21"
         fill="none"
-        transform="matrix(1,0,0,1,424.484772,283.639435)"
+        transform="matrix(1,0,0,1,424.484772,217.448349)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1614,7 +1614,7 @@
       <g
         id="g-svg-22"
         fill="none"
-        transform="matrix(1,0,0,1,424.353973,224.753403)"
+        transform="matrix(1,0,0,1,424.353973,284.780518)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1736,7 +1736,7 @@
       <g
         id="g-svg-23"
         fill="none"
-        transform="matrix(1,0,0,1,390.318665,172.981293)"
+        transform="matrix(1,0,0,1,390.318665,342.877289)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1858,7 +1858,7 @@
       <g
         id="g-svg-24"
         fill="none"
-        transform="matrix(1,0,0,1,331.648895,142.424118)"
+        transform="matrix(1,0,0,1,331.648895,375.915100)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1980,7 +1980,7 @@
       <g
         id="g-svg-25"
         fill="none"
-        transform="matrix(1,0,0,1,264.324310,141.404572)"
+        transform="matrix(1,0,0,1,264.324310,374.895538)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -2102,7 +2102,7 @@
       <g
         id="g-svg-26"
         fill="none"
-        transform="matrix(1,0,0,1,206.681854,170.200363)"
+        transform="matrix(1,0,0,1,206.681854,340.096344)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -2224,7 +2224,7 @@
       <g
         id="g-svg-27"
         fill="none"
-        transform="matrix(1,0,0,1,174.421356,220.968491)"
+        transform="matrix(1,0,0,1,174.421356,280.995605)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -2346,7 +2346,7 @@
       <g
         id="g-svg-28"
         fill="none"
-        transform="matrix(1,0,0,1,176.329468,279.881470)"
+        transform="matrix(1,0,0,1,176.329468,213.690369)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -2468,7 +2468,7 @@
       <g
         id="g-svg-29"
         fill="none"
-        transform="matrix(1,0,0,1,211.886490,330.893372)"
+        transform="matrix(1,0,0,1,211.886490,156.512253)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -2590,7 +2590,7 @@
       <g
         id="g-svg-30"
         fill="none"
-        transform="matrix(1,0,0,1,271.407898,360.110321)"
+        transform="matrix(1,0,0,1,271.407898,125.034668)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">

--- a/__tests__/integration/snapshots/static/monthIntervalFacetCircle.svg
+++ b/__tests__/integration/snapshots/static/monthIntervalFacetCircle.svg
@@ -1248,7 +1248,7 @@
       <g
         id="g-svg-19"
         fill="none"
-        transform="matrix(1,0,0,1,252.134460,361.029938)"
+        transform="matrix(1,0,0,1,252.134460,125.954292)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1370,7 +1370,7 @@
       <g
         id="g-svg-20"
         fill="none"
-        transform="matrix(1,0,0,1,310.675415,333.600891)"
+        transform="matrix(1,0,0,1,310.675415,159.219788)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1492,7 +1492,7 @@
       <g
         id="g-svg-21"
         fill="none"
-        transform="matrix(1,0,0,1,344.484772,283.639435)"
+        transform="matrix(1,0,0,1,344.484772,217.448349)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1614,7 +1614,7 @@
       <g
         id="g-svg-22"
         fill="none"
-        transform="matrix(1,0,0,1,344.353973,224.753403)"
+        transform="matrix(1,0,0,1,344.353973,284.780518)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1736,7 +1736,7 @@
       <g
         id="g-svg-23"
         fill="none"
-        transform="matrix(1,0,0,1,310.318665,172.981293)"
+        transform="matrix(1,0,0,1,310.318665,342.877289)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1858,7 +1858,7 @@
       <g
         id="g-svg-24"
         fill="none"
-        transform="matrix(1,0,0,1,251.648895,142.424118)"
+        transform="matrix(1,0,0,1,251.648895,375.915100)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -1980,7 +1980,7 @@
       <g
         id="g-svg-25"
         fill="none"
-        transform="matrix(1,0,0,1,184.324326,141.404572)"
+        transform="matrix(1,0,0,1,184.324326,374.895538)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -2102,7 +2102,7 @@
       <g
         id="g-svg-26"
         fill="none"
-        transform="matrix(1,0,0,1,126.681862,170.200363)"
+        transform="matrix(1,0,0,1,126.681862,340.096344)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -2224,7 +2224,7 @@
       <g
         id="g-svg-27"
         fill="none"
-        transform="matrix(1,0,0,1,94.421356,220.968491)"
+        transform="matrix(1,0,0,1,94.421356,280.995605)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -2346,7 +2346,7 @@
       <g
         id="g-svg-28"
         fill="none"
-        transform="matrix(1,0,0,1,96.329468,279.881470)"
+        transform="matrix(1,0,0,1,96.329468,213.690369)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -2468,7 +2468,7 @@
       <g
         id="g-svg-29"
         fill="none"
-        transform="matrix(1,0,0,1,131.886490,330.893372)"
+        transform="matrix(1,0,0,1,131.886490,156.512253)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">
@@ -2590,7 +2590,7 @@
       <g
         id="g-svg-30"
         fill="none"
-        transform="matrix(1,0,0,1,191.407898,360.110321)"
+        transform="matrix(1,0,0,1,191.407898,125.034668)"
         class="view"
       >
         <g transform="matrix(1,0,0,1,0,0)">

--- a/src/composition/facetCircle.ts
+++ b/src/composition/facetCircle.ts
@@ -71,7 +71,7 @@ function subLayoutFacetCircle(data) {
   const a3 = a0 + a01 / 2;
   const d = ir * t;
   const cx = x0 + d * Math.sin(a3); // center x of inscribed circle
-  const cy = y0 + d * Math.cos(a3); // center y of inscribed circle
+  const cy = y0 - d * Math.cos(a3); // center y of inscribed circle
   return [cx - s / 2, cy - s / 2, s, s];
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] benchmarks are included
- [x] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change

###### 解决问题
使用facetCircle绘制时，月份的数据和具体图表对应不上的问题 https://github.com/antvis/G2/issues/5624

###### 解决办法
处理在会只过程中对于子坐标系的原点计算的逻辑

###### Demo
```ts
import { Chart } from '../../../src';

export function viewFacetCircle(context) {
  const { container, canvas } = context;

  const M = [
    'Jan.',
    'Feb.',
    'Mar.',
    'Apr.',
    'May',
    'Jun.',
    'Jul.',
    'Aug.',
    'Sept.',
    'Oct.',
    'Nov.',
    'Dec.',
  ];
  const N = ['A', 'B', 'C', 'D'];
  const data = M.flatMap((month, i) =>
    N.map((name, j) => ({
      month,
      name,
      value: i + j,
    })),
  );

  const chart = new Chart({
    container: container,
    canvas,
  });

  const facetCircle = chart
    .facetCircle()
    .data(data)
    .encode('position', 'month');

  facetCircle
    .interval()
    .encode('x', 'name')
    .encode('y', 'value')
    .encode('color', 'name');

  const finished = chart.render();

  return { chart, finished };
}
```
###### 修复前
![image](https://github.com/antvis/G2/assets/25734833/86f5d30d-43bf-4912-a1c1-63cc03d24f45)

###### 修复后
![image](https://github.com/antvis/G2/assets/25734833/60c13cda-558f-42b4-863a-297fa51a8072)


<!-- Provide a description of the change below this comment. -->
