### PR TITLE
fix: when update the position of tooltip, calculate the containerOffset

### DIFF
--- a/__tests__/plots/bugfix/index.ts
+++ b/__tests__/plots/bugfix/index.ts
@@ -1,1 +1,2 @@
 export { issue6396 } from './issue-6396';
+export { issue6399 } from './issue-6399';

--- a/__tests__/plots/bugfix/issue-6399.ts
+++ b/__tests__/plots/bugfix/issue-6399.ts
@@ -1,0 +1,59 @@
+import { Chart, PLOT_CLASS_NAME } from '../../../src';
+
+export function issue6399(context) {
+  const { container, canvas } = context;
+  const box1 = document.createElement('div', {});
+  const box2 = document.createElement('div', {});
+  box1.id = 'box1';
+  box2.style.height = '4000px';
+  container.style.height = '100vh';
+  container.style.overflow = 'auto';
+  box2.append(box1);
+  container.append(box2);
+  const chart = new Chart({
+    container: box1,
+    canvas,
+  });
+
+  chart
+    .line()
+    .data({
+      type: 'fetch',
+      value: 'https://assets.antv.antgroup.com/g2/indices.json',
+    })
+    .transform({ type: 'normalizeY', basis: 'first', groupBy: 'color' })
+    .encode('x', (d) => new Date(d.Date))
+    .encode('y', 'Close')
+    .encode('color', 'Symbol')
+    .axis('y', { title: '↑ Change in price (%)' })
+    .interaction('tooltip', {
+      mount: 'body',
+      crosshairsXStroke: 'red',
+      crosshairsYStroke: 'blue',
+    })
+    .tooltip({
+      title: (d) => new Date(d.Date).toUTCString(),
+      items: [
+        (d, i, data, column) => ({
+          name: 'Close',
+          value: column.y.value[i!].toFixed(1),
+        }),
+      ],
+    })
+    .label({
+      text: 'Symbol',
+      selector: 'last',
+      fontSize: 10,
+    });
+
+  setTimeout(() => {
+    container.scrollTo(0, 400);
+  }, 100);
+
+  const finished = chart.render();
+
+  return {
+    chart,
+    finished,
+  };
+}

--- a/src/interaction/tooltip.ts
+++ b/src/interaction/tooltip.ts
@@ -143,6 +143,7 @@ function showTooltip({
     title,
     position,
     enterable,
+    container: containerOffset,
     ...(render !== undefined && {
       content: render(event, { items, title }),
     }),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->
fixes #6399 
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] benchmarks are included
- [x] commit message follows commit guidelines
- [x] documents are updated

##### Description of change
After setting the height of the outer container of the canvas to 100vh and the overflow to auto, set the height of the inner container to a relatively high value like 4000px. When scrolling and moving the mouse to the lower half of the chart, the tooltip is displayed in the correct position.![image](https://github.com/user-attachments/assets/d7e4dce1-7a0f-4567-af8b-d0c85dfb1ac6)

<!-- Provide a description of the change below this comment. -->
