### PR TITLE
fix:  g版本升级，supportsCSSTransform=true是默认设置

### DIFF
--- a/__tests__/unit/api/chart.spec.ts
+++ b/__tests__/unit/api/chart.spec.ts
@@ -72,16 +72,6 @@ describe('Chart', () => {
     });
   });
 
-  it('Chart({...}) should set canvas.supportsCSSTransform to true.', async () => {
-    const chart = new Chart({
-      canvas: createNodeGCanvas(640, 480),
-    });
-    await chart.render();
-    expect(chart.getContext().canvas?.getConfig().supportsCSSTransform).toBe(
-      true,
-    );
-  });
-
   it('chart.getContainer() should return container.', () => {
     const canvas = createNodeGCanvas(640, 480);
     const container = canvas.getConfig().container as HTMLDivElement;

--- a/src/api/runtime.ts
+++ b/src/api/runtime.ts
@@ -73,7 +73,6 @@ export class Runtime<Spec extends G2Spec = G2Spec> extends CompositionNode {
   render(): Promise<Runtime<Spec>> {
     if (this._rendering) return this._addToTrailing();
     if (!this._context.canvas) this._createCanvas();
-    this._context.canvas.getConfig().supportsCSSTransform = true;
     this._bindAutoFit();
     this._rendering = true;
     const finished = new Promise<Runtime<Spec>>((resolve, reject) =>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] benchmarks are included
- [x] commit message follows commit guidelines
- [x] documents are updated

##### Description of change
解决类型错误：Property 'supportsCSSTransform' does not exist on type 'CanvasConfig'
底层依赖g版本升级，supportsCSSTransform=true是默认设置，g2中不再需要设置supportsCSSTransform属性

<!-- Provide a description of the change below this comment. -->
