### PR TITLE
fix(interaction): reapply some interactions when update

### DIFF
--- a/__tests__/integration/snapshots/api/chart-emit-scrollbar-filter/step0.svg
+++ b/__tests__/integration/snapshots/api/chart-emit-scrollbar-filter/step0.svg
@@ -7,7 +7,7 @@
 >
   <defs>
     <path
-      id="g-svg-110"
+      id="g-svg-198"
       fill="none"
       d="M 0,0 l 282.71999970563456,0 l 0,350 l-282.71999970563456 0 z"
       width="282.71999970563456"
@@ -15,12 +15,12 @@
     />
     <clipPath
       transform="matrix(1,0,0,1,-101.279999,-16)"
-      id="clip-path-110-107"
+      id="clip-path-198-107"
     >
-      <use href="#g-svg-110" transform="matrix(1,0,0,1,101.279999,16)" />
+      <use href="#g-svg-198" transform="matrix(1,0,0,1,101.279999,16)" />
     </clipPath>
     <path
-      id="g-svg-140"
+      id="g-svg-228"
       fill="none"
       d="M 0,0 l 282.71999970563456,0 l 0,350 l-282.71999970563456 0 z"
       width="282.71999970563456"
@@ -28,9 +28,9 @@
     />
     <clipPath
       transform="matrix(1,0,0,1,-101.279999,-16)"
-      id="clip-path-140-107"
+      id="clip-path-228-107"
     >
-      <use href="#g-svg-140" transform="matrix(1,0,0,1,101.279999,16)" />
+      <use href="#g-svg-228" transform="matrix(1,0,0,1,101.279999,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -348,7 +348,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-117"
+                      id="g-svg-205"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -369,7 +369,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-118"
+                      id="g-svg-206"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -390,7 +390,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-119"
+                      id="g-svg-207"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -411,7 +411,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-120"
+                      id="g-svg-208"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -432,7 +432,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-121"
+                      id="g-svg-209"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -460,7 +460,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-122"
+                      id="g-svg-210"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -488,7 +488,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-123"
+                      id="g-svg-211"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -516,7 +516,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-124"
+                      id="g-svg-212"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -544,7 +544,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-125"
+                      id="g-svg-213"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -572,7 +572,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-126"
+                      id="g-svg-214"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -620,6 +620,300 @@
                 >
                   date
                 </text>
+              </g>
+            </g>
+            <g
+              id="g-svg-125"
+              fill="none"
+              class="offscreen"
+              transform="matrix(1,0,0,1,0,0)"
+            >
+              <g
+                id="g-svg-126"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,101.279999,366)">
+                  <line
+                    id="g-svg-127"
+                    fill="none"
+                    x1="0"
+                    y1="0"
+                    x2="282.71999970563456"
+                    y2="0"
+                    visibility="hidden"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-128"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-129"
+                  fill="none"
+                  transform="matrix(1,0,0,1,131.769409,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-134"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-130"
+                  fill="none"
+                  transform="matrix(1,0,0,1,187.204712,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-135"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-131"
+                  fill="none"
+                  transform="matrix(1,0,0,1,242.639999,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-136"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-132"
+                  fill="none"
+                  transform="matrix(1,0,0,1,298.075287,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-137"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-133"
+                  fill="none"
+                  transform="matrix(1,0,0,1,353.510590,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-138"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-139"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-140"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,131.769409,374)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-145"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-01
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-141"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,187.204712,374)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-146"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-02
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-142"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,242.639999,374)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-147"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-03
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-143"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,298.075287,374)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-148"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-04
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-144"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,353.510590,374)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-149"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-05
+                    </text>
+                  </g>
+                </g>
               </g>
             </g>
           </g>
@@ -765,7 +1059,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-129"
+                      id="g-svg-217"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -786,7 +1080,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-130"
+                      id="g-svg-218"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -807,7 +1101,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-131"
+                      id="g-svg-219"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -828,7 +1122,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-132"
+                      id="g-svg-220"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -849,7 +1143,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-133"
+                      id="g-svg-221"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -877,7 +1171,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-134"
+                      id="g-svg-222"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -905,7 +1199,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-135"
+                      id="g-svg-223"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -933,7 +1227,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-136"
+                      id="g-svg-224"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -961,7 +1255,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-137"
+                      id="g-svg-225"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -989,7 +1283,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-138"
+                      id="g-svg-226"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1038,11 +1332,305 @@
                 </text>
               </g>
             </g>
+            <g
+              id="g-svg-162"
+              fill="none"
+              class="offscreen"
+              transform="matrix(1,0,0,1,0,0)"
+            >
+              <g
+                id="g-svg-163"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,101.279999,16)">
+                  <line
+                    id="g-svg-164"
+                    fill="none"
+                    x1="0"
+                    y1="350"
+                    x2="0"
+                    y2="0"
+                    visibility="hidden"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-165"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-166"
+                  fill="none"
+                  transform="matrix(1,0,0,1,101.279999,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-171"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-167"
+                  fill="none"
+                  transform="matrix(1,0,0,1,101.279999,288.222229)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-172"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-168"
+                  fill="none"
+                  transform="matrix(1,0,0,1,101.279999,210.444443)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-173"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-169"
+                  fill="none"
+                  transform="matrix(1,0,0,1,101.279999,132.666672)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-174"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-170"
+                  fill="none"
+                  transform="matrix(1,0,0,1,101.279999,54.888889)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-175"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-176"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-177"
+                  fill="none"
+                  transform="matrix(1,0,0,1,93.279999,366)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-182"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      0
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-178"
+                  fill="none"
+                  transform="matrix(1,0,0,1,93.279999,288.222229)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-183"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      100
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-179"
+                  fill="none"
+                  transform="matrix(1,0,0,1,93.279999,210.444443)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-184"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      200
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-180"
+                  fill="none"
+                  transform="matrix(1,0,0,1,93.279999,132.666672)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-185"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      300
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-181"
+                  fill="none"
+                  transform="matrix(1,0,0,1,93.279999,54.888889)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-186"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      400
+                    </text>
+                  </g>
+                </g>
+              </g>
+            </g>
           </g>
         </g>
         <g
           transform="matrix(1,0,0,1,101.279999,16)"
-          clip-path="url(#clip-path-140-107)"
+          clip-path="url(#clip-path-228-107)"
         >
           <path
             id="g-svg-107"
@@ -1060,7 +1648,7 @@
           >
             <g transform="matrix(1,0,0,1,5.543530,-38.888889)">
               <path
-                id="g-svg-113"
+                id="g-svg-201"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 49.89176465393551,0 l 0,388.8888888888889 l-49.89176465393551 0 z"
                 width="49.89176465393551"
@@ -1073,7 +1661,7 @@
             </g>
             <g transform="matrix(1,0,0,1,60.978825,-116.666664)">
               <path
-                id="g-svg-114"
+                id="g-svg-202"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 49.89176465393551,0 l 0,466.66666666666663 l-49.89176465393551 0 z"
                 width="49.89176465393551"
@@ -1086,7 +1674,7 @@
             </g>
             <g transform="matrix(1,0,0,1,116.414116,116.666664)">
               <path
-                id="g-svg-115"
+                id="g-svg-203"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 49.891764653935496,0 l 0,233.33333333333331 l-49.891764653935496 0 z"
                 width="49.891764653935496"
@@ -1099,7 +1687,7 @@
             </g>
             <g transform="matrix(1,0,0,1,171.849411,-116.666664)">
               <path
-                id="g-svg-141"
+                id="g-svg-229"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 49.891764653935496,0 l 0,466.66666666666663 l-49.891764653935496 0 z"
                 width="49.891764653935496"
@@ -1112,7 +1700,7 @@
             </g>
             <g transform="matrix(1,0,0,1,227.284698,116.666664)">
               <path
-                id="g-svg-142"
+                id="g-svg-230"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 49.89176465393547,0 l 0,233.33333333333331 l-49.89176465393547 0 z"
                 width="49.89176465393547"

--- a/__tests__/integration/snapshots/api/chart-emit-scrollbar-filter/step1.svg
+++ b/__tests__/integration/snapshots/api/chart-emit-scrollbar-filter/step1.svg
@@ -7,7 +7,7 @@
 >
   <defs>
     <path
-      id="g-svg-110"
+      id="g-svg-198"
       fill="none"
       d="M 0,0 l 282.71999970563456,0 l 0,350 l-282.71999970563456 0 z"
       width="282.71999970563456"
@@ -15,12 +15,12 @@
     />
     <clipPath
       transform="matrix(1,0,0,1,-101.279999,-16)"
-      id="clip-path-110-107"
+      id="clip-path-198-107"
     >
-      <use href="#g-svg-110" transform="matrix(1,0,0,1,101.279999,16)" />
+      <use href="#g-svg-198" transform="matrix(1,0,0,1,101.279999,16)" />
     </clipPath>
     <path
-      id="g-svg-140"
+      id="g-svg-228"
       fill="none"
       d="M 0,0 l 282.71999970563456,0 l 0,350 l-282.71999970563456 0 z"
       width="282.71999970563456"
@@ -28,12 +28,12 @@
     />
     <clipPath
       transform="matrix(1,0,0,1,-101.279999,-16)"
-      id="clip-path-140-107"
+      id="clip-path-228-107"
     >
-      <use href="#g-svg-140" transform="matrix(1,0,0,1,101.279999,16)" />
+      <use href="#g-svg-228" transform="matrix(1,0,0,1,101.279999,16)" />
     </clipPath>
     <path
-      id="g-svg-170"
+      id="g-svg-258"
       fill="none"
       d="M 0,0 l 282.71999970563456,0 l 0,350 l-282.71999970563456 0 z"
       width="282.71999970563456"
@@ -41,9 +41,9 @@
     />
     <clipPath
       transform="matrix(1,0,0,1,-101.279999,-16)"
-      id="clip-path-170-107"
+      id="clip-path-258-107"
     >
-      <use href="#g-svg-170" transform="matrix(1,0,0,1,101.279999,16)" />
+      <use href="#g-svg-258" transform="matrix(1,0,0,1,101.279999,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -363,7 +363,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-147"
+                      id="g-svg-235"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -384,7 +384,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-148"
+                      id="g-svg-236"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -405,7 +405,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-149"
+                      id="g-svg-237"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -426,7 +426,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-150"
+                      id="g-svg-238"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -447,7 +447,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-151"
+                      id="g-svg-239"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -475,7 +475,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-152"
+                      id="g-svg-240"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -503,7 +503,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-153"
+                      id="g-svg-241"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -531,7 +531,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-154"
+                      id="g-svg-242"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -559,7 +559,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-155"
+                      id="g-svg-243"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -587,7 +587,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-156"
+                      id="g-svg-244"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -635,6 +635,300 @@
                 >
                   date
                 </text>
+              </g>
+            </g>
+            <g
+              id="g-svg-125"
+              fill="none"
+              class="offscreen"
+              transform="matrix(1,0,0,1,0,0)"
+            >
+              <g
+                id="g-svg-126"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,101.279999,366)">
+                  <line
+                    id="g-svg-127"
+                    fill="none"
+                    x1="0"
+                    y1="0"
+                    x2="282.71999970563456"
+                    y2="0"
+                    visibility="hidden"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-128"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-129"
+                  fill="none"
+                  transform="matrix(1,0,0,1,131.769409,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-134"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-130"
+                  fill="none"
+                  transform="matrix(1,0,0,1,187.204712,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-135"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-131"
+                  fill="none"
+                  transform="matrix(1,0,0,1,242.639999,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-136"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-132"
+                  fill="none"
+                  transform="matrix(1,0,0,1,298.075287,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-137"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-133"
+                  fill="none"
+                  transform="matrix(1,0,0,1,353.510590,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-138"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-139"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-140"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,131.769409,374)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-145"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-01
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-141"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,187.204712,374)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-146"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-02
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-142"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,242.639999,374)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-147"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-03
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-143"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,298.075287,374)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-148"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-04
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-144"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,353.510590,374)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-149"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-05
+                    </text>
+                  </g>
+                </g>
               </g>
             </g>
           </g>
@@ -780,7 +1074,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-159"
+                      id="g-svg-247"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -801,7 +1095,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-160"
+                      id="g-svg-248"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -822,7 +1116,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-161"
+                      id="g-svg-249"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -843,7 +1137,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-162"
+                      id="g-svg-250"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -864,7 +1158,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-163"
+                      id="g-svg-251"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -892,7 +1186,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-164"
+                      id="g-svg-252"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -920,7 +1214,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-165"
+                      id="g-svg-253"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -948,7 +1242,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-166"
+                      id="g-svg-254"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -976,7 +1270,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-167"
+                      id="g-svg-255"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1004,7 +1298,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-168"
+                      id="g-svg-256"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1029,7 +1323,7 @@
             <g
               id="g-svg-104"
               fill="none"
-              transform="matrix(1,0,0,1,35,185.250000)"
+              transform="matrix(1,0,0,1,35,196.750000)"
               class="axis-title-group"
             >
               <g transform="matrix(0,-1,1,0,11.500000,0)">
@@ -1053,11 +1347,305 @@
                 </text>
               </g>
             </g>
+            <g
+              id="g-svg-162"
+              fill="none"
+              class="offscreen"
+              transform="matrix(1,0,0,1,0,0)"
+            >
+              <g
+                id="g-svg-163"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,101.279999,16)">
+                  <line
+                    id="g-svg-164"
+                    fill="none"
+                    x1="0"
+                    y1="350"
+                    x2="0"
+                    y2="0"
+                    visibility="hidden"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-165"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-166"
+                  fill="none"
+                  transform="matrix(1,0,0,1,101.279999,366)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-171"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-167"
+                  fill="none"
+                  transform="matrix(1,0,0,1,101.279999,288.222229)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-172"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-168"
+                  fill="none"
+                  transform="matrix(1,0,0,1,101.279999,210.444443)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-173"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-169"
+                  fill="none"
+                  transform="matrix(1,0,0,1,101.279999,132.666672)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-174"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-170"
+                  fill="none"
+                  transform="matrix(1,0,0,1,101.279999,54.888889)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-175"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-176"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-177"
+                  fill="none"
+                  transform="matrix(1,0,0,1,93.279999,366)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-182"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      0
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-178"
+                  fill="none"
+                  transform="matrix(1,0,0,1,93.279999,288.222229)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-183"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      100
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-179"
+                  fill="none"
+                  transform="matrix(1,0,0,1,93.279999,210.444443)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-184"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      200
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-180"
+                  fill="none"
+                  transform="matrix(1,0,0,1,93.279999,132.666672)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-185"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      300
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-181"
+                  fill="none"
+                  transform="matrix(1,0,0,1,93.279999,54.888889)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-186"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      400
+                    </text>
+                  </g>
+                </g>
+              </g>
+            </g>
           </g>
         </g>
         <g
           transform="matrix(1,0,0,1,101.279999,16)"
-          clip-path="url(#clip-path-170-107)"
+          clip-path="url(#clip-path-258-107)"
         >
           <path
             id="g-svg-107"
@@ -1075,7 +1663,7 @@
           >
             <g transform="matrix(1,0,0,1,5.543530,0)">
               <path
-                id="g-svg-113"
+                id="g-svg-201"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 49.89176465393551,0 l 0,388.8888888888889 l-49.89176465393551 0 z"
                 width="49.89176465393551"
@@ -1088,7 +1676,7 @@
             </g>
             <g transform="matrix(1,0,0,1,60.978825,-77.777779)">
               <path
-                id="g-svg-114"
+                id="g-svg-202"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 49.89176465393551,0 l 0,466.66666666666674 l-49.89176465393551 0 z"
                 width="49.89176465393551"
@@ -1101,7 +1689,7 @@
             </g>
             <g transform="matrix(1,0,0,1,116.414116,155.555557)">
               <path
-                id="g-svg-115"
+                id="g-svg-203"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 49.891764653935496,0 l 0,233.33333333333337 l-49.891764653935496 0 z"
                 width="49.891764653935496"
@@ -1114,7 +1702,7 @@
             </g>
             <g transform="matrix(1,0,0,1,171.849411,-77.777779)">
               <path
-                id="g-svg-141"
+                id="g-svg-229"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 49.891764653935496,0 l 0,466.66666666666674 l-49.891764653935496 0 z"
                 width="49.891764653935496"
@@ -1127,7 +1715,7 @@
             </g>
             <g transform="matrix(1,0,0,1,227.284698,155.555557)">
               <path
-                id="g-svg-142"
+                id="g-svg-230"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 49.89176465393547,0 l 0,233.33333333333337 l-49.89176465393547 0 z"
                 width="49.89176465393547"

--- a/__tests__/integration/snapshots/api/chart-emit-slider-filter/step0.svg
+++ b/__tests__/integration/snapshots/api/chart-emit-slider-filter/step0.svg
@@ -7,7 +7,7 @@
 >
   <defs>
     <path
-      id="g-svg-276"
+      id="g-svg-506"
       fill="none"
       d="M 0,0 l 504.71999970563456,0 l 0,312 l-504.71999970563456 0 z"
       width="504.71999970563456"
@@ -15,9 +15,9 @@
     />
     <clipPath
       transform="matrix(1,0,0,1,-119.279999,-16)"
-      id="clip-path-276-217"
+      id="clip-path-506-217"
     >
-      <use href="#g-svg-276" transform="matrix(1,0,0,1,119.279999,16)" />
+      <use href="#g-svg-506" transform="matrix(1,0,0,1,119.279999,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -187,14 +187,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-242"
+                    id="g-svg-472"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-243"
+                        id="g-svg-473"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -206,7 +206,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-244"
+                          id="g-svg-474"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -220,7 +220,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-245"
+                          id="g-svg-475"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -272,14 +272,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-248"
+                    id="g-svg-478"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-249"
+                        id="g-svg-479"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -291,7 +291,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-250"
+                          id="g-svg-480"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -305,7 +305,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-251"
+                          id="g-svg-481"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -437,14 +437,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-63"
+                    id="g-svg-264"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-64"
+                        id="g-svg-265"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -456,7 +456,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-65"
+                          id="g-svg-266"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -470,7 +470,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-66"
+                          id="g-svg-267"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -522,14 +522,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-73"
+                    id="g-svg-270"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-74"
+                        id="g-svg-271"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -541,7 +541,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-75"
+                          id="g-svg-272"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -555,7 +555,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-76"
+                          id="g-svg-273"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -657,7 +657,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-253"
+                      id="g-svg-483"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -678,7 +678,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-254"
+                      id="g-svg-484"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -699,7 +699,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-255"
+                      id="g-svg-485"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -727,7 +727,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-256"
+                      id="g-svg-486"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -755,7 +755,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-257"
+                      id="g-svg-487"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -783,7 +783,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-258"
+                      id="g-svg-488"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -808,7 +808,7 @@
             <g
               id="g-svg-166"
               fill="none"
-              transform="matrix(1,0,0,1,371.639984,421.679993)"
+              transform="matrix(1,0,0,1,371.639984,423.600006)"
               class="axis-title-group"
             >
               <g transform="matrix(1,0,0,1,0,0)">
@@ -831,6 +831,1050 @@
                 >
                   date
                 </text>
+              </g>
+            </g>
+            <g
+              id="g-svg-275"
+              fill="none"
+              class="offscreen"
+              transform="matrix(1,0,0,1,0,0)"
+            >
+              <g
+                id="g-svg-276"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,119.279999,328)">
+                  <line
+                    id="g-svg-277"
+                    fill="none"
+                    x1="0"
+                    y1="0"
+                    x2="504.71999970563456"
+                    y2="0"
+                    visibility="hidden"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-278"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-279"
+                  fill="none"
+                  transform="matrix(1,0,0,1,133.090744,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-299"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-280"
+                  fill="none"
+                  transform="matrix(1,0,0,1,158.201187,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-300"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-281"
+                  fill="none"
+                  transform="matrix(1,0,0,1,183.311646,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-301"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-282"
+                  fill="none"
+                  transform="matrix(1,0,0,1,208.422089,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-302"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-283"
+                  fill="none"
+                  transform="matrix(1,0,0,1,233.532532,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-303"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-284"
+                  fill="none"
+                  transform="matrix(1,0,0,1,258.642975,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-304"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-285"
+                  fill="none"
+                  transform="matrix(1,0,0,1,283.753418,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-305"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-286"
+                  fill="none"
+                  transform="matrix(1,0,0,1,308.863892,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-306"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-287"
+                  fill="none"
+                  transform="matrix(1,0,0,1,333.974335,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-307"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-288"
+                  fill="none"
+                  transform="matrix(1,0,0,1,359.084778,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-308"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-289"
+                  fill="none"
+                  transform="matrix(1,0,0,1,384.195221,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-309"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-290"
+                  fill="none"
+                  transform="matrix(1,0,0,1,409.305664,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-310"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-291"
+                  fill="none"
+                  transform="matrix(1,0,0,1,434.416107,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-311"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-292"
+                  fill="none"
+                  transform="matrix(1,0,0,1,459.526581,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-312"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-293"
+                  fill="none"
+                  transform="matrix(1,0,0,1,484.637024,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-313"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-294"
+                  fill="none"
+                  transform="matrix(1,0,0,1,509.747467,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-314"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-295"
+                  fill="none"
+                  transform="matrix(1,0,0,1,534.857910,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-315"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-296"
+                  fill="none"
+                  transform="matrix(1,0,0,1,559.968384,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-316"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-297"
+                  fill="none"
+                  transform="matrix(1,0,0,1,585.078796,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-317"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-298"
+                  fill="none"
+                  transform="matrix(1,0,0,1,610.189270,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-318"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-319"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-320"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,133.090744,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-340"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-01
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-321"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,158.201187,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-341"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-02
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-322"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,183.311646,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-342"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-03
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-323"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,208.422089,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-343"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-04
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-324"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,233.532532,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-344"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-05
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-325"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,258.642975,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-345"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-06
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-326"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,283.753418,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-346"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-07
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-327"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,308.863892,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-347"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-08
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-328"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,333.974335,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-348"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-09
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-329"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,359.084778,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-349"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-10
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-330"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,384.195221,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-350"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-11
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-331"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,409.305664,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-351"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-12
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-332"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,434.416107,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-352"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-01
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-333"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,459.526581,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-353"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-02
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-334"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,484.637024,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-354"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-03
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-335"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,509.747467,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-355"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-04
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-336"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,534.857910,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-356"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-05
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-337"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,559.968384,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-357"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-06
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-338"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,585.078796,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-358"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-07
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-339"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,610.189270,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-359"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-08
+                    </text>
+                  </g>
+                </g>
               </g>
             </g>
           </g>
@@ -1000,7 +2044,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-261"
+                      id="g-svg-491"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1021,7 +2065,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-262"
+                      id="g-svg-492"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1042,7 +2086,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-263"
+                      id="g-svg-493"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1063,7 +2107,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-264"
+                      id="g-svg-494"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1084,7 +2128,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-265"
+                      id="g-svg-495"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1105,7 +2149,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-266"
+                      id="g-svg-496"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1126,7 +2170,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-267"
+                      id="g-svg-497"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1154,7 +2198,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-268"
+                      id="g-svg-498"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1182,7 +2226,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-269"
+                      id="g-svg-499"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1210,7 +2254,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-270"
+                      id="g-svg-500"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1238,7 +2282,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-271"
+                      id="g-svg-501"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1266,7 +2310,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-272"
+                      id="g-svg-502"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1294,7 +2338,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-273"
+                      id="g-svg-503"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1322,7 +2366,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-274"
+                      id="g-svg-504"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1371,11 +2415,405 @@
                 </text>
               </g>
             </g>
+            <g
+              id="g-svg-402"
+              fill="none"
+              class="offscreen"
+              transform="matrix(1,0,0,1,0,0)"
+            >
+              <g
+                id="g-svg-403"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,119.279999,16)">
+                  <line
+                    id="g-svg-404"
+                    fill="none"
+                    x1="0"
+                    y1="312"
+                    x2="0"
+                    y2="0"
+                    visibility="hidden"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-405"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-406"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-413"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-407"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,276)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-414"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-408"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,224)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-415"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-409"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,172)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-416"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-410"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,120)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-417"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-411"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,68)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-418"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-412"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,16)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-419"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-420"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-421"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,328)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-428"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      0
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-422"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,276)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-429"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      100
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-423"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,224)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-430"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      200
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-424"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,172)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-431"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      300
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-425"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,120)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-432"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      400
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-426"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,68)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-433"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      500
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-427"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,16)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-434"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      600
+                    </text>
+                  </g>
+                </g>
+              </g>
+            </g>
           </g>
         </g>
         <g
           transform="matrix(1,0,0,1,119.279999,16)"
-          clip-path="url(#clip-path-276-217)"
+          clip-path="url(#clip-path-506-217)"
         >
           <path
             id="g-svg-217"
@@ -1393,7 +2831,7 @@
           >
             <g transform="matrix(1,0,0,1,16.281290,260)">
               <path
-                id="g-svg-220"
+                id="g-svg-450"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 146.53161281776488,0 l 0,52 l-146.53161281776488 0 z"
                 width="146.53161281776488"
@@ -1406,7 +2844,7 @@
             </g>
             <g transform="matrix(1,0,0,1,179.094193,104)">
               <path
-                id="g-svg-221"
+                id="g-svg-451"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 146.53161281776494,0 l 0,208 l-146.53161281776494 0 z"
                 width="146.53161281776494"
@@ -1419,7 +2857,7 @@
             </g>
             <g transform="matrix(1,0,0,1,341.907104,52)">
               <path
-                id="g-svg-222"
+                id="g-svg-452"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 146.53161281776482,0 l 0,260 l-146.53161281776482 0 z"
                 width="146.53161281776482"

--- a/__tests__/integration/snapshots/api/chart-emit-slider-filter/step1.svg
+++ b/__tests__/integration/snapshots/api/chart-emit-slider-filter/step1.svg
@@ -7,7 +7,7 @@
 >
   <defs>
     <path
-      id="g-svg-276"
+      id="g-svg-506"
       fill="none"
       d="M 0,0 l 504.71999970563456,0 l 0,312 l-504.71999970563456 0 z"
       width="504.71999970563456"
@@ -15,12 +15,12 @@
     />
     <clipPath
       transform="matrix(1,0,0,1,-119.279999,-16)"
-      id="clip-path-276-217"
+      id="clip-path-506-217"
     >
-      <use href="#g-svg-276" transform="matrix(1,0,0,1,119.279999,16)" />
+      <use href="#g-svg-506" transform="matrix(1,0,0,1,119.279999,16)" />
     </clipPath>
     <path
-      id="g-svg-312"
+      id="g-svg-542"
       fill="none"
       d="M 0,0 l 504.71999970563456,0 l 0,312 l-504.71999970563456 0 z"
       width="504.71999970563456"
@@ -28,9 +28,9 @@
     />
     <clipPath
       transform="matrix(1,0,0,1,-119.279999,-16)"
-      id="clip-path-312-217"
+      id="clip-path-542-217"
     >
-      <use href="#g-svg-312" transform="matrix(1,0,0,1,119.279999,16)" />
+      <use href="#g-svg-542" transform="matrix(1,0,0,1,119.279999,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -200,14 +200,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-242"
+                    id="g-svg-472"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-243"
+                        id="g-svg-473"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -219,7 +219,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-244"
+                          id="g-svg-474"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -233,7 +233,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-245"
+                          id="g-svg-475"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -285,14 +285,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-248"
+                    id="g-svg-478"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-249"
+                        id="g-svg-479"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -304,7 +304,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-250"
+                          id="g-svg-480"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -318,7 +318,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-251"
+                          id="g-svg-481"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -454,14 +454,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-282"
+                    id="g-svg-512"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-283"
+                        id="g-svg-513"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -473,7 +473,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-284"
+                          id="g-svg-514"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -487,7 +487,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-285"
+                          id="g-svg-515"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -539,14 +539,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-288"
+                    id="g-svg-518"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-289"
+                        id="g-svg-519"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -558,7 +558,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-290"
+                          id="g-svg-520"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -572,7 +572,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-291"
+                          id="g-svg-521"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -674,7 +674,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-293"
+                      id="g-svg-523"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -695,7 +695,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-294"
+                      id="g-svg-524"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -716,7 +716,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-295"
+                      id="g-svg-525"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -744,7 +744,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-296"
+                      id="g-svg-526"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -772,7 +772,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-297"
+                      id="g-svg-527"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -800,7 +800,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-298"
+                      id="g-svg-528"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -825,7 +825,7 @@
             <g
               id="g-svg-166"
               fill="none"
-              transform="matrix(1,0,0,1,371.639984,421.679993)"
+              transform="matrix(1,0,0,1,371.639984,423.600006)"
               class="axis-title-group"
             >
               <g transform="matrix(1,0,0,1,0,0)">
@@ -848,6 +848,1050 @@
                 >
                   date
                 </text>
+              </g>
+            </g>
+            <g
+              id="g-svg-275"
+              fill="none"
+              class="offscreen"
+              transform="matrix(1,0,0,1,0,0)"
+            >
+              <g
+                id="g-svg-276"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,119.279999,328)">
+                  <line
+                    id="g-svg-277"
+                    fill="none"
+                    x1="0"
+                    y1="0"
+                    x2="504.71999970563456"
+                    y2="0"
+                    visibility="hidden"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-278"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-279"
+                  fill="none"
+                  transform="matrix(1,0,0,1,133.090744,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-299"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-280"
+                  fill="none"
+                  transform="matrix(1,0,0,1,158.201187,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-300"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-281"
+                  fill="none"
+                  transform="matrix(1,0,0,1,183.311646,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-301"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-282"
+                  fill="none"
+                  transform="matrix(1,0,0,1,208.422089,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-302"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-283"
+                  fill="none"
+                  transform="matrix(1,0,0,1,233.532532,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-303"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-284"
+                  fill="none"
+                  transform="matrix(1,0,0,1,258.642975,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-304"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-285"
+                  fill="none"
+                  transform="matrix(1,0,0,1,283.753418,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-305"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-286"
+                  fill="none"
+                  transform="matrix(1,0,0,1,308.863892,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-306"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-287"
+                  fill="none"
+                  transform="matrix(1,0,0,1,333.974335,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-307"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-288"
+                  fill="none"
+                  transform="matrix(1,0,0,1,359.084778,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-308"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-289"
+                  fill="none"
+                  transform="matrix(1,0,0,1,384.195221,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-309"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-290"
+                  fill="none"
+                  transform="matrix(1,0,0,1,409.305664,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-310"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-291"
+                  fill="none"
+                  transform="matrix(1,0,0,1,434.416107,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-311"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-292"
+                  fill="none"
+                  transform="matrix(1,0,0,1,459.526581,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-312"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-293"
+                  fill="none"
+                  transform="matrix(1,0,0,1,484.637024,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-313"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-294"
+                  fill="none"
+                  transform="matrix(1,0,0,1,509.747467,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-314"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-295"
+                  fill="none"
+                  transform="matrix(1,0,0,1,534.857910,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-315"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-296"
+                  fill="none"
+                  transform="matrix(1,0,0,1,559.968384,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-316"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-297"
+                  fill="none"
+                  transform="matrix(1,0,0,1,585.078796,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-317"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-298"
+                  fill="none"
+                  transform="matrix(1,0,0,1,610.189270,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <line
+                      id="g-svg-318"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="4"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-319"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-320"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,133.090744,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-340"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-01
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-321"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,158.201187,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-341"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-02
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-322"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,183.311646,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-342"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-03
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-323"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,208.422089,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-343"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-04
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-324"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,233.532532,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-344"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-05
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-325"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,258.642975,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-345"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-06
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-326"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,283.753418,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-346"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-07
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-327"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,308.863892,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-347"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-08
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-328"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,333.974335,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-348"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-09
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-329"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,359.084778,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-349"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-10
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-330"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,384.195221,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-350"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-11
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-331"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,409.305664,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-351"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2001-12
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-332"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,434.416107,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-352"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-01
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-333"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,459.526581,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-353"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-02
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-334"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,484.637024,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-354"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-03
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-335"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,509.747467,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-355"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-04
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-336"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,534.857910,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-356"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-05
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-337"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,559.968384,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-357"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-06
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-338"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,585.078796,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-358"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-07
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-339"
+                  fill="none"
+                  transform="matrix(0,1,-1,0,610.189270,336)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-359"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="left"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      2002-08
+                    </text>
+                  </g>
+                </g>
               </g>
             </g>
           </g>
@@ -993,7 +2037,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-301"
+                      id="g-svg-531"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1014,7 +2058,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-302"
+                      id="g-svg-532"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1035,7 +2079,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-303"
+                      id="g-svg-533"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1056,7 +2100,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-304"
+                      id="g-svg-534"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1077,7 +2121,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-305"
+                      id="g-svg-535"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1105,7 +2149,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-306"
+                      id="g-svg-536"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1133,7 +2177,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-307"
+                      id="g-svg-537"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1161,7 +2205,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-308"
+                      id="g-svg-538"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1189,7 +2233,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-309"
+                      id="g-svg-539"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1217,7 +2261,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-310"
+                      id="g-svg-540"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1266,11 +2310,405 @@
                 </text>
               </g>
             </g>
+            <g
+              id="g-svg-402"
+              fill="none"
+              class="offscreen"
+              transform="matrix(1,0,0,1,0,0)"
+            >
+              <g
+                id="g-svg-403"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-line-group"
+              >
+                <g transform="matrix(1,0,0,1,119.279999,16)">
+                  <line
+                    id="g-svg-404"
+                    fill="none"
+                    x1="0"
+                    y1="312"
+                    x2="0"
+                    y2="0"
+                    visibility="hidden"
+                    class="axis-line axis-line"
+                    stroke-width="0.5"
+                    stroke="rgba(29,33,41,1)"
+                    stroke-opacity="0.45"
+                    opacity="0"
+                  />
+                </g>
+              </g>
+              <g
+                id="g-svg-405"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-tick-group"
+              >
+                <g
+                  id="g-svg-406"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,328)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-413"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-407"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,276)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-414"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-408"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,224)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-415"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-409"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,172)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-416"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-410"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,120)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-417"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-411"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,68)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-418"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-412"
+                  fill="none"
+                  transform="matrix(1,0,0,1,119.279999,16)"
+                  class="axis-tick"
+                >
+                  <g transform="matrix(1,0,0,1,-4,0)">
+                    <line
+                      id="g-svg-419"
+                      fill="none"
+                      x1="4"
+                      y1="0"
+                      x2="0"
+                      y2="0"
+                      visibility="hidden"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g
+                id="g-svg-420"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="axis-label-group"
+              >
+                <g
+                  id="g-svg-421"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,328)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-428"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      0
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-422"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,276)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-429"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      100
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-423"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,224)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-430"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      200
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-424"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,172)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-431"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      300
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-425"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,120)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-432"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      400
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-426"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,68)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-433"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      500
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-427"
+                  fill="none"
+                  transform="matrix(1,0,0,1,111.279999,16)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(1,0,0,1,0,0)">
+                    <text
+                      id="g-svg-434"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="end"
+                      visibility="hidden"
+                      class="axis-label-item"
+                      opacity="0.45"
+                    >
+                      600
+                    </text>
+                  </g>
+                </g>
+              </g>
+            </g>
           </g>
         </g>
         <g
           transform="matrix(1,0,0,1,119.279999,16)"
-          clip-path="url(#clip-path-312-217)"
+          clip-path="url(#clip-path-542-217)"
         >
           <path
             id="g-svg-217"
@@ -1288,7 +2726,7 @@
           >
             <g transform="matrix(1,0,0,1,16.281290,280.799988)">
               <path
-                id="g-svg-220"
+                id="g-svg-450"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 146.53161281776488,0 l 0,62.400000000000034 l-146.53161281776488 0 z"
                 width="146.53161281776488"
@@ -1301,7 +2739,7 @@
             </g>
             <g transform="matrix(1,0,0,1,179.094193,93.599998)">
               <path
-                id="g-svg-221"
+                id="g-svg-451"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 146.53161281776494,0 l 0,249.60000000000002 l-146.53161281776494 0 z"
                 width="146.53161281776494"
@@ -1314,7 +2752,7 @@
             </g>
             <g transform="matrix(1,0,0,1,341.907104,31.200001)">
               <path
-                id="g-svg-222"
+                id="g-svg-452"
                 fill="rgba(23,131,255,1)"
                 d="M 0,0 l 146.53161281776482,0 l 0,312.00000000000006 l-146.53161281776482 0 z"
                 width="146.53161281776482"

--- a/__tests__/integration/snapshots/interaction/aapl-line-slider-filter-transpose/step0.svg
+++ b/__tests__/integration/snapshots/interaction/aapl-line-slider-filter-transpose/step0.svg
@@ -7,14 +7,14 @@
 >
   <defs>
     <path
-      id="g-svg-85"
+      id="g-svg-112"
       fill="none"
       d="M 0,0 l 528,0 l 0,412 l-528 0 z"
       width="528"
       height="412"
     />
-    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-85-69">
-      <use href="#g-svg-85" transform="matrix(1,0,0,1,96,16)" />
+    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-112-69">
+      <use href="#g-svg-112" transform="matrix(1,0,0,1,96,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -154,14 +154,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-75"
+                    id="g-svg-102"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-76"
+                        id="g-svg-103"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -173,7 +173,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-77"
+                          id="g-svg-104"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -187,7 +187,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-78"
+                          id="g-svg-105"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -239,14 +239,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-81"
+                    id="g-svg-108"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-82"
+                        id="g-svg-109"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -258,7 +258,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-83"
+                          id="g-svg-110"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -272,7 +272,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-84"
+                          id="g-svg-111"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -434,14 +434,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-53"
+                    id="g-svg-89"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-54"
+                        id="g-svg-90"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -453,7 +453,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-55"
+                          id="g-svg-91"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -467,7 +467,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-56"
+                          id="g-svg-92"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -519,14 +519,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-63"
+                    id="g-svg-95"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-64"
+                        id="g-svg-96"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -538,7 +538,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-65"
+                          id="g-svg-97"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -552,7 +552,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-66"
+                          id="g-svg-98"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -594,7 +594,7 @@
             </g>
           </g>
         </g>
-        <g transform="matrix(1,0,0,1,96,16)" clip-path="url(#clip-path-85-69)">
+        <g transform="matrix(1,0,0,1,96,16)" clip-path="url(#clip-path-112-69)">
           <path
             id="g-svg-69"
             fill="rgba(0,0,0,0)"

--- a/__tests__/integration/snapshots/interaction/aapl-line-slider-filter-transpose/step1.svg
+++ b/__tests__/integration/snapshots/interaction/aapl-line-slider-filter-transpose/step1.svg
@@ -7,24 +7,24 @@
 >
   <defs>
     <path
-      id="g-svg-85"
+      id="g-svg-112"
       fill="none"
       d="M 0,0 l 528,0 l 0,412 l-528 0 z"
       width="528"
       height="412"
     />
-    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-85-69">
-      <use href="#g-svg-85" transform="matrix(1,0,0,1,96,16)" />
+    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-112-69">
+      <use href="#g-svg-112" transform="matrix(1,0,0,1,96,16)" />
     </clipPath>
     <path
-      id="g-svg-99"
+      id="g-svg-126"
       fill="none"
       d="M 0,0 l 528,0 l 0,412 l-528 0 z"
       width="528"
       height="412"
     />
-    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-99-69">
-      <use href="#g-svg-99" transform="matrix(1,0,0,1,96,16)" />
+    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-126-69">
+      <use href="#g-svg-126" transform="matrix(1,0,0,1,96,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -164,14 +164,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-75"
+                    id="g-svg-102"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-76"
+                        id="g-svg-103"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -183,7 +183,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-77"
+                          id="g-svg-104"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -197,7 +197,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-78"
+                          id="g-svg-105"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -249,14 +249,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-81"
+                    id="g-svg-108"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-82"
+                        id="g-svg-109"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -268,7 +268,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-83"
+                          id="g-svg-110"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -282,7 +282,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-84"
+                          id="g-svg-111"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -448,14 +448,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-89"
+                    id="g-svg-116"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-90"
+                        id="g-svg-117"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -467,7 +467,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-91"
+                          id="g-svg-118"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -481,7 +481,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-92"
+                          id="g-svg-119"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -533,14 +533,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-95"
+                    id="g-svg-122"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-96"
+                        id="g-svg-123"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -552,7 +552,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-97"
+                          id="g-svg-124"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -566,7 +566,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-98"
+                          id="g-svg-125"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -608,7 +608,7 @@
             </g>
           </g>
         </g>
-        <g transform="matrix(1,0,0,1,96,16)" clip-path="url(#clip-path-99-69)">
+        <g transform="matrix(1,0,0,1,96,16)" clip-path="url(#clip-path-126-69)">
           <path
             id="g-svg-69"
             fill="rgba(0,0,0,0)"

--- a/__tests__/integration/snapshots/interaction/aapl-line-slider-filter/step0.svg
+++ b/__tests__/integration/snapshots/interaction/aapl-line-slider-filter/step0.svg
@@ -7,14 +7,14 @@
 >
   <defs>
     <path
-      id="g-svg-85"
+      id="g-svg-112"
       fill="none"
       d="M 0,0 l 528,0 l 0,412 l-528 0 z"
       width="528"
       height="412"
     />
-    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-85-69">
-      <use href="#g-svg-85" transform="matrix(1,0,0,1,96,16)" />
+    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-112-69">
+      <use href="#g-svg-112" transform="matrix(1,0,0,1,96,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -184,14 +184,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-75"
+                    id="g-svg-102"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-76"
+                        id="g-svg-103"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -203,7 +203,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-77"
+                          id="g-svg-104"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -217,7 +217,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-78"
+                          id="g-svg-105"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -269,14 +269,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-81"
+                    id="g-svg-108"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-82"
+                        id="g-svg-109"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -288,7 +288,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-83"
+                          id="g-svg-110"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -302,7 +302,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-84"
+                          id="g-svg-111"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -434,14 +434,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-53"
+                    id="g-svg-89"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-54"
+                        id="g-svg-90"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -453,7 +453,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-55"
+                          id="g-svg-91"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -467,7 +467,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-56"
+                          id="g-svg-92"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -519,14 +519,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-63"
+                    id="g-svg-95"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-64"
+                        id="g-svg-96"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -538,7 +538,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-65"
+                          id="g-svg-97"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -552,7 +552,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-66"
+                          id="g-svg-98"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -594,7 +594,7 @@
             </g>
           </g>
         </g>
-        <g transform="matrix(1,0,0,1,96,16)" clip-path="url(#clip-path-85-69)">
+        <g transform="matrix(1,0,0,1,96,16)" clip-path="url(#clip-path-112-69)">
           <path
             id="g-svg-69"
             fill="rgba(0,0,0,0)"

--- a/__tests__/integration/snapshots/interaction/aapl-line-slider-filter/step1.svg
+++ b/__tests__/integration/snapshots/interaction/aapl-line-slider-filter/step1.svg
@@ -7,24 +7,24 @@
 >
   <defs>
     <path
-      id="g-svg-85"
+      id="g-svg-112"
       fill="none"
       d="M 0,0 l 528,0 l 0,412 l-528 0 z"
       width="528"
       height="412"
     />
-    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-85-69">
-      <use href="#g-svg-85" transform="matrix(1,0,0,1,96,16)" />
+    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-112-69">
+      <use href="#g-svg-112" transform="matrix(1,0,0,1,96,16)" />
     </clipPath>
     <path
-      id="g-svg-99"
+      id="g-svg-126"
       fill="none"
       d="M 0,0 l 528,0 l 0,412 l-528 0 z"
       width="528"
       height="412"
     />
-    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-99-69">
-      <use href="#g-svg-99" transform="matrix(1,0,0,1,96,16)" />
+    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-126-69">
+      <use href="#g-svg-126" transform="matrix(1,0,0,1,96,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -194,14 +194,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-75"
+                    id="g-svg-102"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-76"
+                        id="g-svg-103"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -213,7 +213,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-77"
+                          id="g-svg-104"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -227,7 +227,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-78"
+                          id="g-svg-105"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -279,14 +279,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-81"
+                    id="g-svg-108"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-82"
+                        id="g-svg-109"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -298,7 +298,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-83"
+                          id="g-svg-110"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -312,7 +312,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-84"
+                          id="g-svg-111"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -448,14 +448,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-89"
+                    id="g-svg-116"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-90"
+                        id="g-svg-117"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -467,7 +467,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-91"
+                          id="g-svg-118"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -481,7 +481,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-92"
+                          id="g-svg-119"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -533,14 +533,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-95"
+                    id="g-svg-122"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-96"
+                        id="g-svg-123"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -552,7 +552,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-97"
+                          id="g-svg-124"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -566,7 +566,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-98"
+                          id="g-svg-125"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -608,7 +608,7 @@
             </g>
           </g>
         </g>
-        <g transform="matrix(1,0,0,1,96,16)" clip-path="url(#clip-path-99-69)">
+        <g transform="matrix(1,0,0,1,96,16)" clip-path="url(#clip-path-126-69)">
           <path
             id="g-svg-69"
             fill="rgba(0,0,0,0)"

--- a/__tests__/integration/snapshots/interaction/aapl-line-slider-filter/step2.svg
+++ b/__tests__/integration/snapshots/interaction/aapl-line-slider-filter/step2.svg
@@ -7,34 +7,34 @@
 >
   <defs>
     <path
-      id="g-svg-85"
+      id="g-svg-112"
       fill="none"
       d="M 0,0 l 528,0 l 0,412 l-528 0 z"
       width="528"
       height="412"
     />
-    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-85-69">
-      <use href="#g-svg-85" transform="matrix(1,0,0,1,96,16)" />
+    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-112-69">
+      <use href="#g-svg-112" transform="matrix(1,0,0,1,96,16)" />
     </clipPath>
     <path
-      id="g-svg-99"
+      id="g-svg-126"
       fill="none"
       d="M 0,0 l 528,0 l 0,412 l-528 0 z"
       width="528"
       height="412"
     />
-    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-99-69">
-      <use href="#g-svg-99" transform="matrix(1,0,0,1,96,16)" />
+    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-126-69">
+      <use href="#g-svg-126" transform="matrix(1,0,0,1,96,16)" />
     </clipPath>
     <path
-      id="g-svg-113"
+      id="g-svg-140"
       fill="none"
       d="M 0,0 l 528,0 l 0,412 l-528 0 z"
       width="528"
       height="412"
     />
-    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-113-69">
-      <use href="#g-svg-113" transform="matrix(1,0,0,1,96,16)" />
+    <clipPath transform="matrix(1,0,0,1,-96,-16)" id="clip-path-140-69">
+      <use href="#g-svg-140" transform="matrix(1,0,0,1,96,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -204,14 +204,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-103"
+                    id="g-svg-130"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-104"
+                        id="g-svg-131"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -223,7 +223,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-105"
+                          id="g-svg-132"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -237,7 +237,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-106"
+                          id="g-svg-133"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -289,14 +289,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-109"
+                    id="g-svg-136"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-110"
+                        id="g-svg-137"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -308,7 +308,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-111"
+                          id="g-svg-138"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -322,7 +322,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-112"
+                          id="g-svg-139"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -458,14 +458,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-89"
+                    id="g-svg-116"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-90"
+                        id="g-svg-117"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -477,7 +477,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-91"
+                          id="g-svg-118"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -491,7 +491,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-92"
+                          id="g-svg-119"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -543,14 +543,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-95"
+                    id="g-svg-122"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-96"
+                        id="g-svg-123"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -562,7 +562,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-97"
+                          id="g-svg-124"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -576,7 +576,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-98"
+                          id="g-svg-125"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -618,7 +618,7 @@
             </g>
           </g>
         </g>
-        <g transform="matrix(1,0,0,1,96,16)" clip-path="url(#clip-path-113-69)">
+        <g transform="matrix(1,0,0,1,96,16)" clip-path="url(#clip-path-140-69)">
           <path
             id="g-svg-69"
             fill="rgba(0,0,0,0)"

--- a/__tests__/integration/snapshots/interaction/alphabet-interval-active-scrollbar/step1.svg
+++ b/__tests__/integration/snapshots/interaction/alphabet-interval-active-scrollbar/step1.svg
@@ -7,14 +7,14 @@
 >
   <defs>
     <path
-      id="g-svg-117"
+      id="g-svg-120"
       fill="none"
       d="M 0,0 l 608,0 l 0,412 l-608 0 z"
       width="608"
       height="412"
     />
-    <clipPath transform="matrix(1,0,0,1,-16,-16)" id="clip-path-117-40">
-      <use href="#g-svg-117" transform="matrix(1,0,0,1,16,16)" />
+    <clipPath transform="matrix(1,0,0,1,-16,-16)" id="clip-path-120-40">
+      <use href="#g-svg-120" transform="matrix(1,0,0,1,16,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -184,14 +184,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-107"
+                    id="g-svg-110"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-108"
+                        id="g-svg-111"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -203,7 +203,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-109"
+                          id="g-svg-112"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -217,7 +217,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-110"
+                          id="g-svg-113"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -238,7 +238,7 @@
                   transform="matrix(1,0,0,1,0,0)"
                   class="handle-label-group"
                 >
-                  <g transform="matrix(1,0,0,1,-26.900000,0)">
+                  <g transform="matrix(1,0,0,1,-16.400000,0)">
                     <text
                       id="g-svg-29"
                       fill="rgba(29,33,41,1)"
@@ -251,7 +251,7 @@
                       text-anchor="middle"
                       font-weight="normal"
                     >
-                      1992
+                      S
                     </text>
                   </g>
                 </g>
@@ -269,14 +269,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-113"
+                    id="g-svg-116"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-114"
+                        id="g-svg-117"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -288,7 +288,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-115"
+                          id="g-svg-118"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -302,7 +302,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-116"
+                          id="g-svg-119"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -323,7 +323,7 @@
                   transform="matrix(1,0,0,1,0,0)"
                   class="handle-label-group"
                 >
-                  <g transform="matrix(1,0,0,1,27.080000,0)">
+                  <g transform="matrix(1,0,0,1,16.520000,0)">
                     <text
                       id="g-svg-39"
                       fill="rgba(29,33,41,1)"
@@ -336,7 +336,7 @@
                       text-anchor="middle"
                       font-weight="normal"
                     >
-                      1996
+                      B
                     </text>
                   </g>
                 </g>
@@ -344,7 +344,7 @@
             </g>
           </g>
         </g>
-        <g transform="matrix(1,0,0,1,16,16)" clip-path="url(#clip-path-117-40)">
+        <g transform="matrix(1,0,0,1,16,16)" clip-path="url(#clip-path-120-40)">
           <path
             id="g-svg-40"
             fill="rgba(0,0,0,0)"
@@ -359,14 +359,197 @@
             transform="matrix(1,0,0,1,0,0)"
             class="main-layer"
           >
-            <g transform="matrix(1,0,0,1,0,26.989000)">
+            <g transform="matrix(1,0,0,1,555.607178,0)">
               <path
-                id="g-svg-43"
-                fill="rgba(23,131,255,1)"
-                d="M 0,185.414 L 152,187.894 L 304,169.186 L 456,174.257 L 608,0 L 608,385.011 L 456,385.011 L 304,385.011 L 152,385.011 L 0,385.011 Z"
-                fill-opacity="0.4"
+                id="g-svg-135"
+                fill="rgba(204,214,236,1)"
+                d="M 0,0 l 41.889103448275705,0 l 0,412 l-41.889103448275705 0 z"
+                width="41.889103448275705"
+                height="412"
+                fill-opacity="0.3"
                 stroke-width="0"
-                stroke="rgba(23,131,255,1)"
+                class="element-background"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,566.068970,363.605743)">
+              <path
+                id="g-svg-44"
+                fill="rgba(255,0,0,1)"
+                d="M 0,0 l 20.965517241379303,0 l 0,48.39426861911511 l-20.965517241379303 0 z"
+                width="20.965517241379303"
+                height="48.39426861911511"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,230.620697,321.763489)">
+              <path
+                id="g-svg-45"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379303,0 l 0,90.23649818926151 l-20.965517241379303 0 z"
+                width="20.965517241379303"
+                height="90.23649818926151"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,146.758621,274.050385)">
+              <path
+                id="g-svg-46"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379303,0 l 0,137.94961423397888 l-20.965517241379303 0 z"
+                width="20.965517241379303"
+                height="137.94961423397888"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,398.344818,337.786804)">
+              <path
+                id="g-svg-48"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379303,0 l 0,74.21319477247675 l-20.965517241379303 0 z"
+                width="20.965517241379303"
+                height="74.21319477247675"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,440.275848,346.641785)">
+              <path
+                id="g-svg-49"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379303,0 l 0,65.35821130530627 l-20.965517241379303 0 z"
+                width="20.965517241379303"
+                height="65.35821130530627"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,62.896553,214.336014)">
+              <path
+                id="g-svg-50"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379303,0 l 0,197.66398992284678 l-20.965517241379303 0 z"
+                width="20.965517241379303"
+                height="197.66398992284678"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,188.689651,281.445770)">
+              <path
+                id="g-svg-54"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379303,0 l 0,130.55424342623212 l-20.965517241379303 0 z"
+                width="20.965517241379303"
+                height="130.55424342623212"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,314.482758,333.959381)">
+              <path
+                id="g-svg-55"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379303,0 l 0,78.04062352385449 l-20.965517241379303 0 z"
+                width="20.965517241379303"
+                height="78.04062352385449"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,524.137939,349.431274)">
+              <path
+                id="g-svg-58"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379303,0 l 0,62.56872933396318 l-20.965517241379303 0 z"
+                width="20.965517241379303"
+                height="62.56872933396318"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,104.827583,217.806641)">
+              <path
+                id="g-svg-60"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379317,0 l 0,194.19335537710597 l-20.965517241379317 0 z"
+                width="20.965517241379317"
+                height="194.19335537710597"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,20.965517,206.778458)">
+              <path
+                id="g-svg-61"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.96551724137931,0 l 0,205.22153991497407 l-20.96551724137931 0 z"
+                width="20.96551724137931"
+                height="205.22153991497407"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,272.551727,322.541962)">
+              <path
+                id="g-svg-63"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379303,0 l 0,89.45803810423558 l-20.965517241379303 0 z"
+                width="20.965517241379303"
+                height="89.45803810423558"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,356.413788,335.451416)">
+              <path
+                id="g-svg-65"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379303,0 l 0,76.5485750275547 l-20.965517241379303 0 z"
+                width="20.965517241379303"
+                height="76.5485750275547"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,482.206909,347.971649)">
+              <path
+                id="g-svg-67"
+                fill="rgba(70,130,180,1)"
+                d="M 0,0 l 20.965517241379246,0 l 0,64.0283419933869 l-20.965517241379246 0 z"
+                width="20.965517241379246"
+                height="64.0283419933869"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(70,130,180,1)"
                 class="element"
               />
             </g>
@@ -376,197 +559,7 @@
             fill="none"
             transform="matrix(1,0,0,1,0,0)"
             class="label-layer"
-          >
-            <g
-              id="g-svg-45"
-              fill="none"
-              transform="matrix(1,0,0,1,0,220.238312)"
-              class="label"
-            />
-            <g
-              id="g-svg-49"
-              fill="none"
-              transform="matrix(1,0,0,1,0,212.403214)"
-              class="label"
-            >
-              <g transform="matrix(1,0,0,1,0,-11.500000)">
-                <path
-                  id="background"
-                  fill="none"
-                  d="M 0,0 l 35.68,0 l 0,23 l-35.68 0 z"
-                  width="35.68"
-                  height="23"
-                />
-              </g>
-              <g transform="matrix(1,0,0,1,0,0)">
-                <text
-                  id="text"
-                  fill="rgba(29,33,41,1)"
-                  dominant-baseline="central"
-                  paint-order="stroke"
-                  dx="0.5"
-                  fill-opacity="0.65"
-                  font-size="12"
-                  font-weight="normal"
-                >
-                  16100
-                </text>
-              </g>
-              <g transform="matrix(1,0,0,1,0,0)">
-                <path id="connector" fill="none" d="M 0,0 L 0,0" />
-              </g>
-            </g>
-            <g
-              id="g-svg-53"
-              fill="none"
-              transform="matrix(1,0,0,1,152,214.882675)"
-              class="label"
-            >
-              <g transform="matrix(1,0,0,1,0,-11.500000)">
-                <path
-                  id="background"
-                  fill="none"
-                  d="M 0,0 l 37.480000000000004,0 l 0,23 l-37.480000000000004 0 z"
-                  width="37.480000000000004"
-                  height="23"
-                />
-              </g>
-              <g transform="matrix(1,0,0,1,0,0)">
-                <text
-                  id="text"
-                  fill="rgba(29,33,41,1)"
-                  dominant-baseline="central"
-                  paint-order="stroke"
-                  dx="0.5"
-                  fill-opacity="0.65"
-                  font-size="12"
-                  font-weight="normal"
-                >
-                  15900
-                </text>
-              </g>
-              <g transform="matrix(1,0,0,1,0,0)">
-                <path id="connector" fill="none" d="M 0,0 L 0,0" />
-              </g>
-            </g>
-            <g
-              id="g-svg-57"
-              fill="none"
-              transform="matrix(1,0,0,1,304,196.175125)"
-              class="label"
-            >
-              <g transform="matrix(1,0,0,1,0,-11.500000)">
-                <path
-                  id="background"
-                  fill="none"
-                  d="M 0,0 l 37.12,0 l 0,23 l-37.12 0 z"
-                  width="37.12"
-                  height="23"
-                />
-              </g>
-              <g transform="matrix(1,0,0,1,0,0)">
-                <text
-                  id="text"
-                  fill="rgba(29,33,41,1)"
-                  dominant-baseline="central"
-                  paint-order="stroke"
-                  dx="0.5"
-                  fill-opacity="0.65"
-                  font-size="12"
-                  font-weight="normal"
-                >
-                  17409
-                </text>
-              </g>
-              <g transform="matrix(1,0,0,1,0,0)">
-                <path id="connector" fill="none" d="M 0,0 L 0,0" />
-              </g>
-            </g>
-            <g
-              id="g-svg-61"
-              fill="none"
-              transform="matrix(1,0,0,1,456,201.245636)"
-              class="label"
-            >
-              <g transform="matrix(1,0,0,1,-0,-11.500000)">
-                <path
-                  id="background"
-                  fill="none"
-                  d="M 0,0 l 36.76,0 l 0,23 l-36.76 0 z"
-                  width="36.76"
-                  height="23"
-                />
-              </g>
-              <g transform="matrix(1,0,0,1,0,0)">
-                <text
-                  id="text"
-                  fill="rgba(29,33,41,1)"
-                  dominant-baseline="central"
-                  paint-order="stroke"
-                  dx="0.5"
-                  fill-opacity="0.65"
-                  font-size="12"
-                  font-weight="normal"
-                >
-                  17000
-                </text>
-              </g>
-              <g transform="matrix(1,0,0,1,0,0)">
-                <path id="connector" fill="none" d="M 0,0 L 0,0" />
-              </g>
-            </g>
-            <g
-              id="g-svg-65"
-              fill="none"
-              transform="matrix(1,0,0,1,608,26.988956)"
-              class="label"
-            >
-              <g transform="matrix(1,0,0,1,0,-11.500000)">
-                <path
-                  id="background"
-                  fill="none"
-                  d="M 0,0 l 37.48,0 l 0,23 l-37.48 0 z"
-                  width="37.48"
-                  height="23"
-                />
-              </g>
-              <g transform="matrix(1,0,0,1,0,0)">
-                <text
-                  id="text"
-                  fill="rgba(29,33,41,1)"
-                  dominant-baseline="central"
-                  paint-order="stroke"
-                  dx="0.5"
-                  fill-opacity="0.65"
-                  font-size="12"
-                  font-weight="normal"
-                >
-                  31056
-                </text>
-              </g>
-              <g transform="matrix(1,0,0,1,0,0)">
-                <path id="connector" fill="none" d="M 0,0 L 0,0" />
-              </g>
-            </g>
-            <g
-              id="g-svg-69"
-              fill="none"
-              transform="matrix(1,0,0,1,456,15.509042)"
-              class="label"
-            />
-            <g
-              id="g-svg-73"
-              fill="none"
-              transform="matrix(1,0,0,1,532,14.789998)"
-              class="label"
-            />
-            <g
-              id="g-svg-77"
-              fill="none"
-              transform="matrix(1,0,0,1,608,0)"
-              class="label"
-            />
-          </g>
+          />
         </g>
       </g>
     </g>

--- a/__tests__/integration/snapshots/interaction/countries-annotation-slider-filter/step0.svg
+++ b/__tests__/integration/snapshots/interaction/countries-annotation-slider-filter/step0.svg
@@ -10,14 +10,14 @@
       <use href="#g-svg-136" transform="matrix(1,0,0,1,16,7.500000)" />
     </clipPath>
     <path
-      id="g-svg-265"
+      id="g-svg-405"
       fill="none"
       d="M 0,0 l 572,0 l 0,377 l-572 0 z"
       width="572"
       height="377"
     />
-    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-265-137">
-      <use href="#g-svg-265" transform="matrix(1,0,0,1,52,51)" />
+    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-405-137">
+      <use href="#g-svg-405" transform="matrix(1,0,0,1,52,51)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -187,14 +187,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-232"
+                    id="g-svg-372"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-233"
+                        id="g-svg-373"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -206,7 +206,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-234"
+                          id="g-svg-374"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -220,7 +220,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-235"
+                          id="g-svg-375"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -272,14 +272,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-238"
+                    id="g-svg-378"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-239"
+                        id="g-svg-379"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -291,7 +291,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-240"
+                          id="g-svg-380"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -305,7 +305,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-241"
+                          id="g-svg-381"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -437,14 +437,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-59"
+                    id="g-svg-251"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-60"
+                        id="g-svg-252"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -456,7 +456,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-61"
+                          id="g-svg-253"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -470,7 +470,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-62"
+                          id="g-svg-254"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -522,14 +522,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-69"
+                    id="g-svg-257"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-70"
+                        id="g-svg-258"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -541,7 +541,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-71"
+                          id="g-svg-259"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -555,7 +555,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-72"
+                          id="g-svg-260"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -667,7 +667,7 @@
                         transform="matrix(1,0,0,1,0,0)"
                       >
                         <g
-                          id="g-svg-254"
+                          id="g-svg-394"
                           fill="none"
                           class="items-item-page"
                           transform="matrix(1,0,0,1,0,0)"
@@ -911,7 +911,7 @@
                             fill="none"
                             transform="matrix(1,0,0,1,212.160004,0)"
                             class="items-item"
-                            width="57.79999999999998"
+                            width="57.799999999999955"
                             height="23"
                           >
                             <g
@@ -925,8 +925,8 @@
                                   id="g-svg-116"
                                   fill="rgba(0,0,0,0)"
                                   class="legend-category-item-background"
-                                  d="M 0,0 l 57.79999999999998,0 l 0,23 l-57.79999999999998 0 z"
-                                  width="57.79999999999998"
+                                  d="M 0,0 l 57.799999999999955,0 l 0,23 l-57.799999999999955 0 z"
+                                  width="57.799999999999955"
                                   height="23"
                                   visibility="visible"
                                 />
@@ -1089,7 +1089,7 @@
         </g>
         <g
           transform="matrix(1,0,0,1,52,51)"
-          clip-path="url(#clip-path-265-137)"
+          clip-path="url(#clip-path-405-137)"
         >
           <path
             id="g-svg-137"
@@ -2120,7 +2120,7 @@
             class="main-layer"
           >
             <g
-              id="g-svg-348"
+              id="g-svg-488"
               fill="none"
               transform="matrix(1,0,0,1,572,377)"
               class="element"

--- a/__tests__/integration/snapshots/interaction/countries-annotation-slider-filter/step1.svg
+++ b/__tests__/integration/snapshots/interaction/countries-annotation-slider-filter/step1.svg
@@ -10,24 +10,24 @@
       <use href="#g-svg-136" transform="matrix(1,0,0,1,16,7.500000)" />
     </clipPath>
     <path
-      id="g-svg-265"
+      id="g-svg-405"
       fill="none"
       d="M 0,0 l 572,0 l 0,377 l-572 0 z"
       width="572"
       height="377"
     />
-    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-265-137">
-      <use href="#g-svg-265" transform="matrix(1,0,0,1,52,51)" />
+    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-405-137">
+      <use href="#g-svg-405" transform="matrix(1,0,0,1,52,51)" />
     </clipPath>
     <path
-      id="g-svg-387"
+      id="g-svg-527"
       fill="none"
       d="M 0,0 l 572,0 l 0,377 l-572 0 z"
       width="572"
       height="377"
     />
-    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-387-137">
-      <use href="#g-svg-387" transform="matrix(1,0,0,1,52,51)" />
+    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-527-137">
+      <use href="#g-svg-527" transform="matrix(1,0,0,1,52,51)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -197,14 +197,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-232"
+                    id="g-svg-372"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-233"
+                        id="g-svg-373"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -216,7 +216,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-234"
+                          id="g-svg-374"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -230,7 +230,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-235"
+                          id="g-svg-375"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -282,14 +282,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-238"
+                    id="g-svg-378"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-239"
+                        id="g-svg-379"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -301,7 +301,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-240"
+                          id="g-svg-380"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -315,7 +315,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-241"
+                          id="g-svg-381"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -451,14 +451,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-354"
+                    id="g-svg-494"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-355"
+                        id="g-svg-495"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -470,7 +470,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-356"
+                          id="g-svg-496"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -484,7 +484,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-357"
+                          id="g-svg-497"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -536,14 +536,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-360"
+                    id="g-svg-500"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-361"
+                        id="g-svg-501"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -555,7 +555,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-362"
+                          id="g-svg-502"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -569,7 +569,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-363"
+                          id="g-svg-503"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -681,7 +681,7 @@
                         transform="matrix(1,0,0,1,0,0)"
                       >
                         <g
-                          id="g-svg-376"
+                          id="g-svg-516"
                           fill="none"
                           class="items-item-page"
                           transform="matrix(1,0,0,1,0,0)"
@@ -1103,7 +1103,7 @@
         </g>
         <g
           transform="matrix(1,0,0,1,52,51)"
-          clip-path="url(#clip-path-387-137)"
+          clip-path="url(#clip-path-527-137)"
         >
           <path
             id="g-svg-137"
@@ -2134,7 +2134,7 @@
             class="main-layer"
           >
             <g
-              id="g-svg-470"
+              id="g-svg-610"
               fill="none"
               transform="matrix(1,0,0,1,572,377)"
               class="element"

--- a/__tests__/integration/snapshots/interaction/countries-bubble-multi-legends/step0.svg
+++ b/__tests__/integration/snapshots/interaction/countries-bubble-multi-legends/step0.svg
@@ -388,14 +388,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-342"
+                    id="g-svg-529"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-343"
+                        id="g-svg-530"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -407,7 +407,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-344"
+                          id="g-svg-531"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -421,7 +421,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-345"
+                          id="g-svg-532"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -473,14 +473,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-348"
+                    id="g-svg-535"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-349"
+                        id="g-svg-536"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -492,7 +492,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-350"
+                          id="g-svg-537"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -506,7 +506,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-351"
+                          id="g-svg-538"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -638,14 +638,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-355"
+                    id="g-svg-542"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-356"
+                        id="g-svg-543"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -657,7 +657,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-357"
+                          id="g-svg-544"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -671,7 +671,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-358"
+                          id="g-svg-545"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -723,14 +723,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-361"
+                    id="g-svg-548"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-362"
+                        id="g-svg-549"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -742,7 +742,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-363"
+                          id="g-svg-550"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -756,7 +756,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-364"
+                          id="g-svg-551"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -868,7 +868,7 @@
                         transform="matrix(1,0,0,1,0,0)"
                       >
                         <g
-                          id="g-svg-133"
+                          id="g-svg-377"
                           fill="none"
                           class="items-item-page"
                           transform="matrix(1,0,0,1,0,0)"
@@ -957,7 +957,7 @@
                             fill="none"
                             transform="matrix(1,0,0,1,53.599998,0)"
                             class="items-item"
-                            width="70.64"
+                            width="70.63999999999999"
                             height="23"
                           >
                             <g
@@ -971,8 +971,8 @@
                                   id="g-svg-108"
                                   fill="rgba(0,0,0,0)"
                                   class="legend-category-item-background"
-                                  d="M 0,0 l 70.64,0 l 0,23 l-70.64 0 z"
-                                  width="70.64"
+                                  d="M 0,0 l 70.63999999999999,0 l 0,23 l-70.63999999999999 0 z"
+                                  width="70.63999999999999"
                                   height="23"
                                   visibility="visible"
                                 />
@@ -1035,7 +1035,7 @@
                             fill="none"
                             transform="matrix(1,0,0,1,136.240005,0)"
                             class="items-item"
-                            width="63.91999999999999"
+                            width="63.920000000000016"
                             height="23"
                           >
                             <g
@@ -1049,8 +1049,8 @@
                                   id="g-svg-116"
                                   fill="rgba(0,0,0,0)"
                                   class="legend-category-item-background"
-                                  d="M 0,0 l 63.91999999999999,0 l 0,23 l-63.91999999999999 0 z"
-                                  width="63.91999999999999"
+                                  d="M 0,0 l 63.920000000000016,0 l 0,23 l-63.920000000000016 0 z"
+                                  width="63.920000000000016"
                                   height="23"
                                   visibility="visible"
                                 />
@@ -1113,7 +1113,7 @@
                             fill="none"
                             transform="matrix(1,0,0,1,212.160004,0)"
                             class="items-item"
-                            width="57.8"
+                            width="57.79999999999998"
                             height="23"
                           >
                             <g
@@ -1127,8 +1127,8 @@
                                   id="g-svg-124"
                                   fill="rgba(0,0,0,0)"
                                   class="legend-category-item-background"
-                                  d="M 0,0 l 57.8,0 l 0,23 l-57.8 0 z"
-                                  width="57.8"
+                                  d="M 0,0 l 57.79999999999998,0 l 0,23 l-57.79999999999998 0 z"
+                                  width="57.79999999999998"
                                   height="23"
                                   visibility="visible"
                                 />
@@ -1191,7 +1191,7 @@
                             fill="none"
                             transform="matrix(1,0,0,1,281.959991,0)"
                             class="items-item"
-                            width="51.08"
+                            width="51.08000000000004"
                             height="23"
                           >
                             <g
@@ -1205,8 +1205,8 @@
                                   id="g-svg-132"
                                   fill="rgba(0,0,0,0)"
                                   class="legend-category-item-background"
-                                  d="M 0,0 l 51.08,0 l 0,23 l-51.08 0 z"
-                                  width="51.08"
+                                  d="M 0,0 l 51.08000000000004,0 l 0,23 l-51.08000000000004 0 z"
+                                  width="51.08000000000004"
                                   height="23"
                                   visibility="visible"
                                 />
@@ -1442,7 +1442,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-228"
+                              id="g-svg-418"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1463,7 +1463,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-229"
+                              id="g-svg-419"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1484,7 +1484,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-230"
+                              id="g-svg-420"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1505,7 +1505,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-231"
+                              id="g-svg-421"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1526,7 +1526,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-232"
+                              id="g-svg-422"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1547,7 +1547,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-233"
+                              id="g-svg-423"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1575,7 +1575,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-234"
+                              id="g-svg-424"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1604,7 +1604,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-235"
+                              id="g-svg-425"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1633,7 +1633,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-236"
+                              id="g-svg-426"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1662,7 +1662,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-237"
+                              id="g-svg-427"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1691,7 +1691,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-238"
+                              id="g-svg-428"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1720,7 +1720,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-239"
+                              id="g-svg-429"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1772,14 +1772,14 @@
                       class="handle-icon-group"
                     >
                       <g
-                        id="g-svg-240"
+                        id="g-svg-430"
                         fill="none"
                         transform="matrix(1,0,0,1,0,0)"
                         class="handle-icon"
                       >
                         <g transform="matrix(1,0,0,1,-3.333333,-8)">
                           <path
-                            id="g-svg-241"
+                            id="g-svg-431"
                             fill="rgba(255,255,255,1)"
                             class="handle-icon-rect"
                             stroke-width="1"
@@ -1790,7 +1790,7 @@
                           />
                           <g transform="matrix(1,0,0,1,2.222222,4)">
                             <line
-                              id="g-svg-242"
+                              id="g-svg-432"
                               fill="rgba(255,255,255,1)"
                               x1="0"
                               y1="0"
@@ -1803,7 +1803,7 @@
                           </g>
                           <g transform="matrix(1,0,0,1,4.444445,4)">
                             <line
-                              id="g-svg-243"
+                              id="g-svg-433"
                               fill="rgba(255,255,255,1)"
                               x1="0"
                               y1="0"
@@ -1839,14 +1839,14 @@
                       class="handle-icon-group"
                     >
                       <g
-                        id="g-svg-244"
+                        id="g-svg-434"
                         fill="none"
                         transform="matrix(1,0,0,1,0,0)"
                         class="handle-icon"
                       >
                         <g transform="matrix(1,0,0,1,-3.333333,-8)">
                           <path
-                            id="g-svg-245"
+                            id="g-svg-435"
                             fill="rgba(255,255,255,1)"
                             class="handle-icon-rect"
                             stroke-width="1"
@@ -1857,7 +1857,7 @@
                           />
                           <g transform="matrix(1,0,0,1,2.222222,4)">
                             <line
-                              id="g-svg-246"
+                              id="g-svg-436"
                               fill="rgba(255,255,255,1)"
                               x1="0"
                               y1="0"
@@ -1870,7 +1870,7 @@
                           </g>
                           <g transform="matrix(1,0,0,1,4.444445,4)">
                             <line
-                              id="g-svg-247"
+                              id="g-svg-437"
                               fill="rgba(255,255,255,1)"
                               x1="0"
                               y1="0"

--- a/__tests__/integration/snapshots/interaction/countries-bubble-multi-legends/step1.svg
+++ b/__tests__/integration/snapshots/interaction/countries-bubble-multi-legends/step1.svg
@@ -225,14 +225,14 @@
       <use href="#g-svg-223" transform="matrix(1,0,0,1,410.860008,43)" />
     </clipPath>
     <path
-      id="g-svg-429"
+      id="g-svg-616"
       fill="none"
       d="M 0,0 l 572,0 l 0,331 l-572 0 z"
       width="572"
       height="331"
     />
-    <clipPath transform="matrix(1,0,0,1,-52,-97)" id="clip-path-429-248">
-      <use href="#g-svg-429" transform="matrix(1,0,0,1,52,97)" />
+    <clipPath transform="matrix(1,0,0,1,-52,-97)" id="clip-path-616-248">
+      <use href="#g-svg-616" transform="matrix(1,0,0,1,52,97)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -402,14 +402,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-419"
+                    id="g-svg-606"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-420"
+                        id="g-svg-607"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -421,7 +421,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-421"
+                          id="g-svg-608"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -435,7 +435,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-422"
+                          id="g-svg-609"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -487,14 +487,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-425"
+                    id="g-svg-612"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-426"
+                        id="g-svg-613"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -506,7 +506,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-427"
+                          id="g-svg-614"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -520,7 +520,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-428"
+                          id="g-svg-615"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -652,14 +652,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-355"
+                    id="g-svg-542"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-356"
+                        id="g-svg-543"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -671,7 +671,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-357"
+                          id="g-svg-544"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -685,7 +685,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-358"
+                          id="g-svg-545"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -737,14 +737,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-361"
+                    id="g-svg-548"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-362"
+                        id="g-svg-549"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -756,7 +756,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-363"
+                          id="g-svg-550"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -770,7 +770,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-364"
+                          id="g-svg-551"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -882,7 +882,7 @@
                         transform="matrix(1,0,0,1,0,0)"
                       >
                         <g
-                          id="g-svg-133"
+                          id="g-svg-377"
                           fill="none"
                           class="items-item-page"
                           transform="matrix(1,0,0,1,0,0)"
@@ -971,7 +971,7 @@
                             fill="none"
                             transform="matrix(1,0,0,1,53.599998,0)"
                             class="items-item"
-                            width="70.64"
+                            width="70.63999999999999"
                             height="23"
                           >
                             <g
@@ -985,8 +985,8 @@
                                   id="g-svg-108"
                                   fill="rgba(0,0,0,0)"
                                   class="legend-category-item-background"
-                                  d="M 0,0 l 70.64,0 l 0,23 l-70.64 0 z"
-                                  width="70.64"
+                                  d="M 0,0 l 70.63999999999999,0 l 0,23 l-70.63999999999999 0 z"
+                                  width="70.63999999999999"
                                   height="23"
                                   visibility="visible"
                                 />
@@ -1049,7 +1049,7 @@
                             fill="none"
                             transform="matrix(1,0,0,1,136.240005,0)"
                             class="items-item"
-                            width="63.91999999999999"
+                            width="63.920000000000016"
                             height="23"
                           >
                             <g
@@ -1063,8 +1063,8 @@
                                   id="g-svg-116"
                                   fill="rgba(0,0,0,0)"
                                   class="legend-category-item-background"
-                                  d="M 0,0 l 63.91999999999999,0 l 0,23 l-63.91999999999999 0 z"
-                                  width="63.91999999999999"
+                                  d="M 0,0 l 63.920000000000016,0 l 0,23 l-63.920000000000016 0 z"
+                                  width="63.920000000000016"
                                   height="23"
                                   visibility="visible"
                                 />
@@ -1127,7 +1127,7 @@
                             fill="none"
                             transform="matrix(1,0,0,1,212.160004,0)"
                             class="items-item"
-                            width="57.8"
+                            width="57.79999999999998"
                             height="23"
                           >
                             <g
@@ -1141,8 +1141,8 @@
                                   id="g-svg-124"
                                   fill="rgba(0,0,0,0)"
                                   class="legend-category-item-background"
-                                  d="M 0,0 l 57.8,0 l 0,23 l-57.8 0 z"
-                                  width="57.8"
+                                  d="M 0,0 l 57.79999999999998,0 l 0,23 l-57.79999999999998 0 z"
+                                  width="57.79999999999998"
                                   height="23"
                                   visibility="visible"
                                 />
@@ -1205,7 +1205,7 @@
                             fill="none"
                             transform="matrix(1,0,0,1,281.959991,0)"
                             class="items-item"
-                            width="51.08"
+                            width="51.08000000000004"
                             height="23"
                           >
                             <g
@@ -1219,8 +1219,8 @@
                                   id="g-svg-132"
                                   fill="rgba(0,0,0,0)"
                                   class="legend-category-item-background"
-                                  d="M 0,0 l 51.08,0 l 0,23 l-51.08 0 z"
-                                  width="51.08"
+                                  d="M 0,0 l 51.08000000000004,0 l 0,23 l-51.08000000000004 0 z"
+                                  width="51.08000000000004"
                                   height="23"
                                   visibility="visible"
                                 />
@@ -1456,7 +1456,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-228"
+                              id="g-svg-418"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1477,7 +1477,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-229"
+                              id="g-svg-419"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1498,7 +1498,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-230"
+                              id="g-svg-420"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1519,7 +1519,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-231"
+                              id="g-svg-421"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1540,7 +1540,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-232"
+                              id="g-svg-422"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1561,7 +1561,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,-12)">
                             <line
-                              id="g-svg-233"
+                              id="g-svg-423"
                               fill="none"
                               x1="0"
                               y1="12"
@@ -1589,7 +1589,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-234"
+                              id="g-svg-424"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1618,7 +1618,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-235"
+                              id="g-svg-425"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1647,7 +1647,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-236"
+                              id="g-svg-426"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1676,7 +1676,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-237"
+                              id="g-svg-427"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1705,7 +1705,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-238"
+                              id="g-svg-428"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1734,7 +1734,7 @@
                         >
                           <g transform="matrix(1,0,0,1,0,0)">
                             <text
-                              id="g-svg-239"
+                              id="g-svg-429"
                               fill="rgba(29,33,41,1)"
                               dominant-baseline="central"
                               paint-order="stroke"
@@ -1786,14 +1786,14 @@
                       class="handle-icon-group"
                     >
                       <g
-                        id="g-svg-240"
+                        id="g-svg-430"
                         fill="none"
                         transform="matrix(1,0,0,1,0,0)"
                         class="handle-icon"
                       >
                         <g transform="matrix(1,0,0,1,-3.333333,-8)">
                           <path
-                            id="g-svg-241"
+                            id="g-svg-431"
                             fill="rgba(255,255,255,1)"
                             class="handle-icon-rect"
                             stroke-width="1"
@@ -1804,7 +1804,7 @@
                           />
                           <g transform="matrix(1,0,0,1,2.222222,4)">
                             <line
-                              id="g-svg-242"
+                              id="g-svg-432"
                               fill="rgba(255,255,255,1)"
                               x1="0"
                               y1="0"
@@ -1817,7 +1817,7 @@
                           </g>
                           <g transform="matrix(1,0,0,1,4.444445,4)">
                             <line
-                              id="g-svg-243"
+                              id="g-svg-433"
                               fill="rgba(255,255,255,1)"
                               x1="0"
                               y1="0"
@@ -1853,14 +1853,14 @@
                       class="handle-icon-group"
                     >
                       <g
-                        id="g-svg-244"
+                        id="g-svg-434"
                         fill="none"
                         transform="matrix(1,0,0,1,0,0)"
                         class="handle-icon"
                       >
                         <g transform="matrix(1,0,0,1,-3.333333,-8)">
                           <path
-                            id="g-svg-245"
+                            id="g-svg-435"
                             fill="rgba(255,255,255,1)"
                             class="handle-icon-rect"
                             stroke-width="1"
@@ -1871,7 +1871,7 @@
                           />
                           <g transform="matrix(1,0,0,1,2.222222,4)">
                             <line
-                              id="g-svg-246"
+                              id="g-svg-436"
                               fill="rgba(255,255,255,1)"
                               x1="0"
                               y1="0"
@@ -1884,7 +1884,7 @@
                           </g>
                           <g transform="matrix(1,0,0,1,4.444445,4)">
                             <line
-                              id="g-svg-247"
+                              id="g-svg-437"
                               fill="rgba(255,255,255,1)"
                               x1="0"
                               y1="0"
@@ -1943,7 +1943,7 @@
         </g>
         <g
           transform="matrix(1,0,0,1,52,97)"
-          clip-path="url(#clip-path-429-248)"
+          clip-path="url(#clip-path-616-248)"
         >
           <path
             id="g-svg-248"

--- a/__tests__/integration/snapshots/interaction/profit-interval-legend-filter-element-highlight/step2.svg
+++ b/__tests__/integration/snapshots/interaction/profit-interval-legend-filter-element-highlight/step2.svg
@@ -1,0 +1,585 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="640"
+  height="480"
+  style="background: transparent;"
+  color-interpolation-filters="sRGB"
+>
+  <defs>
+    <clipPath transform="matrix(1,0,0,1,-16,-16)" id="clip-path-51-17">
+      <use href="#g-svg-51" transform="matrix(1,0,0,1,16,16)" />
+    </clipPath>
+  </defs>
+  <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
+    <g id="g-root" fill="none" transform="matrix(1,0,0,1,0,0)">
+      <g id="g-svg-4" fill="none" transform="matrix(1,0,0,1,0,0)" class="view">
+        <g transform="matrix(1,0,0,1,0,0)">
+          <path
+            id="g-svg-5"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 640,0 l 0,480 l-640 0 z"
+            width="640"
+            height="480"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,16,16)">
+          <path
+            id="g-svg-6"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 608,0 l 0,448 l-608 0 z"
+            width="608"
+            height="448"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,76,51)">
+          <path
+            id="g-svg-7"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 548,0 l 0,413 l-548 0 z"
+            width="548"
+            height="413"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,76,51)">
+          <path
+            id="g-svg-8"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 548,0 l 0,413 l-548 0 z"
+            width="548"
+            height="413"
+          />
+        </g>
+        <g
+          id="g-svg-9"
+          fill="none"
+          transform="matrix(1,0,0,1,0,0)"
+          class="component"
+        >
+          <g
+            id="g-svg-10"
+            fill="none"
+            width="608"
+            height="23"
+            transform="matrix(1,0,0,1,16,16)"
+          >
+            <g
+              id="g-svg-11"
+              fill="none"
+              class="legend-category"
+              width="220.07999999999998"
+              height="23"
+              transform="matrix(1,0,0,1,0,0)"
+            >
+              <g
+                id="g-svg-12"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="legend-title-group"
+              >
+                <g
+                  id="g-svg-13"
+                  fill="none"
+                  width="220.07999999999998"
+                  height="23"
+                  transform="matrix(1,0,0,1,0,0)"
+                  class="legend-title"
+                />
+              </g>
+              <g
+                id="g-svg-14"
+                fill="none"
+                transform="matrix(1,0,0,1,0,0)"
+                class="legend-items-group"
+              >
+                <g
+                  id="g-svg-15"
+                  fill="none"
+                  width="220.07999999999998"
+                  height="23"
+                  transform="matrix(1,0,0,1,0,0)"
+                  class="legend-items"
+                >
+                  <g
+                    id="g-svg-16"
+                    fill="none"
+                    transform="matrix(1,0,0,1,0,0)"
+                    class="items-navigator"
+                  >
+                    <g
+                      id="g-svg-17"
+                      fill="none"
+                      class="navigator-content-group"
+                      transform="matrix(1,0,0,1,0,0)"
+                      clip-path="url(#clip-path-51-17)"
+                    >
+                      <g
+                        id="g-svg-18"
+                        fill="none"
+                        class="navigator-play-window"
+                        transform="matrix(1,0,0,1,0,0)"
+                      >
+                        <g
+                          id="g-svg-44"
+                          fill="none"
+                          class="items-item-page"
+                          transform="matrix(1,0,0,1,0,0)"
+                        >
+                          <g
+                            id="g-svg-20"
+                            fill="none"
+                            transform="matrix(1,0,0,1,0,0)"
+                            class="items-item"
+                            width="66.19999999999999"
+                            height="23"
+                          >
+                            <g
+                              id="g-svg-26"
+                              fill="none"
+                              transform="matrix(1,0,0,1,0,0)"
+                              class="legend-category-item-background-group"
+                            >
+                              <g transform="matrix(1,0,0,1,0,0)">
+                                <path
+                                  id="g-svg-27"
+                                  fill="rgba(0,0,0,0)"
+                                  class="legend-category-item-background"
+                                  d="M 0,0 l 66.19999999999999,0 l 0,23 l-66.19999999999999 0 z"
+                                  width="66.19999999999999"
+                                  height="23"
+                                  visibility="visible"
+                                />
+                              </g>
+                            </g>
+                            <g
+                              id="g-svg-21"
+                              fill="none"
+                              transform="matrix(0.500000,0,0,0.500000,4,11.500000)"
+                              class="legend-category-item-marker-group"
+                            >
+                              <g transform="matrix(1,0,0,1,-8,-8)">
+                                <path
+                                  id="g-svg-22"
+                                  fill="rgba(23,131,255,1)"
+                                  d="M 0,0 L 16,0 L 16,16 L 0,16 Z"
+                                  stroke-width="0"
+                                  class="legend-category-item-marker"
+                                  visibility="visible"
+                                />
+                              </g>
+                            </g>
+                            <g
+                              id="g-svg-23"
+                              fill="none"
+                              transform="matrix(1,0,0,1,16,11.500000)"
+                              class="legend-category-item-label-group"
+                            >
+                              <g transform="matrix(1,0,0,1,0,0)">
+                                <text
+                                  id="g-svg-24"
+                                  fill="rgba(29,33,41,1)"
+                                  dominant-baseline="central"
+                                  paint-order="stroke"
+                                  dx="0.5"
+                                  font-family="sans-serif"
+                                  font-size="12"
+                                  font-style="normal"
+                                  font-variant="normal"
+                                  font-weight="normal"
+                                  stroke-width="1"
+                                  text-anchor="left"
+                                  class="legend-category-item-label"
+                                  fill-opacity="0.9"
+                                  visibility="visible"
+                                >
+                                  Increase
+                                </text>
+                              </g>
+                            </g>
+                            <g
+                              id="g-svg-25"
+                              fill="none"
+                              transform="matrix(1,0,0,1,0,0)"
+                              class="legend-category-item-value-group"
+                            />
+                          </g>
+                          <g
+                            id="g-svg-28"
+                            fill="none"
+                            transform="matrix(1,0,0,1,78.199997,0)"
+                            class="items-item"
+                            width="71.47999999999999"
+                            height="23"
+                          >
+                            <g
+                              id="g-svg-34"
+                              fill="none"
+                              transform="matrix(1,0,0,1,0,0)"
+                              class="legend-category-item-background-group"
+                            >
+                              <g transform="matrix(1,0,0,1,0,0)">
+                                <path
+                                  id="g-svg-35"
+                                  fill="rgba(0,0,0,0)"
+                                  class="legend-category-item-background"
+                                  d="M 0,0 l 71.47999999999999,0 l 0,23 l-71.47999999999999 0 z"
+                                  width="71.47999999999999"
+                                  height="23"
+                                  visibility="visible"
+                                />
+                              </g>
+                            </g>
+                            <g
+                              id="g-svg-29"
+                              fill="none"
+                              transform="matrix(0.500000,0,0,0.500000,4,11.500000)"
+                              class="legend-category-item-marker-group"
+                            >
+                              <g transform="matrix(1,0,0,1,-8,-8)">
+                                <path
+                                  id="g-svg-30"
+                                  fill="rgba(0,201,201,1)"
+                                  d="M 0,0 L 16,0 L 16,16 L 0,16 Z"
+                                  stroke-width="0"
+                                  class="legend-category-item-marker"
+                                  visibility="visible"
+                                />
+                              </g>
+                            </g>
+                            <g
+                              id="g-svg-31"
+                              fill="none"
+                              transform="matrix(1,0,0,1,16,11.500000)"
+                              class="legend-category-item-label-group"
+                            >
+                              <g transform="matrix(1,0,0,1,0,0)">
+                                <text
+                                  id="g-svg-32"
+                                  fill="rgba(29,33,41,1)"
+                                  dominant-baseline="central"
+                                  paint-order="stroke"
+                                  dx="0.5"
+                                  font-family="sans-serif"
+                                  font-size="12"
+                                  font-style="normal"
+                                  font-variant="normal"
+                                  font-weight="normal"
+                                  stroke-width="1"
+                                  text-anchor="left"
+                                  class="legend-category-item-label"
+                                  fill-opacity="0.9"
+                                  visibility="visible"
+                                >
+                                  Decrease
+                                </text>
+                              </g>
+                            </g>
+                            <g
+                              id="g-svg-33"
+                              fill="none"
+                              transform="matrix(1,0,0,1,0,0)"
+                              class="legend-category-item-value-group"
+                            />
+                          </g>
+                          <g
+                            id="g-svg-36"
+                            fill="none"
+                            transform="matrix(1,0,0,1,161.679993,0)"
+                            class="items-item"
+                            width="46.400000000000006"
+                            height="23"
+                          >
+                            <g
+                              id="g-svg-42"
+                              fill="none"
+                              transform="matrix(1,0,0,1,0,0)"
+                              class="legend-category-item-background-group"
+                            >
+                              <g transform="matrix(1,0,0,1,0,0)">
+                                <path
+                                  id="g-svg-43"
+                                  fill="rgba(0,0,0,0)"
+                                  class="legend-category-item-background"
+                                  d="M 0,0 l 46.400000000000006,0 l 0,23 l-46.400000000000006 0 z"
+                                  width="46.400000000000006"
+                                  height="23"
+                                  visibility="visible"
+                                />
+                              </g>
+                            </g>
+                            <g
+                              id="g-svg-37"
+                              fill="none"
+                              transform="matrix(0.500000,0,0,0.500000,4,11.500000)"
+                              class="legend-category-item-marker-group"
+                            >
+                              <g transform="matrix(1,0,0,1,-8,-8)">
+                                <path
+                                  id="g-svg-38"
+                                  fill="rgba(240,136,77,1)"
+                                  d="M 0,0 L 16,0 L 16,16 L 0,16 Z"
+                                  stroke-width="0"
+                                  class="legend-category-item-marker"
+                                  visibility="visible"
+                                />
+                              </g>
+                            </g>
+                            <g
+                              id="g-svg-39"
+                              fill="none"
+                              transform="matrix(1,0,0,1,16,11.500000)"
+                              class="legend-category-item-label-group"
+                            >
+                              <g transform="matrix(1,0,0,1,0,0)">
+                                <text
+                                  id="g-svg-40"
+                                  fill="rgba(29,33,41,1)"
+                                  dominant-baseline="central"
+                                  paint-order="stroke"
+                                  dx="0.5"
+                                  font-family="sans-serif"
+                                  font-size="12"
+                                  font-style="normal"
+                                  font-variant="normal"
+                                  font-weight="normal"
+                                  stroke-width="1"
+                                  text-anchor="left"
+                                  class="legend-category-item-label"
+                                  fill-opacity="0.9"
+                                  visibility="visible"
+                                >
+                                  Total
+                                </text>
+                              </g>
+                            </g>
+                            <g
+                              id="g-svg-41"
+                              fill="none"
+                              transform="matrix(1,0,0,1,0,0)"
+                              class="legend-category-item-value-group"
+                            />
+                          </g>
+                        </g>
+                      </g>
+                    </g>
+                    <g
+                      id="g-svg-19"
+                      fill="none"
+                      transform="matrix(1,0,0,1,0,0)"
+                      class="navigator-controller"
+                    />
+                    <g transform="matrix(1,0,0,1,0,0)">
+                      <path
+                        id="g-svg-51"
+                        fill="none"
+                        d="M 0,0 l 208.07999267578123,0 l 0,23 l-208.07999267578123 0 z"
+                        class="navigator-clip-path"
+                        width="208.07999267578123"
+                        height="23"
+                      />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g transform="matrix(1,0,0,1,76,51)">
+          <path
+            id="g-svg-52"
+            fill="rgba(0,0,0,0)"
+            class="plot"
+            d="M 0,0 l 548,0 l 0,413 l-548 0 z"
+            width="548"
+            height="413"
+          />
+          <g
+            id="g-svg-53"
+            fill="none"
+            transform="matrix(1,0,0,1,0,0)"
+            class="main-layer"
+          >
+            <g transform="matrix(1,0,0,1,129.679382,178.449188)">
+              <path
+                id="g-svg-58"
+                fill="rgba(255,0,0,1)"
+                d="M 0,0 l 37.64885496183206,0 l 0,27.584173000108024 l-37.64885496183206 0 z"
+                width="37.64885496183206"
+                height="27.584173000108024"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(0,201,201,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,171.511444,206.033356)">
+              <path
+                id="g-svg-59"
+                fill="rgba(0,201,201,1)"
+                d="M 0,0 l 37.64885496183206,0 l 0,18.025506596321094 l-37.64885496183206 0 z"
+                width="37.64885496183206"
+                height="18.025506596321094"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(0,201,201,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,213.343506,224.058868)">
+              <path
+                id="g-svg-60"
+                fill="rgba(0,201,201,1)"
+                d="M 0,0 l 37.64885496183206,0 l 0,34.87240982942518 l-37.64885496183206 0 z"
+                width="37.64885496183206"
+                height="34.87240982942518"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(0,201,201,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,338.839691,155.265335)">
+              <path
+                id="g-svg-63"
+                fill="rgba(0,201,201,1)"
+                d="M 0,0 l 37.64885496183206,0 l 0,29.313452425412606 l-37.64885496183206 0 z"
+                width="37.64885496183206"
+                height="29.313452425412606"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(0,201,201,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,380.671753,184.578781)">
+              <path
+                id="g-svg-64"
+                fill="rgba(0,201,201,1)"
+                d="M 0,0 l 37.64885496183206,0 l 0,39.13023192180847 l-37.64885496183206 0 z"
+                width="37.64885496183206"
+                height="39.13023192180847"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(0,201,201,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,506.167938,0)">
+              <path
+                id="g-svg-67"
+                fill="rgba(240,136,77,1)"
+                d="M 0,0 l 37.64885496183206,0 l 0,413 l-37.64885496183206 0 z"
+                width="37.64885496183206"
+                height="413"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(240,136,77,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,4.183206,362.465149)">
+              <path
+                id="g-svg-80"
+                fill="rgba(23,131,255,1)"
+                d="M 0,0 l 37.64885496183206,0 l 0,50.5348375612096 l-37.64885496183206 0 z"
+                width="37.64885496183206"
+                height="50.5348375612096"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,46.015266,261.712830)">
+              <path
+                id="g-svg-81"
+                fill="rgba(23,131,255,1)"
+                d="M 0,0 l 37.648854961832065,0 l 0,100.75231868095062 l-37.648854961832065 0 z"
+                width="37.648854961832065"
+                height="100.75231868095062"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,87.847328,178.449188)">
+              <path
+                id="g-svg-82"
+                fill="rgba(23,131,255,1)"
+                d="M 0,0 l 37.64885496183206,0 l 0,83.26365599918606 l-37.64885496183206 0 z"
+                width="37.64885496183206"
+                height="83.26365599918606"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,255.175568,202.636261)">
+              <path
+                id="g-svg-83"
+                fill="rgba(23,131,255,1)"
+                d="M 0,0 l 37.648854961832086,0 l 0,56.29501356421244 l-37.648854961832086 0 z"
+                width="37.648854961832086"
+                height="56.29501356421244"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,297.007629,155.265335)">
+              <path
+                id="g-svg-84"
+                fill="rgba(23,131,255,1)"
+                d="M 0,0 l 37.64885496183206,0 l 0,47.37092955140466 l-37.64885496183206 0 z"
+                width="37.64885496183206"
+                height="47.37092955140466"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,422.503815,144.452774)">
+              <path
+                id="g-svg-85"
+                fill="rgba(23,131,255,1)"
+                d="M 0,0 l 37.64885496183206,0 l 0,79.2562479738991 l-37.64885496183206 0 z"
+                width="37.64885496183206"
+                height="79.2562479738991"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,464.335876,0)">
+              <path
+                id="g-svg-86"
+                fill="rgba(23,131,255,1)"
+                d="M 0,0 l 37.64885496183206,0 l 0,144.4527704422129 l-37.64885496183206 0 z"
+                width="37.64885496183206"
+                height="144.4527704422129"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+          </g>
+          <g
+            id="g-svg-54"
+            fill="none"
+            transform="matrix(1,0,0,1,0,0)"
+            class="label-layer"
+          />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/__tests__/integration/snapshots/interaction/profit-interval-slider-filter/step0.svg
+++ b/__tests__/integration/snapshots/interaction/profit-interval-slider-filter/step0.svg
@@ -10,14 +10,14 @@
       <use href="#g-svg-114" transform="matrix(1,0,0,1,16,7.500000)" />
     </clipPath>
     <path
-      id="g-svg-158"
+      id="g-svg-215"
       fill="none"
       d="M 0,0 l 572,0 l 0,377 l-572 0 z"
       width="572"
       height="377"
     />
-    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-158-115">
-      <use href="#g-svg-158" transform="matrix(1,0,0,1,52,51)" />
+    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-215-115">
+      <use href="#g-svg-215" transform="matrix(1,0,0,1,52,51)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -187,14 +187,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-133"
+                    id="g-svg-190"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-134"
+                        id="g-svg-191"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -206,7 +206,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-135"
+                          id="g-svg-192"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -220,7 +220,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-136"
+                          id="g-svg-193"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -272,14 +272,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-139"
+                    id="g-svg-196"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-140"
+                        id="g-svg-197"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -291,7 +291,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-141"
+                          id="g-svg-198"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -305,7 +305,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-142"
+                          id="g-svg-199"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -437,14 +437,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-57"
+                    id="g-svg-150"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-58"
+                        id="g-svg-151"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -456,7 +456,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-59"
+                          id="g-svg-152"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -470,7 +470,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-60"
+                          id="g-svg-153"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -522,14 +522,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-67"
+                    id="g-svg-156"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-68"
+                        id="g-svg-157"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -541,7 +541,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-69"
+                          id="g-svg-158"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -555,7 +555,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-70"
+                          id="g-svg-159"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -667,7 +667,7 @@
                         transform="matrix(1,0,0,1,0,0)"
                       >
                         <g
-                          id="g-svg-151"
+                          id="g-svg-208"
                           fill="none"
                           class="items-item-page"
                           transform="matrix(1,0,0,1,0,0)"
@@ -933,7 +933,7 @@
         </g>
         <g
           transform="matrix(1,0,0,1,52,51)"
-          clip-path="url(#clip-path-158-115)"
+          clip-path="url(#clip-path-215-115)"
         >
           <path
             id="g-svg-115"

--- a/__tests__/integration/snapshots/interaction/profit-interval-slider-filter/step1.svg
+++ b/__tests__/integration/snapshots/interaction/profit-interval-slider-filter/step1.svg
@@ -10,24 +10,24 @@
       <use href="#g-svg-114" transform="matrix(1,0,0,1,16,7.500000)" />
     </clipPath>
     <path
-      id="g-svg-158"
+      id="g-svg-215"
       fill="none"
       d="M 0,0 l 572,0 l 0,377 l-572 0 z"
       width="572"
       height="377"
     />
-    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-158-115">
-      <use href="#g-svg-158" transform="matrix(1,0,0,1,52,51)" />
+    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-215-115">
+      <use href="#g-svg-215" transform="matrix(1,0,0,1,52,51)" />
     </clipPath>
     <path
-      id="g-svg-193"
+      id="g-svg-250"
       fill="none"
       d="M 0,0 l 572,0 l 0,377 l-572 0 z"
       width="572"
       height="377"
     />
-    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-193-115">
-      <use href="#g-svg-193" transform="matrix(1,0,0,1,52,51)" />
+    <clipPath transform="matrix(1,0,0,1,-52,-51)" id="clip-path-250-115">
+      <use href="#g-svg-250" transform="matrix(1,0,0,1,52,51)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -197,14 +197,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-133"
+                    id="g-svg-190"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-134"
+                        id="g-svg-191"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -216,7 +216,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-135"
+                          id="g-svg-192"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -230,7 +230,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-136"
+                          id="g-svg-193"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -282,14 +282,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-139"
+                    id="g-svg-196"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-140"
+                        id="g-svg-197"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -301,7 +301,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-141"
+                          id="g-svg-198"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -315,7 +315,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-142"
+                          id="g-svg-199"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -451,14 +451,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-168"
+                    id="g-svg-225"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-169"
+                        id="g-svg-226"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -470,7 +470,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-170"
+                          id="g-svg-227"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -484,7 +484,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-171"
+                          id="g-svg-228"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -536,14 +536,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-174"
+                    id="g-svg-231"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-175"
+                        id="g-svg-232"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -555,7 +555,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-176"
+                          id="g-svg-233"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -569,7 +569,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-177"
+                          id="g-svg-234"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -681,7 +681,7 @@
                         transform="matrix(1,0,0,1,0,0)"
                       >
                         <g
-                          id="g-svg-186"
+                          id="g-svg-243"
                           fill="none"
                           class="items-item-page"
                           transform="matrix(1,0,0,1,0,0)"
@@ -947,7 +947,7 @@
         </g>
         <g
           transform="matrix(1,0,0,1,52,51)"
-          clip-path="url(#clip-path-193-115)"
+          clip-path="url(#clip-path-250-115)"
         >
           <path
             id="g-svg-115"

--- a/__tests__/integration/snapshots/static/aaplLineScrollbar.svg
+++ b/__tests__/integration/snapshots/static/aaplLineScrollbar.svg
@@ -7,14 +7,14 @@
 >
   <defs>
     <path
-      id="g-svg-98"
+      id="g-svg-120"
       fill="none"
       d="M 0,0 l 554,0 l 0,402 l-554 0 z"
       width="554"
       height="402"
     />
-    <clipPath transform="matrix(1,0,0,1,-70,-16)" id="clip-path-98-95">
-      <use href="#g-svg-98" transform="matrix(1,0,0,1,70,16)" />
+    <clipPath transform="matrix(1,0,0,1,-70,-16)" id="clip-path-120-95">
+      <use href="#g-svg-120" transform="matrix(1,0,0,1,70,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -375,7 +375,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-46"
+                      id="g-svg-103"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -396,7 +396,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-47"
+                      id="g-svg-104"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -424,7 +424,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-51"
+                      id="g-svg-105"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -452,7 +452,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-52"
+                      id="g-svg-106"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -635,7 +635,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-75"
+                      id="g-svg-108"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -656,7 +656,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-76"
+                      id="g-svg-109"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -677,7 +677,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-77"
+                      id="g-svg-110"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -698,7 +698,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-78"
+                      id="g-svg-111"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -719,7 +719,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-79"
+                      id="g-svg-112"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -740,7 +740,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-80"
+                      id="g-svg-113"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -768,7 +768,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-88"
+                      id="g-svg-114"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -795,7 +795,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-89"
+                      id="g-svg-115"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -822,7 +822,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-90"
+                      id="g-svg-116"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -849,7 +849,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-91"
+                      id="g-svg-117"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -876,7 +876,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-92"
+                      id="g-svg-118"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -903,7 +903,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-93"
+                      id="g-svg-119"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -932,7 +932,7 @@
             />
           </g>
         </g>
-        <g transform="matrix(1,0,0,1,70,16)" clip-path="url(#clip-path-98-95)">
+        <g transform="matrix(1,0,0,1,70,16)" clip-path="url(#clip-path-120-95)">
           <path
             id="g-svg-95"
             fill="rgba(0,0,0,0)"

--- a/__tests__/integration/snapshots/static/aaplLineScrollbarValue.svg
+++ b/__tests__/integration/snapshots/static/aaplLineScrollbarValue.svg
@@ -368,7 +368,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-46"
+                      id="g-svg-102"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -389,7 +389,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-47"
+                      id="g-svg-103"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -417,7 +417,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-51"
+                      id="g-svg-104"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -445,7 +445,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-52"
+                      id="g-svg-105"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -628,7 +628,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-75"
+                      id="g-svg-107"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -649,7 +649,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-76"
+                      id="g-svg-108"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -670,7 +670,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-77"
+                      id="g-svg-109"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -691,7 +691,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-78"
+                      id="g-svg-110"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -712,7 +712,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-79"
+                      id="g-svg-111"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -733,7 +733,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-80"
+                      id="g-svg-112"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -761,7 +761,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-88"
+                      id="g-svg-113"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -789,7 +789,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-89"
+                      id="g-svg-114"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -817,7 +817,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-90"
+                      id="g-svg-115"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -845,7 +845,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-91"
+                      id="g-svg-116"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -873,7 +873,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-92"
+                      id="g-svg-117"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -901,7 +901,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-93"
+                      id="g-svg-118"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"

--- a/__tests__/integration/snapshots/static/aaplLineSlider.svg
+++ b/__tests__/integration/snapshots/static/aaplLineSlider.svg
@@ -169,14 +169,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-32"
+                    id="g-svg-165"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-33"
+                        id="g-svg-166"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -188,7 +188,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-34"
+                          id="g-svg-167"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -202,7 +202,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-35"
+                          id="g-svg-168"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -254,14 +254,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-42"
+                    id="g-svg-171"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-43"
+                        id="g-svg-172"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -273,7 +273,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-44"
+                          id="g-svg-173"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -287,7 +287,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-45"
+                          id="g-svg-174"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -419,14 +419,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-60"
+                    id="g-svg-178"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-61"
+                        id="g-svg-179"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -438,7 +438,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-62"
+                          id="g-svg-180"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -452,7 +452,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-63"
+                          id="g-svg-181"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -504,14 +504,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-70"
+                    id="g-svg-184"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-71"
+                        id="g-svg-185"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -523,7 +523,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-72"
+                          id="g-svg-186"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -537,7 +537,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-73"
+                          id="g-svg-187"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -720,7 +720,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-95"
+                      id="g-svg-189"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -741,7 +741,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-96"
+                      id="g-svg-190"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -762,7 +762,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-97"
+                      id="g-svg-191"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -783,7 +783,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-98"
+                      id="g-svg-192"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -804,7 +804,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-99"
+                      id="g-svg-193"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -832,7 +832,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-106"
+                      id="g-svg-194"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -861,7 +861,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-107"
+                      id="g-svg-195"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -890,7 +890,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-108"
+                      id="g-svg-196"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -919,7 +919,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-109"
+                      id="g-svg-197"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -948,7 +948,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-110"
+                      id="g-svg-198"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1132,7 +1132,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-133"
+                      id="g-svg-200"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1153,7 +1153,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-134"
+                      id="g-svg-201"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1174,7 +1174,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-135"
+                      id="g-svg-202"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1195,7 +1195,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-136"
+                      id="g-svg-203"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1216,7 +1216,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-137"
+                      id="g-svg-204"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1237,7 +1237,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-138"
+                      id="g-svg-205"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1265,7 +1265,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-146"
+                      id="g-svg-206"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1293,7 +1293,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-147"
+                      id="g-svg-207"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1321,7 +1321,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-148"
+                      id="g-svg-208"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1349,7 +1349,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-149"
+                      id="g-svg-209"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1377,7 +1377,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-150"
+                      id="g-svg-210"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1405,7 +1405,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-151"
+                      id="g-svg-211"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"

--- a/__tests__/integration/snapshots/static/aaplLineSliderTransposed.svg
+++ b/__tests__/integration/snapshots/static/aaplLineSliderTransposed.svg
@@ -139,14 +139,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-33"
+                    id="g-svg-177"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-34"
+                        id="g-svg-178"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -158,7 +158,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-35"
+                          id="g-svg-179"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -172,7 +172,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-36"
+                          id="g-svg-180"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -224,14 +224,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-43"
+                    id="g-svg-183"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-44"
+                        id="g-svg-184"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -243,7 +243,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-45"
+                          id="g-svg-185"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -257,7 +257,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-46"
+                          id="g-svg-186"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -419,14 +419,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-66"
+                    id="g-svg-190"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-67"
+                        id="g-svg-191"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -438,7 +438,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-68"
+                          id="g-svg-192"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -452,7 +452,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-69"
+                          id="g-svg-193"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -504,14 +504,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-76"
+                    id="g-svg-196"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-77"
+                        id="g-svg-197"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -523,7 +523,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-78"
+                          id="g-svg-198"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -537,7 +537,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-79"
+                          id="g-svg-199"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -720,7 +720,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-101"
+                      id="g-svg-201"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -741,7 +741,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-102"
+                      id="g-svg-202"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -762,7 +762,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-103"
+                      id="g-svg-203"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -783,7 +783,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-104"
+                      id="g-svg-204"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -804,7 +804,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-105"
+                      id="g-svg-205"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -832,7 +832,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-112"
+                      id="g-svg-206"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -860,7 +860,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-113"
+                      id="g-svg-207"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -888,7 +888,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-114"
+                      id="g-svg-208"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -916,7 +916,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-115"
+                      id="g-svg-209"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -944,7 +944,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-116"
+                      id="g-svg-210"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1127,7 +1127,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-139"
+                      id="g-svg-212"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1148,7 +1148,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-140"
+                      id="g-svg-213"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1169,7 +1169,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-141"
+                      id="g-svg-214"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1190,7 +1190,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-142"
+                      id="g-svg-215"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1211,7 +1211,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-143"
+                      id="g-svg-216"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1232,7 +1232,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-144"
+                      id="g-svg-217"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1260,7 +1260,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-152"
+                      id="g-svg-218"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1289,7 +1289,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-153"
+                      id="g-svg-219"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1318,7 +1318,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-154"
+                      id="g-svg-220"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1347,7 +1347,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-155"
+                      id="g-svg-221"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1376,7 +1376,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-156"
+                      id="g-svg-222"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1405,7 +1405,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-157"
+                      id="g-svg-223"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"

--- a/__tests__/integration/snapshots/static/alphabetIntervalAutoPaddingSlider.svg
+++ b/__tests__/integration/snapshots/static/alphabetIntervalAutoPaddingSlider.svg
@@ -169,14 +169,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-62"
+                    id="g-svg-335"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-63"
+                        id="g-svg-336"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -188,7 +188,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-64"
+                          id="g-svg-337"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -202,7 +202,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-65"
+                          id="g-svg-338"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -254,14 +254,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-72"
+                    id="g-svg-341"
                     fill="none"
                     transform="matrix(1,0,0,1,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-73"
+                        id="g-svg-342"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -273,7 +273,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-74"
+                          id="g-svg-343"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -287,7 +287,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-75"
+                          id="g-svg-344"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -419,14 +419,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-90"
+                    id="g-svg-348"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-91"
+                        id="g-svg-349"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -438,7 +438,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-92"
+                          id="g-svg-350"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -452,7 +452,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-93"
+                          id="g-svg-351"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -504,14 +504,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-100"
+                    id="g-svg-354"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-101"
+                        id="g-svg-355"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -523,7 +523,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-102"
+                          id="g-svg-356"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -537,7 +537,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-103"
+                          id="g-svg-357"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -639,7 +639,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-138"
+                      id="g-svg-359"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -660,7 +660,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-139"
+                      id="g-svg-360"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -681,7 +681,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-140"
+                      id="g-svg-361"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -702,7 +702,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-141"
+                      id="g-svg-362"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -723,7 +723,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-142"
+                      id="g-svg-363"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -744,7 +744,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-143"
+                      id="g-svg-364"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -765,7 +765,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-144"
+                      id="g-svg-365"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -786,7 +786,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-145"
+                      id="g-svg-366"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -807,7 +807,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-146"
+                      id="g-svg-367"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -828,7 +828,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-147"
+                      id="g-svg-368"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -849,7 +849,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-148"
+                      id="g-svg-369"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -870,7 +870,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-149"
+                      id="g-svg-370"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -891,7 +891,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-150"
+                      id="g-svg-371"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -912,7 +912,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-151"
+                      id="g-svg-372"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -933,7 +933,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-152"
+                      id="g-svg-373"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -954,7 +954,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-153"
+                      id="g-svg-374"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -975,7 +975,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-154"
+                      id="g-svg-375"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -996,7 +996,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-155"
+                      id="g-svg-376"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1017,7 +1017,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-156"
+                      id="g-svg-377"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1038,7 +1038,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-157"
+                      id="g-svg-378"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1059,7 +1059,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-158"
+                      id="g-svg-379"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1080,7 +1080,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-159"
+                      id="g-svg-380"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1101,7 +1101,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-160"
+                      id="g-svg-381"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1122,7 +1122,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-161"
+                      id="g-svg-382"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1143,7 +1143,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-162"
+                      id="g-svg-383"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1164,7 +1164,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-163"
+                      id="g-svg-384"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1192,7 +1192,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-191"
+                      id="g-svg-385"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1220,7 +1220,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-192"
+                      id="g-svg-386"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1248,7 +1248,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-193"
+                      id="g-svg-387"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1276,7 +1276,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-194"
+                      id="g-svg-388"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1304,7 +1304,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-195"
+                      id="g-svg-389"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1332,7 +1332,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-196"
+                      id="g-svg-390"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1360,7 +1360,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-197"
+                      id="g-svg-391"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1388,7 +1388,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-198"
+                      id="g-svg-392"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1416,7 +1416,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-199"
+                      id="g-svg-393"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1444,7 +1444,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-200"
+                      id="g-svg-394"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1472,7 +1472,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-201"
+                      id="g-svg-395"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1500,7 +1500,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-202"
+                      id="g-svg-396"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1528,7 +1528,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-203"
+                      id="g-svg-397"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1556,7 +1556,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-204"
+                      id="g-svg-398"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1584,7 +1584,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-205"
+                      id="g-svg-399"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1612,7 +1612,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-206"
+                      id="g-svg-400"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1640,7 +1640,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-207"
+                      id="g-svg-401"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1668,7 +1668,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-208"
+                      id="g-svg-402"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1696,7 +1696,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-209"
+                      id="g-svg-403"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1724,7 +1724,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-210"
+                      id="g-svg-404"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1752,7 +1752,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-211"
+                      id="g-svg-405"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1780,7 +1780,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-212"
+                      id="g-svg-406"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1808,7 +1808,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-213"
+                      id="g-svg-407"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1836,7 +1836,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-214"
+                      id="g-svg-408"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1864,7 +1864,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-215"
+                      id="g-svg-409"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1892,7 +1892,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-216"
+                      id="g-svg-410"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2109,7 +2109,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-243"
+                      id="g-svg-413"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -2130,7 +2130,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-244"
+                      id="g-svg-414"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -2151,7 +2151,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-245"
+                      id="g-svg-415"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -2172,7 +2172,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-246"
+                      id="g-svg-416"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -2193,7 +2193,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-247"
+                      id="g-svg-417"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -2214,7 +2214,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-248"
+                      id="g-svg-418"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -2235,7 +2235,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-249"
+                      id="g-svg-419"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -2263,7 +2263,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-258"
+                      id="g-svg-420"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2291,7 +2291,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-259"
+                      id="g-svg-421"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2319,7 +2319,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-260"
+                      id="g-svg-422"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2347,7 +2347,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-261"
+                      id="g-svg-423"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2375,7 +2375,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-262"
+                      id="g-svg-424"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2403,7 +2403,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-263"
+                      id="g-svg-425"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2431,7 +2431,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-264"
+                      id="g-svg-426"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"

--- a/__tests__/integration/snapshots/static/weatherLineMultiScrollbar.svg
+++ b/__tests__/integration/snapshots/static/weatherLineMultiScrollbar.svg
@@ -7,14 +7,14 @@
 >
   <defs>
     <path
-      id="g-svg-197"
+      id="g-svg-301"
       fill="none"
       d="M 0,0 l 449.1999943878883,0 l 0,382 l-449.1999943878883 0 z"
       width="449.1999943878883"
       height="382"
     />
-    <clipPath transform="matrix(1,0,0,1,-91.680000,-16)" id="clip-path-197-192">
-      <use href="#g-svg-197" transform="matrix(1,0,0,1,91.680000,16)" />
+    <clipPath transform="matrix(1,0,0,1,-91.680000,-16)" id="clip-path-301-192">
+      <use href="#g-svg-301" transform="matrix(1,0,0,1,91.680000,16)" />
     </clipPath>
   </defs>
   <g id="g-svg-camera" transform="matrix(1,0,0,1,0,0)">
@@ -300,7 +300,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-76"
+                      id="g-svg-244"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -321,7 +321,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-77"
+                      id="g-svg-245"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -342,7 +342,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-78"
+                      id="g-svg-246"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -363,7 +363,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-79"
+                      id="g-svg-247"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -384,7 +384,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-80"
+                      id="g-svg-248"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -405,7 +405,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-81"
+                      id="g-svg-249"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -426,7 +426,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-82"
+                      id="g-svg-250"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -447,7 +447,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-83"
+                      id="g-svg-251"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -468,7 +468,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-84"
+                      id="g-svg-252"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -489,7 +489,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-85"
+                      id="g-svg-253"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -510,7 +510,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-86"
+                      id="g-svg-254"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -531,7 +531,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-87"
+                      id="g-svg-255"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -559,7 +559,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-101"
+                      id="g-svg-256"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -588,7 +588,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-102"
+                      id="g-svg-257"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -617,7 +617,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-103"
+                      id="g-svg-258"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -646,7 +646,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-104"
+                      id="g-svg-259"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -675,7 +675,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-105"
+                      id="g-svg-260"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -704,7 +704,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-106"
+                      id="g-svg-261"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -733,7 +733,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-107"
+                      id="g-svg-262"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -762,7 +762,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-108"
+                      id="g-svg-263"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -791,7 +791,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-109"
+                      id="g-svg-264"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -820,7 +820,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-110"
+                      id="g-svg-265"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -849,7 +849,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-111"
+                      id="g-svg-266"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -878,7 +878,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-112"
+                      id="g-svg-267"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -991,7 +991,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-130"
+                      id="g-svg-270"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1012,7 +1012,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-131"
+                      id="g-svg-271"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1033,7 +1033,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-132"
+                      id="g-svg-272"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1054,7 +1054,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-133"
+                      id="g-svg-273"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1075,7 +1075,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-134"
+                      id="g-svg-274"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1096,7 +1096,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-135"
+                      id="g-svg-275"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1117,7 +1117,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-136"
+                      id="g-svg-276"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1138,7 +1138,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-137"
+                      id="g-svg-277"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1166,7 +1166,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-147"
+                      id="g-svg-278"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1194,7 +1194,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-148"
+                      id="g-svg-279"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1222,7 +1222,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-149"
+                      id="g-svg-280"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1250,7 +1250,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-150"
+                      id="g-svg-281"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1278,7 +1278,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-151"
+                      id="g-svg-282"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1306,7 +1306,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-152"
+                      id="g-svg-283"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1334,7 +1334,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-153"
+                      id="g-svg-284"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1362,7 +1362,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-154"
+                      id="g-svg-285"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1473,7 +1473,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-170"
+                      id="g-svg-288"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1494,7 +1494,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-171"
+                      id="g-svg-289"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1515,7 +1515,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-172"
+                      id="g-svg-290"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1536,7 +1536,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-173"
+                      id="g-svg-291"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1557,7 +1557,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-174"
+                      id="g-svg-292"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1578,7 +1578,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-175"
+                      id="g-svg-293"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1606,7 +1606,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-183"
+                      id="g-svg-294"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1634,7 +1634,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-184"
+                      id="g-svg-295"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1662,7 +1662,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-185"
+                      id="g-svg-296"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1690,7 +1690,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-186"
+                      id="g-svg-297"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1718,7 +1718,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-187"
+                      id="g-svg-298"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1746,7 +1746,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-188"
+                      id="g-svg-299"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1800,7 +1800,7 @@
         </g>
         <g
           transform="matrix(1,0,0,1,91.680000,16)"
-          clip-path="url(#clip-path-197-192)"
+          clip-path="url(#clip-path-301-192)"
         >
           <path
             id="g-svg-192"

--- a/__tests__/integration/snapshots/static/weatherLineMultiSlider.svg
+++ b/__tests__/integration/snapshots/static/weatherLineMultiSlider.svg
@@ -139,14 +139,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-55"
+                    id="g-svg-323"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-56"
+                        id="g-svg-324"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -158,7 +158,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-57"
+                          id="g-svg-325"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -172,7 +172,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-58"
+                          id="g-svg-326"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -224,14 +224,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-65"
+                    id="g-svg-329"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-66"
+                        id="g-svg-330"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -243,7 +243,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-67"
+                          id="g-svg-331"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -257,7 +257,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-68"
+                          id="g-svg-332"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -389,14 +389,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-83"
+                    id="g-svg-336"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-84"
+                        id="g-svg-337"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -408,7 +408,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-85"
+                          id="g-svg-338"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -422,7 +422,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-86"
+                          id="g-svg-339"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -474,14 +474,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-93"
+                    id="g-svg-342"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-94"
+                        id="g-svg-343"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -493,7 +493,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-95"
+                          id="g-svg-344"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -507,7 +507,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-96"
+                          id="g-svg-345"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -639,14 +639,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-111"
+                    id="g-svg-349"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-112"
+                        id="g-svg-350"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -658,7 +658,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-113"
+                          id="g-svg-351"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -672,7 +672,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-114"
+                          id="g-svg-352"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -724,14 +724,14 @@
                   class="handle-icon-group"
                 >
                   <g
-                    id="g-svg-121"
+                    id="g-svg-355"
                     fill="none"
                     transform="matrix(0,1,-1,0,0,0)"
                     class="handle-icon"
                   >
                     <g transform="matrix(1,0,0,1,-5,-12)">
                       <path
-                        id="g-svg-122"
+                        id="g-svg-356"
                         fill="rgba(247,247,247,1)"
                         class="handle-icon-rect"
                         stroke-width="1"
@@ -743,7 +743,7 @@
                       />
                       <g transform="matrix(1,0,0,1,3.333333,6)">
                         <line
-                          id="g-svg-123"
+                          id="g-svg-357"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -757,7 +757,7 @@
                       </g>
                       <g transform="matrix(1,0,0,1,6.666667,6)">
                         <line
-                          id="g-svg-124"
+                          id="g-svg-358"
                           fill="rgba(247,247,247,1)"
                           x1="0"
                           y1="0"
@@ -859,7 +859,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-145"
+                      id="g-svg-360"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -880,7 +880,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-146"
+                      id="g-svg-361"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -901,7 +901,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-147"
+                      id="g-svg-362"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -922,7 +922,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-148"
+                      id="g-svg-363"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -943,7 +943,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-149"
+                      id="g-svg-364"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -964,7 +964,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-150"
+                      id="g-svg-365"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -985,7 +985,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-151"
+                      id="g-svg-366"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1006,7 +1006,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-152"
+                      id="g-svg-367"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1027,7 +1027,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-153"
+                      id="g-svg-368"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1048,7 +1048,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-154"
+                      id="g-svg-369"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1069,7 +1069,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-155"
+                      id="g-svg-370"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1090,7 +1090,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-156"
+                      id="g-svg-371"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -1118,7 +1118,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-170"
+                      id="g-svg-372"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1147,7 +1147,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-171"
+                      id="g-svg-373"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1176,7 +1176,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-172"
+                      id="g-svg-374"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1205,7 +1205,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-173"
+                      id="g-svg-375"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1234,7 +1234,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-174"
+                      id="g-svg-376"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1263,7 +1263,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-175"
+                      id="g-svg-377"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1292,7 +1292,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-176"
+                      id="g-svg-378"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1321,7 +1321,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-177"
+                      id="g-svg-379"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1350,7 +1350,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-178"
+                      id="g-svg-380"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1379,7 +1379,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-179"
+                      id="g-svg-381"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1408,7 +1408,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-180"
+                      id="g-svg-382"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1437,7 +1437,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-181"
+                      id="g-svg-383"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1550,7 +1550,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-197"
+                      id="g-svg-386"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1571,7 +1571,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-198"
+                      id="g-svg-387"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1592,7 +1592,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-199"
+                      id="g-svg-388"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1613,7 +1613,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-200"
+                      id="g-svg-389"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1634,7 +1634,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-201"
+                      id="g-svg-390"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1655,7 +1655,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-202"
+                      id="g-svg-391"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1683,7 +1683,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-210"
+                      id="g-svg-392"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1711,7 +1711,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-211"
+                      id="g-svg-393"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1739,7 +1739,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-212"
+                      id="g-svg-394"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1767,7 +1767,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-213"
+                      id="g-svg-395"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1795,7 +1795,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-214"
+                      id="g-svg-396"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1823,7 +1823,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-215"
+                      id="g-svg-397"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -1934,7 +1934,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-230"
+                      id="g-svg-400"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1955,7 +1955,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-231"
+                      id="g-svg-401"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1976,7 +1976,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-232"
+                      id="g-svg-402"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -1997,7 +1997,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-233"
+                      id="g-svg-403"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -2018,7 +2018,7 @@
                 >
                   <g transform="matrix(1,0,0,1,-4,0)">
                     <line
-                      id="g-svg-234"
+                      id="g-svg-404"
                       fill="none"
                       x1="4"
                       y1="0"
@@ -2046,7 +2046,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-241"
+                      id="g-svg-405"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2074,7 +2074,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-242"
+                      id="g-svg-406"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2102,7 +2102,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-243"
+                      id="g-svg-407"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2130,7 +2130,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-244"
+                      id="g-svg-408"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2158,7 +2158,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-245"
+                      id="g-svg-409"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2269,7 +2269,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-258"
+                      id="g-svg-412"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -2290,7 +2290,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-259"
+                      id="g-svg-413"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -2311,7 +2311,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <line
-                      id="g-svg-260"
+                      id="g-svg-414"
                       fill="none"
                       x1="0"
                       y1="0"
@@ -2339,7 +2339,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-265"
+                      id="g-svg-415"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2367,7 +2367,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-266"
+                      id="g-svg-416"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"
@@ -2395,7 +2395,7 @@
                 >
                   <g transform="matrix(1,0,0,1,0,0)">
                     <text
-                      id="g-svg-267"
+                      id="g-svg-417"
                       fill="rgba(29,33,41,1)"
                       dominant-baseline="central"
                       paint-order="stroke"

--- a/__tests__/plots/api/chart-on-scrollbar-filter.ts
+++ b/__tests__/plots/api/chart-on-scrollbar-filter.ts
@@ -1,0 +1,33 @@
+import { Chart } from '../../../src';
+
+export function chartOnScrollbarFilter(context) {
+  const { container, canvas } = context;
+
+  const chart = new Chart({ container, canvas });
+
+  chart
+    .interval()
+    .data([
+      { genre: 'Sports', sold: 275 },
+      { genre: 'Strategy', sold: 115 },
+      { genre: 'Action', sold: 120 },
+      { genre: 'Shooter', sold: 350 },
+      { genre: 'Other', sold: 150 },
+    ])
+    .encode('x', 'genre')
+    .encode('y', 'sold')
+    .encode('color', 'genre')
+    .scrollbar('x', true)
+    .interaction('elementSelect');
+
+  chart.on('element:select', (event) => {
+    const { data, nativeEvent } = event;
+    if (nativeEvent) console.log(data);
+  });
+
+  chart.on('element:click', (e) => console.log(e.data.data));
+
+  const finished = chart.render();
+
+  return { chart, finished };
+}

--- a/__tests__/plots/api/index.ts
+++ b/__tests__/plots/api/index.ts
@@ -47,3 +47,4 @@ export { chartChangeSizeCustomShape } from './chart-change-size-custom-shape';
 export { chartOptionsCallbackChildren } from './chart-options-callback-children';
 export { chartAutoFitSlider } from './chart-auto-fit-slider';
 export { chart3d } from './chart-3d';
+export { chartOnScrollbarFilter } from './chart-on-scrollbar-filter';

--- a/__tests__/plots/interaction/alphabet-interval-active-scrollbar.ts
+++ b/__tests__/plots/interaction/alphabet-interval-active-scrollbar.ts
@@ -1,0 +1,45 @@
+import { G2Spec, ELEMENT_CLASS_NAME } from '../../../src';
+import { SLIDER_CLASS_NAME } from '../../../src/interaction/sliderFilter';
+import { disableDelay, step } from './utils';
+import { dispatchValueChange } from './appl-line-slider-filter';
+
+export function alphabetIntervalActiveScrollbar(): G2Spec {
+  return {
+    type: 'interval',
+    data: {
+      type: 'fetch',
+      value: 'data/alphabet.csv',
+    },
+    encode: {
+      x: 'letter',
+      y: 'frequency',
+      color: 'steelblue',
+    },
+    scale: { x: { padding: 0.5 } },
+    slider: { x: true },
+    transform: [{ type: 'sortX', by: 'y', reverse: true }],
+    state: { active: { fill: 'red' } },
+    interaction: { elementHighlight: { background: true } },
+  };
+}
+
+alphabetIntervalActiveScrollbar.steps = ({ canvas }) => {
+  const { document } = canvas;
+  const sliders = document.getElementsByClassName(SLIDER_CLASS_NAME);
+  const [s1] = sliders;
+  return [
+    {
+      changeState: () => {
+        dispatchValueChange(s1);
+      },
+      skip: true,
+    },
+    {
+      changeState: () => {
+        const elements = document.getElementsByClassName(ELEMENT_CLASS_NAME);
+        const [e] = elements;
+        return step(e, 'pointerover').changeState();
+      },
+    },
+  ];
+};

--- a/__tests__/plots/interaction/index.ts
+++ b/__tests__/plots/interaction/index.ts
@@ -73,3 +73,5 @@ export { pointsPointTooltipMarker } from './points-point-tooltip-marker';
 export { mockPieInteraction } from './mock-pie-interaction';
 export { missingAreaTooltipMarker } from './missing-area-tooltip-marker';
 export { penguinsPointRepeatMatrixLegendFilter } from './penguins-point-repeat-matrix-legend-filter';
+export { alphabetIntervalActiveScrollbar } from './alphabet-interval-active-scrollbar';
+export { profitIntervalLegendFilterElementHighlight } from './profit-interval-legend-filter-element-highlight';

--- a/__tests__/plots/interaction/profit-interval-legend-filter-element-highlight.ts
+++ b/__tests__/plots/interaction/profit-interval-legend-filter-element-highlight.ts
@@ -1,0 +1,43 @@
+import { ELEMENT_CLASS_NAME, G2Spec } from '../../../src';
+import { LEGEND_ITEMS_CLASS_NAME } from '../../../src/interaction/legendFilter';
+import { profit } from '../../data/profit';
+import { step } from './utils';
+
+export function profitIntervalLegendFilterElementHighlight(): G2Spec {
+  return {
+    paddingLeft: 60,
+    type: 'interval',
+    data: profit,
+    axis: { x: { animate: false }, y: { labelFormatter: '~s' } },
+    legend: {
+      color: {
+        state: { unselected: { labelOpacity: 0.5, markerOpacity: 0.5 } },
+      },
+    },
+    encode: {
+      x: 'month',
+      y: ['end', 'start'],
+      color: (d) =>
+        d.month === 'Total' ? 'Total' : d.profit > 0 ? 'Increase' : 'Decrease',
+    },
+    state: { active: { fill: 'red' } },
+    interaction: { elementHighlight: true },
+  };
+}
+
+profitIntervalLegendFilterElementHighlight.steps = ({ canvas }) => {
+  const { document } = canvas;
+  const items = document.getElementsByClassName(LEGEND_ITEMS_CLASS_NAME);
+
+  const [i0] = items;
+  return [
+    step(i0, 'click', { skip: true }),
+    step(i0, 'click', { skip: true }),
+    {
+      changeState: () => {
+        const [e0] = document.getElementsByClassName(ELEMENT_CLASS_NAME);
+        step(e0, 'pointerover').changeState();
+      },
+    },
+  ];
+};

--- a/src/interaction/chartIndex.ts
+++ b/src/interaction/chartIndex.ts
@@ -154,7 +154,7 @@ export function ChartIndex({
         return clonedOptions;
       });
 
-      const newState = await update();
+      const newState = await update('chartIndex');
       newView = newState.view;
     };
 
@@ -215,3 +215,7 @@ export function ChartIndex({
     };
   };
 }
+
+ChartIndex.props = {
+  reapplyWhenUpdate: true,
+};

--- a/src/interaction/elementHighlight.ts
+++ b/src/interaction/elementHighlight.ts
@@ -194,3 +194,7 @@ export function ElementHighlight({
     });
   };
 }
+
+ElementHighlight.props = {
+  reapplyWhenUpdate: true,
+};

--- a/src/interaction/elementHighlightByColor.ts
+++ b/src/interaction/elementHighlightByColor.ts
@@ -4,3 +4,7 @@ import { ElementHighlight } from './elementHighlight';
 export function ElementHighlightByColor(options) {
   return ElementHighlight({ ...options, createGroup: createColorKey });
 }
+
+ElementHighlightByColor.props = {
+  reapplyWhenUpdate: true,
+};

--- a/src/interaction/elementHighlightByX.ts
+++ b/src/interaction/elementHighlightByX.ts
@@ -4,3 +4,7 @@ import { ElementHighlight } from './elementHighlight';
 export function ElementHighlightByX(options) {
   return ElementHighlight({ ...options, createGroup: createXKey });
 }
+
+ElementHighlightByX.props = {
+  reapplyWhenUpdate: true,
+};

--- a/src/interaction/elementSelect.ts
+++ b/src/interaction/elementSelect.ts
@@ -209,3 +209,7 @@ export function ElementSelect({
     });
   };
 }
+
+ElementSelect.props = {
+  reapplyWhenUpdate: true,
+};

--- a/src/interaction/elementSelectByColor.ts
+++ b/src/interaction/elementSelectByColor.ts
@@ -4,3 +4,7 @@ import { ElementSelect } from './elementSelect';
 export function ElementSelectByColor(options) {
   return ElementSelect({ ...options, createGroup: createColorKey });
 }
+
+ElementSelectByColor.props = {
+  reapplyWhenUpdate: true,
+};

--- a/src/interaction/elementSelectByX.ts
+++ b/src/interaction/elementSelectByX.ts
@@ -4,3 +4,7 @@ import { ElementSelect } from './elementSelect';
 export function ElementSelectByX(options) {
   return ElementSelect({ ...options, createGroup: createXKey });
 }
+
+ElementSelectByX.props = {
+  reapplyWhenUpdate: true,
+};

--- a/src/interaction/event.ts
+++ b/src/interaction/event.ts
@@ -162,3 +162,7 @@ export function Event() {
     };
   };
 }
+
+Event.props = {
+  reapplyWhenUpdate: true,
+};

--- a/src/interaction/poptip.ts
+++ b/src/interaction/poptip.ts
@@ -85,3 +85,7 @@ export function Poptip({ offsetX = 8, offsetY = 8, ...style }) {
     };
   };
 }
+
+Poptip.props = {
+  reapplyWhenUpdate: true,
+};

--- a/src/interaction/sliderFilter.ts
+++ b/src/interaction/sliderFilter.ts
@@ -207,6 +207,9 @@ export function SliderFilter({
       emitHandlers.add([eventName, emitHandler]);
     }
 
+    // Update to async state such as scale.
+    update();
+
     return () => {
       for (const [slider, handler] of sliderHandler) {
         slider.removeEventListener('valuechange', handler);

--- a/src/interaction/tooltip.ts
+++ b/src/interaction/tooltip.ts
@@ -992,3 +992,7 @@ export function Tooltip(options) {
     });
   };
 }
+
+Tooltip.props = {
+  reapplyWhenUpdate: true,
+};

--- a/src/runtime/types/common.ts
+++ b/src/runtime/types/common.ts
@@ -53,7 +53,7 @@ export type G2ViewInstance = {
   view: G2ViewDescriptor;
   container: DisplayObject;
   options: G2ViewTree;
-  update: (options: G2ViewTree) => Promise<any>;
+  update: (options: G2ViewTree, source?: string) => Promise<any>;
 };
 
 export type ChannelGroups = {


### PR DESCRIPTION
- fix: https://github.com/antvis/G2/issues/5838
- fix: https://github.com/antvis/G2/issues/5619
- fix: https://github.com/antvis/G2/issues/5529
- fix: https://github.com/antvis/G2/issues/5503

## 存在问题

部分交互 A 触发之后，某些交互 B 需要重新应用才能生效。 比如当 slider 滑动之后，比例尺、图形都发生了变化，element highlight 交互就需要重新应用，才能在新的尺度下对新的图形应用。类似 sliderFilter 的 A 类交互有：

- brushFilter
- legendFilter
- scollbarFilter

需要重新应用的 B 类交互有

- highlight
- select
- event
- tooltip 

## 解决办法

对于 B 类交互，设置 props:

```js
function A() {
}

A.props = { reapplyWhenUpdate: true }
```

在执行 A 交互的更新操作的时候，重新应用这些交互

## 说明

slider 和 scrollbar 相关截图的更新只是元素 id 的变化，图表本身没有变化。