### PR TITLE
chore: resolve d3-array type locked issue

### DIFF
--- a/__tests__/plots/static/barley-line-trail.ts
+++ b/__tests__/plots/static/barley-line-trail.ts
@@ -9,8 +9,8 @@ export async function barleyLineTrail(): Promise<G2Spec> {
   const keyDelta = rollup(
     data,
     ([a, b]) => {
-      if (b.year < a.year) [a, b] = [b, a];
-      return b.yield - a.yield;
+      if ((b as any).year < (a as any).year) [a, b] = [b, a];
+      return (b as any).yield - (a as any).yield;
     },
     key,
   );

--- a/__tests__/plots/static/income-statement-by-region-interval-custom.ts
+++ b/__tests__/plots/static/income-statement-by-region-interval-custom.ts
@@ -16,7 +16,7 @@ export function incomeStatementByRegionIntervalCustom() {
   const groupData = (data) => {
     const groups = group(data, (d: any) => d.x);
     return Array.from(groups.entries()).reduce((r, [k, v]) => {
-      const y = v[v.length - 1].end;
+      const y = (v[v.length - 1] as any).end;
       return r.concat({
         x: k,
         y,

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@antv/g-plugin-dragndrop": "^2.0.22",
     "@antv/scale": "^0.4.16",
     "@antv/util": "^3.3.10",
-    "@antv/vendor": "1.0.6",
+    "@antv/vendor": "^1.0.8",
     "flru": "^1.0.2",
     "fmin": "0.0.2",
     "pdfast": "^0.2.0"

--- a/src/data/utils/arc/arc.ts
+++ b/src/data/utils/arc/arc.ts
@@ -1,6 +1,6 @@
 import { group, sum } from '@antv/vendor/d3-array';
 import { error } from '../../../utils/helper';
-import { ArcData, ArcOptions } from './types';
+import { ArcData, ArcOptions, Edge, Node } from './types';
 import * as SortMethods from './sort';
 
 const DEFAULT_OPTIONS = {
@@ -53,7 +53,7 @@ export function Arc(options?: ArcOptions) {
   /**
    * Calculate id, value, frequency for node, and source,target for edge.
    */
-  function preprocess(nodes, edges) {
+  function preprocess(nodes: Node[], edges: Edge[]) {
     edges.forEach((edge) => {
       edge.source = source(edge);
       edge.target = target(edge);
@@ -83,7 +83,7 @@ export function Arc(options?: ArcOptions) {
     return { nodes, edges };
   }
 
-  function sortNodes(nodes, edges) {
+  function sortNodes(nodes: Node[], edges: Edge[]) {
     const method = typeof sortBy === 'function' ? sortBy : SortMethods[sortBy];
 
     if (method) {
@@ -91,7 +91,7 @@ export function Arc(options?: ArcOptions) {
     }
   }
 
-  function layoutNodes(nodes, edges) {
+  function layoutNodes(nodes: Node[], edges: Edge[]) {
     const size = nodes.length;
     if (!size) {
       throw error("Invalid nodes: it's empty!");
@@ -145,7 +145,7 @@ export function Arc(options?: ArcOptions) {
   /**
    * Get edge layout information from nodes, and save into edge object.
    */
-  function layoutEdges(nodes, edges) {
+  function layoutEdges(nodes: Node[], edges: Edge[]) {
     const nodesMap = new Map(nodes.map((d) => [d.id, d]));
 
     if (!weight) {

--- a/src/data/utils/arc/arc.ts
+++ b/src/data/utils/arc/arc.ts
@@ -1,6 +1,6 @@
 import { group, sum } from '@antv/vendor/d3-array';
 import { error } from '../../../utils/helper';
-import { ArcData, ArcOptions, Edge, Node } from './types';
+import { ArcData, ArcOptions, ArcEdge, ArcNode } from './types';
 import * as SortMethods from './sort';
 
 const DEFAULT_OPTIONS = {
@@ -53,7 +53,7 @@ export function Arc(options?: ArcOptions) {
   /**
    * Calculate id, value, frequency for node, and source,target for edge.
    */
-  function preprocess(nodes: Node[], edges: Edge[]) {
+  function preprocess(nodes: ArcNode[], edges: ArcEdge[]) {
     edges.forEach((edge) => {
       edge.source = source(edge);
       edge.target = target(edge);
@@ -83,7 +83,7 @@ export function Arc(options?: ArcOptions) {
     return { nodes, edges };
   }
 
-  function sortNodes(nodes: Node[], edges: Edge[]) {
+  function sortNodes(nodes: ArcNode[], edges: ArcEdge[]) {
     const method = typeof sortBy === 'function' ? sortBy : SortMethods[sortBy];
 
     if (method) {
@@ -91,7 +91,7 @@ export function Arc(options?: ArcOptions) {
     }
   }
 
-  function layoutNodes(nodes: Node[], edges: Edge[]) {
+  function layoutNodes(nodes: ArcNode[], edges: ArcEdge[]) {
     const size = nodes.length;
     if (!size) {
       throw error("Invalid nodes: it's empty!");
@@ -145,7 +145,7 @@ export function Arc(options?: ArcOptions) {
   /**
    * Get edge layout information from nodes, and save into edge object.
    */
-  function layoutEdges(nodes: Node[], edges: Edge[]) {
+  function layoutEdges(nodes: ArcNode[], edges: ArcEdge[]) {
     const nodesMap = new Map(nodes.map((d) => [d.id, d]));
 
     if (!weight) {

--- a/src/data/utils/arc/types.ts
+++ b/src/data/utils/arc/types.ts
@@ -21,7 +21,25 @@ export type ArcOptions = {
   thickness?: number;
 };
 
+export interface Edge {
+  source: string;
+  target: string;
+  sourceWeight: number;
+  targetWeight: number;
+  x: number | number[];
+  value: any;
+  [key: string]: any;
+}
+
+export interface Node {
+  key: string;
+  id: string;
+  x: number | number[];
+  y: number | number[];
+  [key: string]: any;
+}
+
 export type ArcData = {
-  nodes: any[];
-  edges: any[];
+  nodes: Node[];
+  edges: Edge[];
 };

--- a/src/data/utils/arc/types.ts
+++ b/src/data/utils/arc/types.ts
@@ -20,26 +20,34 @@ export type ArcOptions = {
   /** Thickness of node, default: 0.05 */
   thickness?: number;
 };
-
-export interface Edge {
+export interface ArcEdge {
   source: string;
   target: string;
   sourceWeight: number;
   targetWeight: number;
-  x: number | number[];
-  value: any;
+  x: number[] | number;
+  y: number[] | number;
+  value: number;
+  weight?: number;
+  width?: number;
+  height?: number;
+  frequency?: number;
   [key: string]: any;
 }
 
-export interface Node {
-  key: string;
+export interface ArcNode {
   id: string;
-  x: number | number[];
-  y: number | number[];
+  x: number[] | number;
+  y: number[] | number;
+  value: number;
+  frequency: number;
+  weight?: number;
+  width?: number;
+  height?: number;
   [key: string]: any;
 }
 
 export type ArcData = {
-  nodes: Node[];
-  edges: Edge[];
+  nodes: ArcNode[];
+  edges: ArcEdge[];
 };

--- a/src/interaction/legendHighlight.ts
+++ b/src/interaction/legendHighlight.ts
@@ -1,4 +1,4 @@
-import { group } from '@antv/vendor/d3-array';
+import { InternMap, group } from '@antv/vendor/d3-array';
 import { subObject } from '../utils/helper';
 import {
   mergeState,
@@ -66,7 +66,9 @@ export function LegendHighlight() {
       const highlightItem = (event, item) => {
         // Update UI.
         const value = datumOf(item);
-        const elementSet = new Set(elementGroup.get(value));
+        const elementSet = new Set(
+          (elementGroup as InternMap<unknown, any[]>).get(value),
+        );
         for (const e of elements) {
           if (elementSet.has(e)) setState(e, 'active');
           else setState(e, 'inactive');

--- a/src/runtime/layout.ts
+++ b/src/runtime/layout.ts
@@ -1,5 +1,12 @@
 import { Coordinate } from '@antv/coord';
-import { ascending, group, max, min, sum } from '@antv/vendor/d3-array';
+import {
+  NestedInternMap,
+  ascending,
+  group,
+  max,
+  min,
+  sum,
+} from '@antv/vendor/d3-array';
 import { deepMix } from '@antv/util';
 import { isParallel, isPolar, isRadar, radiusOf } from '../utils/coordinate';
 import { capitalizeFirst, defined } from '../utils/helper';
@@ -389,10 +396,16 @@ export function placeComponents(
   layout: Layout,
 ): void {
   // Group components by plane & position.
-  const positionComponents = group<G2GuideComponentOptions, string>(
+
+  const positionComponents: NestedInternMap<
+    G2GuideComponentOptions,
+    G2GuideComponentOptions[],
+    [string]
+  > = group<G2GuideComponentOptions, [string]>(
     components,
     (d) => `${d.plane || 'xy'}-${d.position}`,
   );
+
   const {
     paddingLeft,
     paddingRight,

--- a/src/transform/bin.ts
+++ b/src/transform/bin.ts
@@ -39,7 +39,7 @@ export const Bin: TC<BinOptions> = (options = {}) => {
   const channelIndexKey = {};
 
   // Group indexes and update channelIndexKey.
-  const groupBy = (I, mark) => {
+  const groupBy = (I, mark): number[][] => {
     const { encode } = mark;
     const binValues = binChannels.map((channel) => {
       const [V] = columnOf(encode, channel);
@@ -80,7 +80,7 @@ export const Bin: TC<BinOptions> = (options = {}) => {
 
     // Group by indexes by channel keys.
     const key = (i: number) => groupKeys.map((key) => key(i)).join('-');
-    return Array.from(group(DI, key).values());
+    return Array.from(group(DI, key).values()) as number[][];
   };
 
   return GroupN({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change
- 将 vendor 版本设置为 ^1.0.8，解决了 @types/d3-array 锁死的问题
<img width="472" alt="image" src="https://github.com/user-attachments/assets/0c36b2e5-f33d-485d-85bc-212be9ea14db" />


<!-- Provide a description of the change below this comment. -->
