### PR TITLE
fix:  prevent label overlap in multiple charts

### DIFF
--- a/src/label-transform/exceedAdjust.ts
+++ b/src/label-transform/exceedAdjust.ts
@@ -34,9 +34,7 @@ export type ExceedAdjustOptions = Omit<ExceedAdjustLabel, 'type'>;
  * adjust the label when exceed the plot
  */
 export const ExceedAdjust: LLC<ExceedAdjustOptions> = () => {
-  return (labels: DisplayObject[], { canvas }) => {
-    const { width, height } = canvas.getConfig();
-
+  return (labels: DisplayObject[], { canvas, layout }) => {
     labels.forEach((l) => {
       show(l);
       const { max, min } = l.getRenderBounds();
@@ -47,9 +45,10 @@ export const ExceedAdjust: LLC<ExceedAdjustOptions> = () => {
           [xMin, yMin],
           [xMax, yMax],
         ],
+        // Prevent label overlap in multiple charts by calculating layouts separately to avoid collisions.
         [
-          [0, 0],
-          [width, height],
+          [layout.x, layout.y],
+          [layout.x + layout.width, layout.y + layout.height],
         ],
       );
       // For label with connectorPoints

--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -1229,11 +1229,12 @@ function plotLabel(
   const labelGroups = group(labelShapes, (d) =>
     labelDescriptor.get(d.__data__),
   );
-  const { coordinate } = view;
+  const { coordinate, layout } = view;
 
   const labelTransformContext = {
     canvas: context.canvas,
     coordinate,
+    layout,
   };
   for (const [label, shapes] of labelGroups) {
     const { transform = [] } = label;

--- a/src/runtime/types/component.ts
+++ b/src/runtime/types/component.ts
@@ -15,6 +15,7 @@ import {
   Vector2,
   G2MarkState,
   GuideComponentPlane,
+  Layout,
 } from './common';
 import { DataComponent } from './data';
 import { Encode, EncodeComponent } from './encode';
@@ -233,6 +234,7 @@ export type LabelTransform = (
   context: {
     coordinate: Coordinate;
     canvas: Canvas;
+    layout: Layout;
   },
 ) => DisplayObject[];
 export type LabelTransformComponent<O = Record<string, unknown>> =


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] benchmarks are included
- [x] commit message follows commit guidelines
- [x] documents are updated

##### Description of change
<!-- Provide a description of the change below this comment. -->
Prevent label overlap in multiple charts by calculating layouts separately to avoid collisions.
![image](https://github.com/user-attachments/assets/132d5322-e747-4cef-8047-f157427c671c)

