### PR TITLE
fix: site dev error & lodash ghost dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-shape": "^3.2.0",
     "flru": "^1.0.2",
-    "fmin": "^0.0.4",
+    "fmin": "0.0.2",
     "pdfast": "^0.2.0"
   },
   "devDependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -36,7 +36,8 @@
     "dirichlet": "^1.0.1",
     "dumi": "^2.2.14",
     "fecha": "^4.2.3",
-
+    "lodash": "^4.17.21",
+    "fmin": "0.0.2",
     "react-color": "^2.19.3",
     "topojson": "^3.0.2",
     "webfontloader": "1.6.28"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### issue
<img width="887" alt="image" src="https://github.com/user-attachments/assets/d4584e18-0d0e-4886-97bf-443e5e2ba33c">
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/0267f0a6-7efa-4b30-8b80-14c4d7a7a02b">


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes 
<img width="417" alt="image" src="https://github.com/user-attachments/assets/d218eb7a-c962-48e7-b335-48bfb152120f">

- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
- Downgrade fmin version to fix development packaging issues
- Solve the ghost dependency problem of lodash in site when using `pnpm install`