### PR TITLE
fix(label): 图表开启label配置，多次render后卸载图表导致报错(#6104)

### DIFF
--- a/src/component/update-label.ts
+++ b/src/component/update-label.ts
@@ -1,6 +1,6 @@
 import { Coordinate } from '@antv/coord';
 import { IGroup, IShape } from '@antv/g-base';
-import { each, get } from '@antv/util';
+import { each, get, isArray } from '@antv/util';
 import { doAnimate } from '../animate';
 import { getReplaceAttrs } from '../util/graphics';
 
@@ -60,7 +60,7 @@ export function updateLabel(fromShape: IGroup, toShape: IGroup, cfg: Cfg): void 
 
   // append
   each(toShape.getChildren(), (child, idx) => {
-    if (idx >= fromShape.getCount()) {
+    if (isArray(fromShape.getChildren()) && idx >= fromShape.getCount()) {
       if (!child.destroyed) {
         fromShape.add(child);
       }

--- a/tests/bugs/6104.spec.ts
+++ b/tests/bugs/6104.spec.ts
@@ -1,0 +1,48 @@
+import { Chart } from '../../src';
+import { createDiv } from '../util/dom';
+
+
+describe('#6104', () => {
+  it('dual-axes-label.spec', async () => {
+
+    const data = [
+      { time: '10:10', call: 4, waiting: 2, people: 2 },
+      { time: '10:15', call: 2, waiting: 6, people: 3 },
+      { time: '10:20', call: 13, waiting: 2, people: 5 },
+      { time: '10:25', call: 9, waiting: 9, people: 1 },
+      { time: '10:30', call: 5, waiting: 2, people: 3 },
+      { time: '10:35', call: 8, waiting: 2, people: 1 },
+      { time: '10:40', call: 13, waiting: 1, people: 2 }
+    ];
+    const chart = new Chart({
+      container: createDiv(),
+      autoFit: true,
+      height: 500
+    });
+    chart.clear();
+    chart.data(data);
+    chart.interval()
+      .position('time*waiting')
+      .color('#3182bd')
+      .label('waiting', {
+        style: {
+          fill: '#f00',
+        },
+      })
+    chart.line()
+      .position('time*people')
+      .color('#fdae6b')
+      .size(3)
+      .shape('smooth')
+      .label('waiting', {
+        style: {
+          fill: '#0f0',
+        },
+      })
+
+
+    chart.render();
+    chart.render();
+    chart.destroy();
+  })
+})


### PR DESCRIPTION
PR includes
    1. fix 图表开启Label配置，多次render后执行卸载操作导致图表底层报错。[详情查看](https://github.com/antvis/G2/issues/6104)
