### PR TITLE
docs: g2官网api文档跳转以及文案错误订正

### DIFF
--- a/site/docs/api/chart.zh.md
+++ b/site/docs/api/chart.zh.md
@@ -113,7 +113,7 @@ chart.render();
 
 <!-- 暂缺 -->
 
-添加 connector 图形，具体见 [mark](/spec/mark/connector)。
+添加 connector 图形。
 
 ### `chart.sankey`
 
@@ -137,7 +137,7 @@ chart.render();
 
 ### `chart.shape`
 
-添加 shape 图形，具体见 [mark](/spec/mark/shape)。
+添加自定义图形，具体见 [mark](/spec/mark/shape)。
 
 ### `chart.pack`
 
@@ -153,7 +153,7 @@ chart.render();
 
 ### `chart.wordCloud`
 
-添加 wordCloud 图形，具体见 [mark](/spec/mark/word-cloud)。
+添加 wordCloud 图形，具体见 [mark](/spec/mark/wordcloud)。
 
 ### `chart.gauge`
 
@@ -211,15 +211,15 @@ chart.render();
 
 ### `chart.width`
 
-设置或获取图表的 width。
+设置或获取图表的宽度。
 
 ### `chart.height`
 
-设置或获取图表的 height。
+设置或获取图表的高度。
 
 ### `chart.title`
 
-设置或获取图表的 title。
+设置或获取图表的标题。
 
 ### `chart.options`
 
@@ -231,9 +231,7 @@ chart.render();
 
 ### `chart.encode`
 
-<!-- 暂缺 -->
-
-设置图形每个通道的字段名称，具体见 [encode](/api/encode/overview)。
+设置图形每个通道的字段名称，具体见 [encode](/manual/core/encode)。
 
 ### `chart.scale`
 
@@ -247,7 +245,7 @@ chart.render();
 
 ### `chart.tooltip`
 
-设置图形的 Tooltip，具体见 [tooltip](/spec/component/tooltip)。
+设置图形的提示，具体见 [tooltip](/spec/component/tooltip)。
 
 ### `chart.axis`
 
@@ -255,7 +253,7 @@ chart.render();
 
 ### `chart.slider`
 
-设置图形的坐标轴，具体见 [slider](/spec/component/slider)。
+设置图形的缩略轴，具体见 [slider](/spec/component/slider)。
 
 ### `chart.label`
 
@@ -269,13 +267,13 @@ chart.render();
 
 ### `chart.theme`
 
-设置图形的主题，具体见 [theme](/spec/theme/academy)。
+设置图形的主题，具体见 [theme](/spec/overview#theme)。
 
 ### `chart.labelTransform`
 
 <!-- 缺失 -->
 
-设置图形的 labelTransform，具体见 [label](/spec/label/overview)
+设置图形的 labelTransform，具体见 [label](/spec/label/overview)里的transform配置。
 
 ## 渲染图表
 
@@ -359,7 +357,7 @@ chart.render();
 
 ### `chart.off`
 
-写在 chart 上的监听事件。
+卸载 chart 上的监听事件。
 
 ### `chart.getNodesByType`
 

--- a/site/docs/api/facetCircle.zh.md
+++ b/site/docs/api/facetCircle.zh.md
@@ -112,7 +112,7 @@ chart.render();
 
 ### `facetCircle.connector`
 
-添加 connector 图形，具体见 [mark](/spec/mark/connector)。
+添加 connector 图形。
 
 ### `facetCircle.sankey`
 
@@ -128,7 +128,7 @@ chart.render();
 
 ### `facetCircle.shape`
 
-添加 shape 图形，具体见 [mark](/spec/mark/shape)。
+添加自定义图形，具体见 [mark](/spec/mark/shape)。
 
 ### `facetCircle.pack`
 
@@ -144,7 +144,7 @@ chart.render();
 
 ### `facetCircle.wordCloud`
 
-添加 wordCloud 图形，具体见 [mark](/spec/mark/word-cloud)。
+添加 wordCloud 图形，具体见 [mark](/spec/mark/wordcloud)。
 
 ### `facetCircle.gauge`
 
@@ -178,4 +178,4 @@ chart.render();
 
 ### `facetCircle.theme`
 
-设置图形的主题，具体见 [theme](/spec/theme/overview)。
+设置图形的主题，具体见 [theme](/spec/overview#theme)。

--- a/site/docs/api/facetRect.zh.md
+++ b/site/docs/api/facetRect.zh.md
@@ -36,36 +36,132 @@ chart.render();
 
 ## 创建可视化
 
-## `facetRect.[mark]`
+### `facetRect.interval`
 
-设置图表的 Mark 标记，具体见 [mark](/api/mark/area)。
+添加 interval 图形，具体见 [mark](/spec/mark/interval)。
+
+### `facetRect.rect`
+
+添加 rect 图形，具体见 [mark](/spec/mark/rect)。
+
+### `facetRect.point`
+
+添加 point 图形，具体见 [mark](/spec/mark/point)。
+
+### `facetRect.area`
+
+添加 area 图形，具体见 [mark](/spec/mark/area)。
+
+### `facetRect.line`
+
+添加 line 图形，具体见 [mark](/spec/mark/line)。
+
+### `facetRect.vector`
+
+添加 vector 图形，具体见 [mark](/spec/mark/vector)。
+
+### `facetRect.link`
+
+添加 link 图形，具体见 [mark](/spec/mark/link)。
+
+### `facetRect.polygon`
+
+添加 polygon 图形，具体见 [mark](/spec/mark/polygon)。
+
+### `facetRect.image`
+
+添加 image 图形，具体见 [mark](/spec/mark/image)。
+
+### `facetRect.text`
+
+添加 text 图形，具体见 [mark](/spec/mark/text)。
+
+### `facetRect.lineX`
+
+添加 lineX 图形，具体见 [mark](/spec/mark/line-x)。
+
+### `facetRect.lineY`
+
+添加 lineY 图形，具体见 [mark](/spec/mark/line-y)。
+
+### `facetRect.range`
+
+添加 range 图形，具体见 [mark](/spec/mark/range)。
+
+### `facetRect.rangeX`
+
+添加 rangeX 图形，具体见 [mark](/spec/mark/range-x)。
+
+### `facetRect.rangeY`
+
+添加 rangeY 图形，具体见 [mark](/spec/mark/range-y)。
+
+### `facetRect.connector`
+
+添加 connector 图形。
+
+### `facetRect.sankey`
+
+添加 sankey 图形，具体见 [graph](/spec/graph/sankey)。
+
+### `facetRect.treemap`
+
+添加 treemap 图形，具体见 [graph](/spec/graph/treemap)。
+
+### `facetRect.boxplot`
+
+添加 boxplot 图形，具体见 [mark](/spec/mark/boxplot)。
+
+### `facetRect.shape`
+
+添加自定义图形，具体见 [mark](/spec/mark/shape)。
+
+### `facetRect.pack`
+
+添加 pack 图形，具体见 [graph](/spec/graph/pack)。
+
+### `facetRect.forceGraph`
+
+添加 forceGraph 图形，具体见 [graph](/spec/graph/force-graph)。
+
+### `facetRect.tree`
+
+添加 tree 图形，具体见 [graph](/spec/graph/tree)。
+
+### `facetRect.wordCloud`
+
+添加 wordCloud 图形，具体见 [mark](/spec/mark/wordcloud)。
+
+### `facetRect.gauge`
+
+添加 gauge 图形，具体见 [mark](/spec/mark/gauge)。
 
 ## 设置属性
 
-## `facetRect.attr`
+### `facetRect.attr`
 
 获取或设置图表的配置项。
 
-## `facetRect.data`
+### `facetRect.data`
 
 设置图形的数据，支持多种数据来源和数据变换，具体见 [data](/spec/data/overview)。
 
-## `facetRect.scale`
+### `facetRect.scale`
 
 设置图形每个通道的比例尺，具体见 [scale](/spec/overview#scale)。
 
-## `facetRect.legend`
+### `facetRect.legend`
 
 设置图形的图例，具体见 [legend](/spec/component/legend)。
 
-## `facetRect.axis`
+### `facetRect.axis`
 
 设置图形的坐标轴，具体见 [axis](/spec/component/axis)。
 
-## `facetRect.style`
+### `facetRect.style`
 
 设置图形的样式，具体见 [style](/spec/common/style)。
 
-## `facetRect.theme`
+### `facetRect.theme`
 
-设置图形的主题，具体见 [theme](/spec/theme/overview)。
+设置图形的主题，具体见 [theme](/spec/overview#theme)。

--- a/site/docs/api/geoView.zh.md
+++ b/site/docs/api/geoView.zh.md
@@ -109,11 +109,11 @@ fetch('https://assets.antv.antgroup.com/g2/countries-50m.json')
 
 ### `geoView.connector`
 
-添加 connector 图形，具体见 [mark](/spec/mark/connector)。
+添加 connector 图形。
 
 ### `geoView.sankey`
 
-添加 sankey 图形，具体见 [mark](/spec/mark/sankey)。
+添加 sankey 图形，具体见 [graph](/spec/graph/sankey)。
 
 ### `geoView.treemap`
 
@@ -125,7 +125,7 @@ fetch('https://assets.antv.antgroup.com/g2/countries-50m.json')
 
 ### `geoView.shape`
 
-添加 shape 图形，具体见 [mark](/spec/mark/shape)。
+添加自定义图形，具体见 [mark](/spec/mark/shape)。
 
 ### `geoView.pack`
 
@@ -141,7 +141,7 @@ fetch('https://assets.antv.antgroup.com/g2/countries-50m.json')
 
 ### `geoView.wordCloud`
 
-添加 wordCloud 图形，具体见 [mark](/spec/mark/word-cloud)。
+添加 wordCloud 图形，具体见 [mark](/spec/mark/wordcloud)。
 
 ### `geoView.gauge`
 
@@ -159,7 +159,7 @@ fetch('https://assets.antv.antgroup.com/g2/countries-50m.json')
 
 ### `geoView.encode`
 
-设置图形每个通道的字段名称，具体见 [encode](/api/encode/overview)。
+设置图形每个通道的字段名称，具体见 [encode](/manual/core/encode)。
 
 ### `geoView.scale`
 
@@ -171,7 +171,7 @@ fetch('https://assets.antv.antgroup.com/g2/countries-50m.json')
 
 ### `geoView.tooltip`
 
-设置图形的 Tooltip，具体见 [tooltip](/spec/component/tooltip)。
+设置图形的提示，具体见 [tooltip](/spec/component/tooltip)。
 
 ### `geoView.axis`
 
@@ -187,4 +187,4 @@ fetch('https://assets.antv.antgroup.com/g2/countries-50m.json')
 
 ### `geoView.theme`
 
-设置图形的主题，具体见 [theme](/spec/theme/overview)。
+设置图形的主题，具体见 [theme](/spec/overview#theme)。

--- a/site/docs/api/mark.zh.md
+++ b/site/docs/api/mark.zh.md
@@ -30,78 +30,78 @@ chart.render();
 
 ## Mark API
 
-### 设置属性
+## 设置属性
 
-#### `mark.attr`
+### `mark.attr`
 
 获取或设置图表的配置项。
 
-#### `mark.data`
+### `mark.data`
 
 设置图形的数据，支持多种数据来源和数据变换，具体见 [data](/spec/data/overview)。
 
-### `chart.changeData`
+### `mark.changeData`
 
 更改图形的数据并重新渲染图表。
 
-#### `mark.encode`
+### `mark.encode`
 
-设置图形每个通道的字段名称，具体见 [encode](/api/encode/overview)。
+设置图形每个通道的字段名称，具体见 [encode](/manual/core/encode)。
 
-#### `mark.scale`
+### `mark.scale`
 
 设置图形每个通道的比例尺，具体见 [scale](/spec/overview#scale)。
 
-#### `mark.label`
+### `mark.label`
 
 设置图形的标签，具体见 [label](/spec/label/overview)。
 
-#### `mark.style`
+### `mark.style`
 
 设置图形的样式，具体见 [style](/spec/common/style)。
 
-#### `mark.theme`
+### `mark.theme`
 
-设置图形的主题，具体见 [theme](/spec/theme/overview)。
+设置图形的主题，具体见 [theme](/spec/overview#theme)。
 
-#### `mark.animate`
+### `mark.animate`
 
-设置图形的动画，具体见 [style](/api/animate/overview)。
+设置图形的动画，具体见 [animation](/spec/animation/overview)。
 
-#### `mark.axis`
+### `mark.axis`
 
-设置图形的坐标轴 [style](/api/axis/overview)。
+设置图形的坐标轴，具体见 [axis](/spec/component/axis)。
 
-#### `mark.legend`
+### `mark.legend`
 
-设置图形的图例，具体见 [style](/api/legend/overview)。
+设置图形的图例，具体见 [legend](/spec/component/legend)。
 
-#### `mark.slider`
+### `mark.slider`
 
-设置图形的缩略轴，具体见 [style](/api/slider/overview)。
+设置图形的缩略轴，具体见 [slider](/spec/component/slider)。
 
-#### `mark.scrollbar`
+### `mark.scrollbar`
 
-设置图形的滚动条，具体见 [style](/api/scrollbar/overview)。
+设置图形的滚动条，具体见 [scrollbar](/spec/component/scrollbar)。
 
-#### `mark.state`
+### `mark.state`
 
-设置图形的状态样式，具体见 [style](/api/state/overview)。
+设置图形的状态样式，具体见 [state](/manual/core/state)。
 
-#### `mark.tooltip`
+### `mark.tooltip`
 
-设置图形的 Tooltip，具体见 [style](/api/tooltip/overview)。
+设置图形的提示，具体见 [tooltip](/spec/component/tooltip)。
 
-### 获取实例
+## 获取实例
 
-#### `chart.getGroup`
+### `mark.getGroup`
 
-返回 chart 渲染时的 canvas group 实例。
+返回 mark 渲染时的 canvas group 实例。
 
-#### `chart.getScale`
+### `mark.getScale`
 
-返回 chart 渲染时所有的 scale 实例。
+返回 mark 渲染时所有的 scale 实例。
 
-#### `chart.getScaleByChannel`
+### `mark.getScaleByChannel`
 
-通过通道名称查找返回 chart 渲染时对应的 scale 实例。
+通过通道名称查找返回 mark 渲染时对应的 scale 实例。

--- a/site/docs/api/repeatMatrix.zh.md
+++ b/site/docs/api/repeatMatrix.zh.md
@@ -107,7 +107,7 @@ chart.render();
 
 ### `repeatMatrix.connector`
 
-添加 connector 图形，具体见 [mark](/spec/mark/connector)。
+添加 connector 图形。
 
 ### `repeatMatrix.sankey`
 
@@ -123,7 +123,7 @@ chart.render();
 
 ### `repeatMatrix.shape`
 
-添加 shape 图形，具体见 [mark](/spec/mark/shape)。
+添加自定义图形，具体见 [mark](/spec/mark/shape)。
 
 ### `repeatMatrix.pack`
 
@@ -139,7 +139,7 @@ chart.render();
 
 ### `repeatMatrix.wordCloud`
 
-添加 wordCloud 图形，具体见 [mark](/spec/mark/word-cloud)。
+添加 wordCloud 图形，具体见 [mark](/spec/mark/wordcloud)。
 
 ### `repeatMatrix.gauge`
 
@@ -157,7 +157,7 @@ chart.render();
 
 ### `repeatMatrix.encode`
 
-设置图形每个通道的字段名称，具体见 [encode](/api/encode/overview)。
+设置图形每个通道的字段名称，具体见 [encode](/manual/core/encode)。
 
 ### `repeatMatrix.scale`
 
@@ -169,7 +169,7 @@ chart.render();
 
 ### `repeatMatrix.tooltip`
 
-设置图形的 Tooltip，具体见 [tooltip](/spec/component/tooltip)。
+设置图形的提示 [tooltip](/spec/component/tooltip)。
 
 ### `repeatMatrix.axis`
 
@@ -177,7 +177,7 @@ chart.render();
 
 ### `repeatMatrix.slider`
 
-设置图形的坐标轴，具体见 [slider](/spec/component/slider)。
+设置图形的缩略轴，具体见 [slider](/spec/component/slider)。
 
 ### `repeatMatrix.label`
 
@@ -189,4 +189,4 @@ chart.render();
 
 ### `repeatMatrix.theme`
 
-设置图形的主题，具体见 [theme](/spec/theme/overview)。
+设置图形的主题，具体见 [theme](/spec/overview#theme)。

--- a/site/docs/api/spaceFlex.zh.md
+++ b/site/docs/api/spaceFlex.zh.md
@@ -133,7 +133,7 @@ chart.render();
 
 ### `spaceFlex.connector`
 
-添加 connector 图形，具体见 [mark](/spec/mark/connector)。
+添加 connector 图形。
 
 ### `spaceFlex.sankey`
 
@@ -149,7 +149,7 @@ chart.render();
 
 ### `spaceFlex.shape`
 
-添加 shape 图形，具体见 [mark](/spec/mark/shape)。
+添加自定义图形，具体见 [mark](/spec/mark/shape)。
 
 ### `spaceFlex.pack`
 
@@ -165,7 +165,7 @@ chart.render();
 
 ### `spaceFlex.wordCloud`
 
-添加 wordCloud 图形，具体见 [mark](/spec/mark/word-cloud)。
+添加 wordCloud 图形，具体见 [mark](/spec/mark/wordcloud)。
 
 ### `spaceFlex.gauge`
 

--- a/site/docs/api/spaceLayer.zh.md
+++ b/site/docs/api/spaceLayer.zh.md
@@ -119,7 +119,7 @@ chart.render();
 
 ### `spaceLayer.connector`
 
-添加 connector 图形，具体见 [mark](/spec/mark/connector)。
+添加 connector 图形。
 
 ### `spaceLayer.sankey`
 
@@ -135,7 +135,7 @@ chart.render();
 
 ### `spaceLayer.shape`
 
-添加 shape 图形，具体见 [mark](/spec/mark/shape)。
+添加自定义图形，具体见 [mark](/spec/mark/shape)。
 
 ### `spaceLayer.pack`
 
@@ -151,7 +151,7 @@ chart.render();
 
 ### `spaceLayer.wordCloud`
 
-添加 wordCloud 图形，具体见 [mark](/spec/mark/word-cloud)。
+添加 wordCloud 图形，具体见 [mark](/spec/mark/wordcloud)。
 
 ### `spaceLayer.gauge`
 

--- a/site/docs/api/timingKeyframe.zh.md
+++ b/site/docs/api/timingKeyframe.zh.md
@@ -107,7 +107,7 @@ chart.render();
 
 ### `timingKeyFrame.connector`
 
-添加 connector 图形，具体见 [mark](/spec/mark/connector)。
+添加 connector 图形。
 
 ### `timingKeyFrame.sankey`
 
@@ -123,7 +123,7 @@ chart.render();
 
 ### `timingKeyFrame.shape`
 
-添加 shape 图形，具体见 [mark](/spec/mark/shape)。
+添加自定义图形，具体见 [mark](/spec/mark/shape)。
 
 ### `timingKeyFrame.pack`
 
@@ -139,7 +139,7 @@ chart.render();
 
 ### `timingKeyFrame.wordCloud`
 
-添加 wordCloud 图形，具体见 [mark](/spec/mark/word-cloud)。
+添加 wordCloud 图形，具体见 [mark](/spec/mark/wordcloud)。
 
 ### `timingKeyFrame.gauge`
 

--- a/site/docs/api/view.zh.md
+++ b/site/docs/api/view.zh.md
@@ -114,7 +114,7 @@ chart.render();
 
 ### `view.connector`
 
-添加 connector 图形，具体见 [mark](/spec/mark/connector)。
+添加 connector 图形。
 
 ### `view.sankey`
 
@@ -138,7 +138,7 @@ chart.render();
 
 ### `view.shape`
 
-添加 shape 图形，具体见 [mark](/spec/mark/shape)。
+添加自定义图形，具体见 [mark](/spec/mark/shape)。
 
 ### `view.pack`
 
@@ -154,7 +154,7 @@ chart.render();
 
 ### `view.wordCloud`
 
-添加 wordCloud 图形，具体见 [mark](/spec/mark/word-cloud)。
+添加 wordCloud 图形，具体见 [mark](/spec/mark/wordcloud)。
 
 ### `view.gauge`
 
@@ -172,7 +172,7 @@ chart.render();
 
 ### `view.encode`
 
-设置图形每个通道的字段名称，具体见 [encode](/api/encode/overview)。
+设置图形每个通道的字段名称，具体见 [encode](/manual/core/encode)。
 
 ### `view.scale`
 
@@ -184,7 +184,7 @@ chart.render();
 
 ### `view.tooltip`
 
-设置图形的 Tooltip，具体见 [tooltip](/spec/component/tooltip)。
+设置图形的提示，具体见 [tooltip](/spec/component/tooltip)。
 
 ### `view.axis`
 
@@ -192,7 +192,7 @@ chart.render();
 
 ### `view.slider`
 
-设置图形的坐标轴，具体见 [slider](/spec/component/slider)。
+设置图形的缩略轴，具体见 [slider](/spec/component/slider)。
 
 ### `view.label`
 
@@ -204,7 +204,7 @@ chart.render();
 
 ### `view.theme`
 
-设置图形的主题，具体见 [theme](/spec/theme/overview)。
+设置图形的主题，具体见 [theme](/spec/overview#theme)。
 
 ## 获取实例
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->
本次文档修订覆盖官网的api部分，以下均为共通的问题，不止一处，不一一列出：
- connector 文档缺失，隐藏链接。
- wordCloud 文档链接错误
- width、height、title、tooltip 文案优化，统一为中文
- encode 文档链接错误
- slider 文案错误 坐标轴=>缩略轴
- theme 文档链接错误
- labelTransform 文案补充 具体见 label=>具体见 label里的transform配置
- chart.off 文案错误 写在 chart 上的监听事件。=>卸载 chart 上的监听事件。
- mark.encode mark.theme mark.animatemark.axismark.legendmark.slidermark.scrollbarmark.statemark.tooltip 文档链接错误
- geoView.sankey 文档链接错误
- shape 文案错误 添加 shape 图形=>添加自定义图形
- mark.changeData mark.getGroup mark.getScale mark.getScaleByChannel都写成chart了，已统一修改