### PR TITLE
fix(composition): fix composition lost chart value options

### DIFF
--- a/__tests__/unit/api/options.spec.ts
+++ b/__tests__/unit/api/options.spec.ts
@@ -152,6 +152,27 @@ describe('chart api and options', () => {
     });
   });
 
+  it('chart.options({...}) should update composition.', () => {
+    const chart = new Chart({
+      canvas: createNodeGCanvas(640, 480),
+      autoFit: true,
+      padding: 10,
+    });
+
+    chart.options({
+      type: 'spaceFlex',
+      padding: 20,
+      children: [{ type: 'interval', data: [1, 2, 3] }],
+    });
+
+    expect(chart.options()).toEqual({
+      type: 'spaceFlex',
+      autoFit: true,
+      padding: 20,
+      children: [{ type: 'interval', data: [1, 2, 3] }],
+    });
+  });
+
   it('chart.options({...}) should update node with same height and index.', () => {
     const chart = new Chart({
       canvas: createNodeGCanvas(640, 480),

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -158,7 +158,8 @@ function normalizeRootOptions(
       }
     }
     return options;
-  } else if (isMark(type, marks)) {
+  }
+  if (isMark(type, marks)) {
     const view = { type: 'view' };
     const mark = { ...options };
     for (const key of VIEW_KEYS) {
@@ -168,9 +169,8 @@ function normalizeRootOptions(
       }
     }
     return { ...view, children: [mark] };
-  } else {
-    return options;
   }
+  return options;
 }
 
 function typeCtor(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] benchmarks are included
- [x] commit message follows commit guidelines
- [x] documents are updated

##### Description of change

<!-- Provide a description of the change below this comment. -->
解决问题：
fixes #5783  修复当 root 是一个 composition node 时候，丢失chart options的问题

解决方案：
当检测到跟节点是composition node的时候，将chart配置的 VIEW_KEYS 下发到composition中

修改后：

https://github.com/antvis/G2/assets/35752509/0a163f36-a7c5-4bce-a0f9-66210a1de415

