### PR TITLE
fix: hide axisZ when axis disabled

### DIFF
--- a/src/runtime/layout.ts
+++ b/src/runtime/layout.ts
@@ -29,11 +29,11 @@ import {
 } from './coordinate';
 
 export function processAxisZ(components: G2GuideComponentOptions[]) {
+  const axisX = components.find(({ type }) => type === 'axisX');
+  const axisY = components.find(({ type }) => type === 'axisY');
   const axisZ = components.find(({ type }) => type === 'axisZ');
-  if (axisZ) {
-    const axisX = components.find(({ type }) => type === 'axisX');
+  if (axisX && axisY && axisZ) {
     axisX.plane = 'xy';
-    const axisY = components.find(({ type }) => type === 'axisY');
     axisY.plane = 'xy';
     axisZ.plane = 'yz';
     axisZ.origin = [axisX.bbox.x, axisX.bbox.y, 0];

--- a/src/runtime/transform.ts
+++ b/src/runtime/transform.ts
@@ -260,8 +260,8 @@ export function addGuideToScale(
   };
   const axisChannels =
     typeof axis === 'object'
-      ? Array.from(new Set(['x', 'y', ...Object.keys(axis)]))
-      : ['x', 'y'];
+      ? Array.from(new Set(['x', 'y', 'z', ...Object.keys(axis)]))
+      : ['x', 'y', 'z'];
 
   deepMix(mark, {
     scale: {


### PR DESCRIPTION
Only display axisZ when axis enabled. Add `Z` to axis channels so that it can be toggled with `axis` option.

```ts
chart
    .point3D()
    .data({
      type: "fetch",
      value: "data/cars2.csv",
    })
    .encode("x", "Horsepower")
    .encode("y", "Miles_per_Gallon")
    .encode("z", "Weight_in_lbs")
    .encode("size", "Origin")
    .encode("color", "Cylinders")
    .encode("shape", "cube")
    .coordinate({ type: "cartesian3D" })
    .scale("x", { nice: true })
    .scale("y", { nice: true })
    .scale("z", { nice: true })
    .axis(false)
    .legend(false);
```

<img width="370" alt="截屏2024-05-26 下午3 05 32" src="https://github.com/antvis/G2/assets/3608471/f4dfd973-08a4-41c7-b051-1a05c870950a">
