### PR TITLE
fix: cannot find document if group destroyed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ site/.dumi/tmp-production
 
 # Editor
 .vscode
-
+.history
 
 # Other
 !/src/lib

--- a/src/runtime/library.ts
+++ b/src/runtime/library.ts
@@ -15,7 +15,7 @@ export function useLibrary<
 >(
   namespace: G2ComponentNamespaces,
   publicLibrary: G2Library,
-): [(options: O, context?) => V, (type: O['type']) => C] {
+): [(options: O, context?: G2Context) => V, (type: O['type']) => C] {
   const library = { ...builtinlib(), ...publicLibrary };
 
   const create = (type: O['type']) => {
@@ -23,15 +23,25 @@ export function useLibrary<
     const key = `${namespace}.${type}`;
     return library[key] || error(`Unknown Component: ${key}`);
   };
-  const use = (options: O, context?) => {
+
+  const use = (options: O, context?: G2Context) => {
     const { type, ...rest } = options;
-    return create(type)(rest, context);
+    if (!type) {
+      error(`Plot type is required!`);
+    }
+
+    const currentLibrary = create(type);
+    return currentLibrary?.(rest, context);
   };
+
   return [use, create];
 }
 
 export function documentOf(library: G2Context): IDocument {
   const { canvas, group } = library;
-  if (group) return group.ownerDocument;
-  return canvas.document;
+  return (
+    canvas?.document ||
+    group?.ownerDocument ||
+    error(`Cannot find library document`)
+  );
 }

--- a/src/runtime/render.ts
+++ b/src/runtime/render.ts
@@ -137,17 +137,18 @@ export function renderToMountedElement<T extends G2ViewTree = G2ViewTree>(
     error(`renderToMountedElement can't render chart to unmounted group.`);
   }
 
+  const canvas = context.canvas || group?.ownerDocument?.defaultView;
   const selection = select(group);
   context.group = group;
   context.emitter = emitter;
+  context.canvas ??= canvas as GCanvas;
 
   emitter.emit(ChartEvent.BEFORE_RENDER);
   // Plot the chart and mutate context.
   // Make sure that plot chart after container is ready for every time.
   plot<T>({ ...keyed, width, height }, selection, library, context)
     .then(() => {
-      const canvas = group.ownerDocument.defaultView;
-      canvas.requestAnimationFrame(() => {
+      canvas?.requestAnimationFrame(() => {
         emitter.emit(ChartEvent.AFTER_RENDER);
         resolve?.();
       });

--- a/src/runtime/render.ts
+++ b/src/runtime/render.ts
@@ -137,18 +137,18 @@ export function renderToMountedElement<T extends G2ViewTree = G2ViewTree>(
     error(`renderToMountedElement can't render chart to unmounted group.`);
   }
 
-  const canvas = context.canvas || group?.ownerDocument?.defaultView;
   const selection = select(group);
   context.group = group;
   context.emitter = emitter;
-  context.canvas ??= canvas as GCanvas;
+  context.canvas =
+    context.canvas || (group?.ownerDocument?.defaultView as GCanvas);
 
   emitter.emit(ChartEvent.BEFORE_RENDER);
   // Plot the chart and mutate context.
   // Make sure that plot chart after container is ready for every time.
   plot<T>({ ...keyed, width, height }, selection, library, context)
     .then(() => {
-      canvas?.requestAnimationFrame(() => {
+      context.canvas?.requestAnimationFrame(() => {
         emitter.emit(ChartEvent.AFTER_RENDER);
         resolve?.();
       });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] benchmarks are included
- [ ] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change

<!-- Provide a description of the change below this comment. -->

for `renderToMountedElement` func.

if cell is dynamic render, and removed outside of the viewport. G2 cannot find document

1. add canvas document default value
2. add plot type validate

```ts
curve.ts:113 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'createElement')

render.ts:149 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'defaultView')
```

| Before | After |
| -  |  - |
|  ![image](https://github.com/antvis/G2/assets/21015895/be33c207-115f-41f3-8022-04212a24486a) |  ![image](https://github.com/antvis/G2/assets/21015895/8b4c3568-eccf-4b89-931b-45c115a06dc9) |

