### PR TITLE
chore: bump to 5.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [5.1.18](https://github.com/antvis/g2/compare/5.1.17...5.1.18) (2024-04-08)
+
+
+### Features
+
+* update to g@6.0 for better performance ([#6149](https://github.com/antvis/g2/issues/6149)) ([72012e8](https://github.com/antvis/g2/commit/72012e8713afbd898322887d404d4b61d2b1d423))
+
+
+
 ## [5.1.17](https://github.com/antvis/g2/compare/5.1.16...5.1.17) (2024-03-21)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g2",
-  "version": "5.1.17",
+  "version": "5.1.18",
   "description": "the Grammar of Graphics in Javascript",
   "license": "MIT",
   "main": "lib/index.js",

--- a/site/examples/annotation/shape/demo/watermark.ts
+++ b/site/examples/annotation/shape/demo/watermark.ts
@@ -65,6 +65,7 @@ function watermark({ x, y }, context) {
       x,
       y,
       text: '数据保密',
+      transformOrigin: 'center',
       transform: 'rotate(30)',
       fontSize: 20,
       fill: 'red',

--- a/site/examples/geo/geo/demo/hexjson-usa.ts
+++ b/site/examples/geo/geo/demo/hexjson-usa.ts
@@ -17,12 +17,12 @@ function processRow(row) {
 }
 
 register('data.hexbin', ({ width = 1, height = 1 }) => {
-  return (data) => renderHexJSON(data, width, height).map(processRow);
+  return (data) => renderHexJSON(data.value, width, height).map(processRow);
 });
 
 register('data.hexgird', ({ width = 1, height = 1 }) => {
   return (data) =>
-    renderHexJSON(getGridForHexJSON(data), width, height).map(processRow);
+    renderHexJSON(getGridForHexJSON(data.value), width, height).map(processRow);
 });
 
 const chart = new Chart({

--- a/site/examples/interesting/interesting/demo/petal.ts
+++ b/site/examples/interesting/interesting/demo/petal.ts
@@ -111,7 +111,7 @@ function petal({ offset = 1, ratio = 0.5 }, context) {
     const g = document.createElement('g', {});
     const p = document.createElement('path', {
       style: {
-        path,
+        d: path,
         inset: 1,
         fill: value.color,
       },

--- a/site/package.json
+++ b/site/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.1.17",
+  "version": "5.1.18",
   "scripts": {
     "start": "dumi dev",
     "build": "dumi build",


### PR DESCRIPTION
发布 5.1.18

案例都检查了一遍，发现目前线上有一个例子报错：
https://g2.antv.antgroup.com/zh/examples/geo/geo#hexjson-usa