### PR TITLE
docs(tooltip): update click example

### DIFF
--- a/__tests__/integration/snapshots/api/chart-emit-item-tooltip/step0.html
+++ b/__tests__/integration/snapshots/api/chart-emit-item-tooltip/step0.html
@@ -1,7 +1,7 @@
 <div
   xmlns="http://www.w3.org/1999/xhtml"
   class="g2-tooltip"
-  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: sans-serif; left: 257.44941265568264px; top: 350.99285714285713px;"
+  style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: sans-serif; transform: translate(-50%, -100%); left: 247.44941265568264px; top: 51px;"
 >
   <div
     class="g2-tooltip-title"

--- a/__tests__/integration/snapshots/api/chart-emit-item-tooltip/step1.html
+++ b/__tests__/integration/snapshots/api/chart-emit-item-tooltip/step1.html
@@ -1,7 +1,7 @@
 <div
   xmlns="http://www.w3.org/1999/xhtml"
   class="g2-tooltip"
-  style="pointer-events: none; position: absolute; visibility: hidden; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: sans-serif; left: 257.44941265568264px; top: 350.99285714285713px;"
+  style="pointer-events: none; position: absolute; visibility: hidden; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: sans-serif; transform: translate(-50%, -100%); left: 247.44941265568264px; top: 51px;"
 >
   <div
     class="g2-tooltip-title"

--- a/__tests__/plots/api/chart-emit-item-tooltip.ts
+++ b/__tests__/plots/api/chart-emit-item-tooltip.ts
@@ -33,13 +33,21 @@ export function chartEmitItemTooltip(context) {
     ])
     .encode('x', 'genre')
     .encode('y', 'sold')
-    .encode('color', 'genre');
+    .encode('color', 'genre')
+    .interaction('tooltip', {
+      offset: [0, 0],
+      css: {
+        '.g2-tooltip': {
+          transform: 'translate(-50%, -100%)',
+        },
+      },
+    });
 
   const finished = chart.render();
 
   finished.then((chart) =>
     chart.emit('tooltip:show', {
-      data: { data: { sold: 115 } },
+      data: { data: { sold: 115 }, offsetY: 0 },
     }),
   );
 

--- a/site/docs/spec/interaction/tooltip.zh.md
+++ b/site/docs/spec/interaction/tooltip.zh.md
@@ -33,32 +33,33 @@ chart.render();
 
 ## 选项
 
-| 属性                      | 描述                                                              | 类型                                        | 默认值                |
-| ------------------------- | ----------------------------------------------------------------- | ------------------------------------------- | --------------------- |
-| wait                      | 提示信息更新的时间间隔，单位为毫秒                                | `number`                                    | 50                    |
-| leading                   | 是否在时间间隔开始的时候更新提示信息                              | `boolean`                                   | true                  |
-| trailing                  | 是否在时间间隔结束的时候更新提示信息                              | `boolean`                                   | false                 |
-| shared                    | 相同 x 的元素是否共享 tooltip                                     | `boolean`                                   | false                 |
-| series                    | 是否是系列元素的 tooltip                                          | `boolean`                                   | -                     |
-| body                      | 是否展示 tooltip                                                  | `boolean`                                   | true                  |
-| marker                    | 是否展示 marker                                                   | `boolean`                                   | true                  |
-| groupName                 | 是否使用 groupName                                                | `boolean`                                   | true                  |
-| position                  | tooltip 位置                                                      | `TooltipPosition`                           | -                     |
-| mount                     | tooltip 渲染的 dom 节点                                           | `string` \| `HTMLElement`                   | 图表容器              |
-| bounding                  | tooltip 渲染的限制区域，超出会自动调整位置                        | `BBox`                                      | 图表区域大小          |
-| crosshairs                | 是否展示指示线                                                     | `boolean`                                   | -                     |
-| crosshairsX               | 是否展示X方向指示线                                            | `boolean`                                   | -                     |
-| crosshairsY               | 是否展示Y方向指示线                                                  | `boolean`                                   | -                     |
-| `crosshairs${StyleAttrs}`               | 指示线的样式                                                  | `number \| string`                                   | -                     |
-| `crosshairsX${StyleAttrs}`               | X方向指示线的样式（优先级更高）                                                  | `number \| string`                                   | -                     |
-| `crosshairsY${StyleAttrs}`              | Y方向指示线的样式 （优先级更高）                                                 | `number \| string`                                   | -                     |
-| `marker${StyleAttrs}`     | marker 的样式                                                     | `number \| string`                          | -                     |
-| markerType          | marker 的类型                                                     | `'hollow' \| undefined`                          | undefined                    |
-| render                    | 自定义 tooltip 渲染函数                                           | `(event, options) => HTMLElement \| string` | -                     |
-| sort                      | item 排序器                                                       | `(d: TooltipItemValue) => any`              | -                     |
-| filter                    | item 筛选器                                                       | `(d: TooltipItemValue) => any`              | -                     |
-| disableNative             | 是否响应原生事件（pointerover 和 pointerout）                     | true                                        | `boolean`             |
-| css                       | 设置容器的 [css](/examples/component/tooltip/#tooltip-style) 样式 | -                                           | `Record<string, any>` |
+| 属性                       | 描述                                                              | 类型                                        | 默认值                |
+| -------------------------- | ----------------------------------------------------------------- | ------------------------------------------- | --------------------- |
+| wait                       | 提示信息更新的时间间隔，单位为毫秒                                | `number`                                    | 50                    |
+| leading                    | 是否在时间间隔开始的时候更新提示信息                              | `boolean`                                   | true                  |
+| trailing                   | 是否在时间间隔结束的时候更新提示信息                              | `boolean`                                   | false                 |
+| shared                     | 相同 x 的元素是否共享 tooltip                                     | `boolean`                                   | false                 |
+| series                     | 是否是系列元素的 tooltip                                          | `boolean`                                   | -                     |
+| body                       | 是否展示 tooltip                                                  | `boolean`                                   | true                  |
+| marker                     | 是否展示 marker                                                   | `boolean`                                   | true                  |
+| groupName                  | 是否使用 groupName                                                | `boolean`                                   | true                  |
+| position                   | tooltip 位置                                                      | `TooltipPosition`                           | -                     |
+| mount                      | tooltip 渲染的 dom 节点                                           | `string` \| `HTMLElement`                   | 图表容器              |
+| bounding                   | tooltip 渲染的限制区域，超出会自动调整位置                        | `BBox`                                      | 图表区域大小          |
+| offset                     | tooltip 离鼠标的偏离位置                                          | `[number, number]`                          | [10, 10]              |
+| crosshairs                 | 是否展示指示线                                                    | `boolean`                                   | -                     |
+| crosshairsX                | 是否展示 X 方向指示线                                             | `boolean`                                   | -                     |
+| crosshairsY                | 是否展示 Y 方向指示线                                             | `boolean`                                   | -                     |
+| `crosshairs${StyleAttrs}`  | 指示线的样式                                                      | `number \| string`                          | -                     |
+| `crosshairsX${StyleAttrs}` | X 方向指示线的样式（优先级更高）                                  | `number \| string`                          | -                     |
+| `crosshairsY${StyleAttrs}` | Y 方向指示线的样式 （优先级更高）                                 | `number \| string`                          | -                     |
+| `marker${StyleAttrs}`      | marker 的样式                                                     | `number \| string`                          | -                     |
+| markerType                 | marker 的类型                                                     | `'hollow' \| undefined`                     | undefined             |
+| render                     | 自定义 tooltip 渲染函数                                           | `(event, options) => HTMLElement \| string` | -                     |
+| sort                       | item 排序器                                                       | `(d: TooltipItemValue) => any`              | -                     |
+| filter                     | item 筛选器                                                       | `(d: TooltipItemValue) => any`              | -                     |
+| disableNative              | 是否响应原生事件（pointerover 和 pointerout）                     | true                                        | `boolean`             |
+| css                        | 设置容器的 [css](/examples/component/tooltip/#tooltip-style) 样式 | -                                           | `Record<string, any>` |
 
 ```ts
 type TooltipPosition =
@@ -142,8 +143,9 @@ chart
 chart.render().then((chart) =>
   chart.emit('tooltip:show', {
     data: {
-      // 会找从原始数据里面找到匹配的数据
-      data: { genre: 'Sports' },
+      data: { genre: 'Sports' }, // 会找从原始数据里面找到匹配的数据
+      offsetX: 10, // 相对于 plot 区域的位置
+      offsetX: 20, // 相对于 plot 区域的位置
     },
   }),
 );
@@ -181,37 +183,39 @@ chart.emit('tooltip:enable'); // 启用交互
 ```
 
 ### 设置十字辅助线
+
 默认情况下，`crossharisY`是开启的，`crosshairsX`是关闭的，所以如果要开启十字辅助线，有以下两种方式。
+
 1. 设置`crosshairs`为`true`。
+
 ```js
-chart.interaction("tooltip", {
+chart.interaction('tooltip', {
   crosshairs: true, // 开启十字辅助线
   crosshairsXStroke: 'red', // 设置 X 轴辅助线颜色为'red'
-  crosshairsYStroke: 'blue',// 设置 Y 轴辅助线颜色为'blue'
-})
+  crosshairsYStroke: 'blue', // 设置 Y 轴辅助线颜色为'blue'
+});
 ```
 
 2. 设置`crosshairsX`为`true`。
+
 ```js
-chart.interaction("tooltip", {
+chart.interaction('tooltip', {
   crosshairsX: true, // 开启crosshairsX辅助线
   crosshairsXStroke: 'red', // 设置 X 轴辅助线颜色为'red'
-  crosshairsYStroke: 'blue',// 设置 Y 轴辅助线颜色为'blue'
-})
+  crosshairsYStroke: 'blue', // 设置 Y 轴辅助线颜色为'blue'
+});
 ```
+
 `crosshairsX`的优先级大于`crosshairs`的优先级。
 
 <img alt="example" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*_LFDT7p6hRQAAAAAAAAAAAAADmJ7AQ/original" width="640">
 
-
-
-
 ### 设置提示点为空心圆
 
 ```js
-chart.interaction("tooltip", {
-  markerType: "hollow", // 设置提示点的样式为空心圆
-})
+chart.interaction('tooltip', {
+  markerType: 'hollow', // 设置提示点的样式为空心圆
+});
 ```
 
 <img alt="example" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*s8KjQLiSyTwAAAAAAAAAAAAADmJ7AQ/original" width="640">

--- a/site/examples/component/tooltip/demo/meta.json
+++ b/site/examples/component/tooltip/demo/meta.json
@@ -58,7 +58,7 @@
         "zh": "点击提示",
         "en": "Click Tooltip"
       },
-      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*OZz0RZle0tsAAAAAAAAAAAAADmJ7AQ/original"
+      "screenshot": "https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*8lsAQ5dCO-IAAAAAAAAAAAAADmJ7AQ/original"
     },
     {
       "filename": "tooltip-style.ts",

--- a/site/examples/component/tooltip/demo/tooltip-click.ts
+++ b/site/examples/component/tooltip/demo/tooltip-click.ts
@@ -1,5 +1,15 @@
 import { Chart } from '@antv/g2';
 
+function css(...styles) {
+  return styles
+    .map((obj) =>
+      Object.entries(obj)
+        .map(([k, v]) => k + ':' + v)
+        .join(';'),
+    )
+    .join(';');
+}
+
 const chart = new Chart({
   container: 'container',
   autoFit: true,
@@ -15,9 +25,88 @@ chart
   .encode('x', 'letter')
   .encode('y', 'frequency')
   .axis('y', { labelFormatter: '.0%' })
-  .interaction('tooltip', { disableNative: true }); // Disable pointerover and pointerout events.
+  .interaction('tooltip', {
+    disableNative: true, // Disable pointerover and pointerout events.
+    bounding: {
+      x: -Infinity,
+      y: -Infinity,
+      width: Infinity,
+      height: Infinity,
+    },
+    css: {
+      '.g2-tooltip': {
+        background: 'transparent',
+        'box-shadow': 'none',
+        transform: 'translate(-50%, -100%)',
+      },
+    },
+    offset: [0, -10],
+    mount: 'body',
+    render: (event, { title, items }) => {
+      const plot = chart
+        .getContext()
+        .canvas.document.getElementsByClassName('plot')[0];
+      const plotBounds = plot.getRenderBounds();
+      const target = event.target;
+      const bounds = target.getRenderBounds();
+      const height = bounds.min[1] - plotBounds.min[1];
+      return `<div>
+        <div style="${css({
+          position: 'relative',
+          background: '#fff',
+          'box-shadow': '0 6px 12px 0 rgba(0, 0, 0, 0.12)',
+          'z-index': 999,
+          padding: '12px',
+          'min-width': '120px',
+        })}">
+          <h2
+            style="${css({
+              'margin-bottom': '9px',
+              'font-size': '18px',
+              'line-height': '30px',
+              'font-weight': '500px',
+            })}"
+          >
+            Letter: ${title}
+          </h2>
+          ${items
+            .map(
+              (item) =>
+                `<div style="font-size: 16px; color: #666">
+                  <span style="${css({
+                    height: '10px',
+                    width: '10px',
+                    background: item.color,
+                    display: 'inline-block',
+                    'border-radius': '50%',
+                  })}"></span>
+                  <span>${item.name}</span>
+                  <span>${item.value}</span>
+                </div>`,
+            )
+            .join('')}
+        </div>
+        <div style="${css({
+          width: '1px',
+          height: height + 'px',
+          background: '#aaa',
+          position: 'absolute',
+          left: '50%',
+          top: '90%',
+          'z-index': 500,
+        })}"></div>
+      </div>`;
+    },
+  });
 
-chart.on('element:click', ({ data }) => chart.emit('tooltip:show', { data }));
+chart.on('element:click', ({ data }) =>
+  chart.emit('tooltip:show', {
+    data: {
+      data: data.data,
+      offsetY: 0,
+    },
+  }),
+);
 
 chart.on('plot:click', () => chart.emit('tooltip:hide'));
 

--- a/src/interaction/tooltip.ts
+++ b/src/interaction/tooltip.ts
@@ -69,6 +69,7 @@ function createTooltip(
   bounding,
   containerOffset,
   css = {},
+  offset: [number, number] = [10, 10],
 ) {
   const defaults = {
     '.g2-tooltip': {},
@@ -89,7 +90,7 @@ function createTooltip(
       position,
       enterable,
       title: '',
-      offset: [10, 10],
+      offset,
       template: {
         prefixCls: 'g2-',
       },
@@ -113,6 +114,7 @@ function showTooltip({
   css,
   mount,
   bounding,
+  offset,
 }) {
   const container = getContainer(root, mount);
   const canvasContainer = getContainer(root);
@@ -130,6 +132,7 @@ function showTooltip({
       b,
       containerOffset,
       css,
+      offset,
     ),
   } = parent as any;
   const { items, title = '' } = data;
@@ -572,6 +575,7 @@ export function seriesTooltip(
     mount,
     bounding,
     theme,
+    offset,
     disableNative = false,
     marker = true,
     preserve = false,
@@ -798,6 +802,7 @@ export function seriesTooltip(
           mount,
           bounding,
           css,
+          offset,
         });
       }
 
@@ -974,6 +979,7 @@ export function tooltip(
     mount,
     bounding,
     theme,
+    offset,
     shared = false,
     body = true,
     disableNative = false,
@@ -1055,6 +1061,7 @@ export function tooltip(
           mount,
           bounding,
           css,
+          offset,
         });
       }
 
@@ -1090,16 +1097,18 @@ export function tooltip(
     }
   };
 
-  const onTooltipShow = ({ nativeEvent, data }) => {
+  const onTooltipShow = ({ nativeEvent, data: raw }) => {
     if (nativeEvent) return;
-    const element = selectElementByData(elements, data.data, datum);
+    const { data, offsetX, offsetY } = raw;
+    const element = selectElementByData(elements, data, datum);
     if (!element) return;
     const bbox = element.getBBox();
     const { x, y, width, height } = bbox;
+    const rootBBox = root.getBBox();
     pointermove({
       target: element,
-      offsetX: x + width / 2,
-      offsetY: y + height / 2,
+      offsetX: offsetX !== undefined ? offsetX + rootBBox.x : x + width / 2,
+      offsetY: offsetY !== undefined ? offsetY + rootBBox.y : y + height / 2,
     });
   };
 


### PR DESCRIPTION
优化点击展示 tooltip 的例子，为了完成这个例子，增加了以下的能力：

- 传递 offset
- chart.emit('tooltip:show")  可以传递 offsetX 和 offsetY

<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*8lsAQ5dCO-IAAAAAAAAAAAAADmJ7AQ/original" />