### PR TITLE
feat(rangeX and rangeY): add syntactic sugar for data

### DIFF
--- a/src/mark/rangeX.ts
+++ b/src/mark/rangeX.ts
@@ -1,6 +1,7 @@
 import { MarkComponent as MC } from '../runtime';
 import { RangeXMark } from '../spec';
 import { RangeShape } from '../shape';
+import { MaybeDefaultX } from '../transform';
 import {
   baseAnnotationChannels,
   basePostInference,
@@ -27,6 +28,6 @@ RangeX.props = {
     ...baseAnnotationChannels({ shapes: Object.keys(shape) }),
     { name: 'x', required: true },
   ],
-  preInference: [...basePreInference()],
+  preInference: [...basePreInference(), { type: MaybeDefaultX }],
   postInference: [...basePostInference()],
 };

--- a/src/mark/rangeY.ts
+++ b/src/mark/rangeY.ts
@@ -1,6 +1,7 @@
 import { MarkComponent as MC } from '../runtime';
 import { RangeYMark } from '../spec';
 import { RangeShape } from '../shape';
+import { MaybeDefaultY } from '../transform';
 import {
   baseAnnotationChannels,
   basePostInference,
@@ -27,6 +28,6 @@ RangeY.props = {
     ...baseAnnotationChannels({ shapes: Object.keys(shape) }),
     { name: 'y', required: true },
   ],
-  preInference: [...basePreInference()],
+  preInference: [...basePreInference(), { type: MaybeDefaultY }],
   postInference: [...basePostInference()],
 };

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -9,6 +9,8 @@ export { MaybeKey } from './maybeKey';
 export { MaybeSeries } from './maybeSeries';
 export { MaybeTupleY } from './maybeTupleY';
 export { MaybeTupleX } from './maybeTupleX';
+export { MaybeDefaultX } from './maybeDefaultX';
+export { MaybeDefaultY } from './maybeDefaultY';
 export { MaybeIdentityY } from './maybeIdentityY';
 export { MaybeIdentityX } from './maybeIdentityX';
 export { MaybeTooltip } from './maybeTooltip';

--- a/src/transform/maybeDefaultX.ts
+++ b/src/transform/maybeDefaultX.ts
@@ -1,0 +1,36 @@
+import { deepMix } from '@antv/util';
+import { TransformComponent as TC } from '../runtime';
+import { column, isObject } from './utils/helper';
+
+export type MaybeDefaultXOptions = Record<string, never>;
+
+/**
+ * Add a default encode for rangeX
+ * when data is just an array
+ */
+export const MaybeDefaultX: TC<MaybeDefaultXOptions> = () => {
+  return (I, mark) => {
+    const { data } = mark;
+    if (
+      Array.isArray(data) &&
+      (data.every(Array.isArray) || !data.some(isObject))
+    ) {
+      const extractX = (data, index: number) =>
+        Array.isArray(data[0])
+          ? data.map((item) => item[index])
+          : [data[index]];
+      return [
+        I,
+        deepMix({}, mark, {
+          encode: {
+            y: column(extractX(data, 0)),
+            y1: column(extractX(data, 1)),
+          },
+        }),
+      ];
+    }
+    return [I, mark];
+  };
+};
+
+MaybeDefaultX.props = {};

--- a/src/transform/maybeDefaultY.ts
+++ b/src/transform/maybeDefaultY.ts
@@ -1,0 +1,37 @@
+import { deepMix } from '@antv/util';
+import { Primitive, TransformComponent as TC } from '../runtime';
+import { column, isObject } from './utils/helper';
+
+export type MaybeDefaultYOptions = Record<string, never>;
+
+/**
+ * Add a default encode for rangeY
+ * when data is just an array
+ */
+export const MaybeDefaultY: TC<MaybeDefaultYOptions> = () => {
+  return (I, mark) => {
+    const { data } = mark;
+    if (
+      Array.isArray(data) &&
+      (data.every(Array.isArray) || !data.some(isObject))
+    ) {
+      console.log('yes');
+      const extractY = (data, index: number) =>
+        Array.isArray(data[0])
+          ? data.map((item) => item[index])
+          : [data[index]];
+      return [
+        I,
+        deepMix({}, mark, {
+          encode: {
+            y: column(extractY(data, 0)),
+            y1: column(extractY(data, 1)),
+          },
+        }),
+      ];
+    }
+    return [I, mark];
+  };
+};
+
+MaybeDefaultY.props = {};


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] benchmarks are included
- [ ] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change

解决该issue #5803 
添加一个默认的 transform，为rangeX和rangeY增加语法糖，使得可以支持以下写法
chart.rangeY().data([350, 600]); 以及
chart.rangeY().data([[350, 400],[500,600]]);
原写法为：chart.rangeY().data([[350, 600]]).encode('y', d => d)
