### PR TITLE
fix: heatmap render error

### DIFF
--- a/src/shape/heatmap/heatmap.ts
+++ b/src/shape/heatmap/heatmap.ts
@@ -66,7 +66,7 @@ export const Heatmap: SC<HeatmapOptions> = (options, context) => {
       .style('y', 0)
       .style('width', width)
       .style('height', height)
-      .style('src', ctx.canvas)
+      .style('src', ctx.canvas.toDataURL())
       .style('transform', transform)
       .call(applyStyle, style)
       .node();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- fixed #6512 

After the upgrade of the underlying G engine, the `src` attribute of the image element no longer supports directly passing the canvas instance. The abnormal rendering problem of the heat map can be solved by passing the dataurl string.
