### PR TITLE
feat(gauge): add custom text tooltip support for gauge chart

### DIFF
--- a/__tests__/integration/snapshots/static/gaugeCustomTextTooltip.svg
+++ b/__tests__/integration/snapshots/static/gaugeCustomTextTooltip.svg
@@ -1,0 +1,415 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="640"
+  height="480"
+  style="background: transparent;"
+  color-interpolation-filters="sRGB"
+>
+  <defs />
+  <g id="g-svg-camera">
+    <g id="g-root" fill="none">
+      <g id="g-svg-6" fill="none" class="view">
+        <g>
+          <path
+            id="g-svg-7"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 640,0 l 0,480 l-640 0 z"
+            x="0"
+            y="0"
+            width="640"
+            height="480"
+          />
+        </g>
+        <g>
+          <path
+            id="g-svg-8"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 16,16 l 608,0 l 0,448 l-608 0 z"
+            x="16"
+            y="16"
+            width="608"
+            height="448"
+          />
+        </g>
+        <g>
+          <path
+            id="g-svg-9"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 16,16 l 608,0 l 0,448 l-608 0 z"
+            x="16"
+            y="16"
+            width="608"
+            height="448"
+          />
+        </g>
+        <g>
+          <path
+            id="g-svg-10"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 43,43 l 554,0 l 0,394 l-554 0 z"
+            x="43"
+            y="43"
+            width="554"
+            height="394"
+          />
+        </g>
+        <g id="g-svg-11" fill="none" class="component">
+          <g id="g-svg-12" fill="none">
+            <g id="g-svg-13" fill="none" class="axis-grid-group" />
+            <g id="g-svg-14" fill="none" class="axis-main-group">
+              <g id="g-svg-15" fill="none" class="axis-line-group" />
+              <g id="g-svg-16" fill="none" class="axis-tick-group">
+                <g
+                  id="g-svg-17"
+                  fill="none"
+                  transform="matrix(1,0,0,1,132.641861,300.876343)"
+                  class="axis-tick"
+                >
+                  <g>
+                    <line
+                      id="g-svg-22"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="-3.8042260651806137"
+                      y2="1.2360679774997918"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-18"
+                  fill="none"
+                  transform="matrix(1,0,0,1,154.675980,132.869385)"
+                  class="axis-tick"
+                >
+                  <g>
+                    <line
+                      id="g-svg-23"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="-3.3568328783772077"
+                      y2="-2.1752409123234586"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-19"
+                  fill="none"
+                  transform="matrix(1,0,0,1,299.020813,44.120255)"
+                  class="axis-tick"
+                >
+                  <g>
+                    <line
+                      id="g-svg-24"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="-0.4259731140211543"
+                      y2="-3.9772536889329957"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-20"
+                  fill="none"
+                  transform="matrix(1,0,0,1,458.886566,100.287727)"
+                  class="axis-tick"
+                >
+                  <g>
+                    <line
+                      id="g-svg-25"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="2.8200319167024563"
+                      y2="-2.8367974881509377"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+                <g
+                  id="g-svg-21"
+                  fill="none"
+                  transform="matrix(1,0,0,1,516.000671,259.817719)"
+                  class="axis-tick"
+                >
+                  <g>
+                    <line
+                      id="g-svg-26"
+                      fill="none"
+                      x1="0"
+                      y1="0"
+                      x2="3.979708772474456"
+                      y2="0.4023904649589258"
+                      class="axis-tick-item"
+                      stroke-width="1"
+                      stroke="rgba(29,33,41,1)"
+                      opacity="0.45"
+                    />
+                  </g>
+                </g>
+              </g>
+              <g id="g-svg-27" fill="none" class="axis-label-group">
+                <g
+                  id="g-svg-28"
+                  fill="none"
+                  transform="matrix(1,0,0,1,125.033417,303.348480)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(0.309017,0.951057,-0.951057,0.309017,0,0)">
+                    <text
+                      id="g-svg-33"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                    >
+                      0
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-29"
+                  fill="none"
+                  transform="matrix(1,0,0,1,147.962311,128.518906)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(0.543804,-0.839212,0.839212,0.543804,0,0)">
+                    <text
+                      id="g-svg-34"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="-11.5px"
+                      opacity="0.45"
+                    >
+                      100
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-30"
+                  fill="none"
+                  transform="matrix(1,0,0,1,298.168884,36.165749)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(0.994313,-0.106493,0.106493,0.994313,0,0)">
+                    <text
+                      id="g-svg-35"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="-11.5px"
+                      opacity="0.45"
+                    >
+                      200
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-31"
+                  fill="none"
+                  transform="matrix(1,0,0,1,464.526642,94.614128)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(0.709202,0.705006,-0.705006,0.709202,0,0)">
+                    <text
+                      id="g-svg-36"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="-11.5px"
+                      opacity="0.45"
+                    >
+                      300
+                    </text>
+                  </g>
+                </g>
+                <g
+                  id="g-svg-32"
+                  fill="none"
+                  transform="matrix(1,0,0,1,523.960083,260.622498)"
+                  class="axis-label"
+                >
+                  <g transform="matrix(0.100605,-0.994926,0.994926,0.100605,0,0)">
+                    <text
+                      id="g-svg-37"
+                      fill="rgba(29,33,41,1)"
+                      dominant-baseline="central"
+                      paint-order="stroke"
+                      dx="0.5"
+                      font-family="sans-serif"
+                      font-size="12"
+                      font-style="normal"
+                      font-variant="normal"
+                      font-weight="normal"
+                      stroke-width="1"
+                      text-anchor="middle"
+                      class="axis-label-item"
+                      dy="11.5px"
+                      opacity="0.45"
+                    >
+                      400
+                    </text>
+                  </g>
+                </g>
+              </g>
+            </g>
+            <g id="g-svg-38" fill="none" class="axis-title-group" />
+          </g>
+        </g>
+        <g transform="matrix(1,0,0,1,16,16)">
+          <path
+            id="g-svg-39"
+            fill="rgba(0,0,0,0)"
+            class="plot"
+            d="M 0,0 l 608,0 l 0,448 l-608 0 z"
+            width="608"
+            height="448"
+          />
+          <g id="g-svg-40" fill="none" class="main-layer">
+            <g transform="matrix(1,0,0,1,304,224)">
+              <path
+                id="g-svg-44"
+                fill="rgba(48,191,120,1)"
+                d="M -185.655,60.323 A 195.209 195.209 0 0 1 -88.623 -173.933 L -81.306,-159.571 A 179.091 179.091 0 0 0 -170.326 55.342 Z"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(48,191,120,1)"
+                class="element"
+              />
+            </g>
+            <g transform="matrix(1,0,0,1,304,224)">
+              <path
+                id="g-svg-45"
+                fill="rgba(208,208,208,1)"
+                d="M -88.623,-173.933 A 195.209 195.209 0 0 1 185.655 60.323 L 170.326,55.342 A 179.091 179.091 0 0 0 -81.306 -159.571 Z"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(208,208,208,1)"
+                class="element"
+              />
+            </g>
+          </g>
+          <g id="g-svg-41" fill="none" class="main-layer">
+            <g id="g-svg-46" fill="none" class="element">
+              <g>
+                <line
+                  id="g-svg-47"
+                  fill="none"
+                  x1="236.95872078348782"
+                  y1="92.40384864602805"
+                  x2="304"
+                  y2="224"
+                  stroke="rgba(48,191,120,1)"
+                  stroke-linecap="round"
+                  stroke-width="4"
+                />
+              </g>
+            </g>
+          </g>
+          <g id="g-svg-42" fill="none" class="main-layer">
+            <g
+              id="g-svg-48"
+              fill="none"
+              transform="matrix(1,0,0,1,304,268.799988)"
+              class="element"
+            >
+              <g>
+                <path
+                  id="background"
+                  fill="none"
+                  d="M -65.6,-38 l 131.2,0 l 0,76 l-131.2 0 z"
+                  x="-65.6"
+                  y="-38"
+                  width="131.2"
+                  height="76"
+                />
+              </g>
+              <g>
+                <text
+                  id="text"
+                  fill="rgba(136,136,136,1)"
+                  dominant-baseline="central"
+                  paint-order="stroke"
+                  font-size="20"
+                  stroke-width="0"
+                  text-anchor="middle"
+                  font-weight="800"
+                >
+                  <tspan x="0" dx="0" dy="-18">
+                    得分：159
+                  </tspan>
+                  <tspan x="0" dx="0" dy="36">
+                    占比：37.5%
+                  </tspan>
+                </text>
+              </g>
+              <g>
+                <path id="connector" fill="none" d="M 0,0 L 0,0" />
+              </g>
+            </g>
+          </g>
+          <g id="g-svg-43" fill="none" class="label-layer" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/__tests__/plots/static/gauge-custom-text-tooltip.ts
+++ b/__tests__/plots/static/gauge-custom-text-tooltip.ts
@@ -1,0 +1,29 @@
+import { G2Spec } from '../../../src';
+export function gaugeCustomTextTooltip(): G2Spec {
+  return {
+    type: 'gauge',
+    data: {
+      value: {
+        target: 159,
+        total: 424,
+        name: 'score',
+      },
+    },
+    style: {
+      pinShape: false,
+      textContent: (target, total) => {
+        return `得分：${target}\n占比：${(target / total) * 100}%`;
+      },
+      textTooltip: {
+        items: [
+          (d, index, data, column) => {
+            return {
+              name: 'y',
+              value: column.y.value[index], // 使用 y 通道的值
+            };
+          },
+        ],
+      },
+    },
+  };
+}

--- a/__tests__/plots/static/index.ts
+++ b/__tests__/plots/static/index.ts
@@ -217,6 +217,7 @@ export { commitsPointGroupedConstant } from './commits-point-grouped-constant';
 export { soldHOMMultiple } from './sold-hom-multiple';
 export { soldIntervalCustomShape } from './sold-interval-custom-shape';
 export { gaugeDefault } from './gauge-default';
+export { gaugeCustomTextTooltip } from './gauge-custom-text-tooltip';
 export { gaugeCustomColor } from './gauge-custom-color';
 export { gaugeCustomShape } from './gauge-custom-shape';
 export { gaugeRoundShape } from './gauge-round-shape';

--- a/src/mark/gauge.ts
+++ b/src/mark/gauge.ts
@@ -123,6 +123,7 @@ const DEFAULT_TEXT_OPTIONS = {
     fontWeight: 800,
     fill: '#888',
   },
+  tooltip: false,
 };
 
 export type GaugeData =
@@ -212,7 +213,7 @@ export const Gauge: CC<GaugeOptions> = (options) => {
     total,
     scale: newScale,
   } = dataTransform(data, scale);
-  const textStyle = subObject(style, 'text');
+  const { tooltip, ...textStyle } = subObject(style, 'text');
   // pointer + pin
   const indicatorStyle = filterPrefixObject(style, ['pointer', 'pin']);
 
@@ -244,6 +245,7 @@ export const Gauge: CC<GaugeOptions> = (options) => {
         text: getTextContent(textStyle, { target, total }),
         ...textStyle,
       },
+      tooltip,
       animate:
         typeof animate === 'object' ? subObject(animate, 'text') : animate,
     }),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
<img width="494" alt="image" src="https://github.com/user-attachments/assets/90c3dc78-a8e1-42c8-8d35-80574a214dad">

- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
- Add gauge-custom-text-tooltip.ts test case
- Update gauge mark to support text tooltip configuration
- Remove default tooltip from DEFAULT_TEXT_OPTIONS
- Extract tooltip from textStyle in gauge mark
