### PR TITLE
docs: update title of examples' outline

### DIFF
--- a/site/examples/analysis/bin/index.zh.md
+++ b/site/examples/analysis/bin/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Bin
+title: 分箱
 order: 1
 ---

--- a/site/examples/analysis/group/index.zh.md
+++ b/site/examples/analysis/group/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Group
+title: 分组
 order: 1
 ---

--- a/site/examples/analysis/regression/index.zh.md
+++ b/site/examples/analysis/regression/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Regression
+title: 回归线
 order: 1
 ---

--- a/site/examples/animation/lottie/index.zh.md
+++ b/site/examples/animation/lottie/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Lottie
+title: Lottie 动画
 order: 3
 ---

--- a/site/examples/annotation/connector/index.zh.md
+++ b/site/examples/annotation/connector/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Connector
+title: 连接标注
 order: 3
 ---

--- a/site/examples/annotation/line/index.zh.md
+++ b/site/examples/annotation/line/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Line
+title: 线标注
 order: 2
 ---

--- a/site/examples/annotation/range/index.zh.md
+++ b/site/examples/annotation/range/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Range
+title: 区间标注
 order: 4
 ---

--- a/site/examples/annotation/shape/index.zh.md
+++ b/site/examples/annotation/shape/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Shape
+title: 图形标注
 order: 5
 ---

--- a/site/examples/annotation/text/index.zh.md
+++ b/site/examples/annotation/text/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Text
+title: 文本标注
 order: 1
 ---

--- a/site/examples/component/scrollbar/index.zh.md
+++ b/site/examples/component/scrollbar/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Scrollbar
+title: 滚动条
 order: 5
 ---

--- a/site/examples/composition/facet/index.zh.md
+++ b/site/examples/composition/facet/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Facet
+title: 分面复合
 order: 2
 ---

--- a/site/examples/composition/repeat/index.zh.md
+++ b/site/examples/composition/repeat/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Repeat
+title: 重复复合
 order: 3
 ---

--- a/site/examples/composition/space/index.zh.md
+++ b/site/examples/composition/space/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Space
+title: 空间复合
 order: 1
 ---

--- a/site/examples/general/Liquid/index.zh.md
+++ b/site/examples/general/Liquid/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Liquid
+title: 水波图
 order: 16
 ---

--- a/site/examples/general/area/index.zh.md
+++ b/site/examples/general/area/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Area
+title: 面积图
 order: 4
 ---

--- a/site/examples/general/box/index.zh.md
+++ b/site/examples/general/box/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Box
+title: 箱线图
 order: 13
 ---

--- a/site/examples/general/candlestick/index.zh.md
+++ b/site/examples/general/candlestick/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Candlestick
+title: 股票图
 order: 10
 ---

--- a/site/examples/general/cell/index.zh.md
+++ b/site/examples/general/cell/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Cell
+title: 色块图
 order: 5
 ---

--- a/site/examples/general/dual/index.zh.md
+++ b/site/examples/general/dual/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Dual
+title: 多轴图
 order: 6
 ---

--- a/site/examples/general/gauge/index.zh.md
+++ b/site/examples/general/gauge/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Gauge
+title: 仪表盘
 order: 16
 ---

--- a/site/examples/general/image/index.zh.md
+++ b/site/examples/general/image/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Image
+title: 图片
 order: 15
 ---

--- a/site/examples/general/interval/index.zh.md
+++ b/site/examples/general/interval/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Interval
+title: 条形图
 order: 1
 ---

--- a/site/examples/general/line/index.zh.md
+++ b/site/examples/general/line/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Line
+title: 折线图
 order: 2
 ---

--- a/site/examples/general/link/index.zh.md
+++ b/site/examples/general/link/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Link
+title: 连接图
 order: 11
 ---

--- a/site/examples/general/parallel/index.zh.md
+++ b/site/examples/general/parallel/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Parallel
+title: 平行坐标系
 order: 9
 ---

--- a/site/examples/general/pie/index.zh.md
+++ b/site/examples/general/pie/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Pie
+title: 饼图
 order: 5
 ---

--- a/site/examples/general/point/index.zh.md
+++ b/site/examples/general/point/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Point
+title: 散点图
 order: 3
 ---

--- a/site/examples/general/radar/index.zh.md
+++ b/site/examples/general/radar/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Radar
+title: 雷达图
 order: 8
 ---

--- a/site/examples/general/radial/index.zh.md
+++ b/site/examples/general/radial/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Radial
+title: 径向图
 order: 7
 ---

--- a/site/examples/general/rose/index.zh.md
+++ b/site/examples/general/rose/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Rose
+title: 玫瑰图
 order: 6
 ---

--- a/site/examples/general/text/index.zh.md
+++ b/site/examples/general/text/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Text
+title: 文本
 order: 14
 ---

--- a/site/examples/general/vector/index.zh.md
+++ b/site/examples/general/vector/index.zh.md
@@ -1,4 +1,4 @@
 ---
-title: Vector
+title: 向量场
 order: 12
 ---


### PR DESCRIPTION
把案例页面大纲里面的英文都变成了中文。

<img width="289" alt="image" src="https://github.com/antvis/G2/assets/49330279/a2b392ce-7ae5-4f93-a751-5d40c4267a78">
