### PR TITLE
docs: mark-range、mark-rangeX、mark-rangeY

### DIFF
--- a/site/docs/manual/core/mark/range.zh.md
+++ b/site/docs/manual/core/mark/range.zh.md
@@ -3,84 +3,125 @@ title: range
 order: 20
 ---
 
-使用一组 `x`(x1, x2) 和一组 `y`(y1, y2) 来定位一个矩形区域，常用于绘制辅助背景区域。
+## 概述
 
-## 开始使用
+`range` 是用来定义一个矩形区域的工具。这个矩形的位置和大小可以通过两组数字来确定：一组用于水平方向（x1, x2），另一组用于垂直方向（y1, y2）。它常用于绘制辅助背景区域或标记某个区域。
 
-<img alt="range" src="https://mdn.alipayobjects.com/mdn/huamei_qa8qxu/afts/img/A*6JLeTLg7YQoAAAAAAAAAAAAADmJ7AQ" width="600" />
+- 水平方向（x1, x2）：
 
-```ts
-import { Chart } from '@antv/g2';
+  - `x1`：矩形在水平方向上从哪里开始。
+  - `x2`：矩形在水平方向上到哪里结束。
 
-const chart = new Chart({ container: 'container' });
+- 垂直方向（y1, y2）：
 
-chart.data({
-  type: 'fetch',
-  value:
-    'https://gw.alipayobjects.com/os/bmw-prod/0b37279d-1674-42b4-b285-29683747ad9a.json',
-});
+  - `y1`：矩形在垂直方向上从哪里开始。
+  - `y2`：矩形在垂直方向上到哪里结束。
 
-chart.lineX().data([0]);
-chart.lineY().data([0]);
+```js | ob
+(() => {
+  const chart = new G2.Chart();
 
-chart
-  .range()
-  .data([
-    { x: [-25, 0], y: [-30, 0], region: '1' },
-    { x: [-25, 0], y: [0, 20], region: '2' },
-    { x: [0, 5], y: [-30, 0], region: '2' },
-    { x: [0, 5], y: [0, 20], region: '1' },
-  ])
-  .encode('x', 'x')
-  .encode('y', 'y')
-  .encode('color', 'region')
-  .scale('color', {
-    range: ['#d8d0c0', '#a3dda1'],
-    independent: true,
-    guide: null,
-  })
-  .style('fillOpacity', 0.2);
+  chart.options({
+    type: 'view',
+    data: {
+      type: 'fetch',
+      value:
+        'https://gw.alipayobjects.com/os/bmw-prod/0b37279d-1674-42b4-b285-29683747ad9a.json',
+    },
+    children: [
+      { type: 'lineX', data: [0] },
+      { type: 'lineY', data: [0] },
+      {
+        type: 'range',
+        // 区域图的数据
+        data: [
+          { x: [-25, 0], y: [-30, 0], region: '1' },
+          { x: [-25, 0], y: [0, 20], region: '2' },
+          { x: [0, 5], y: [-30, 0], region: '2' },
+          { x: [0, 5], y: [0, 20], region: '1' },
+        ],
+        // 编码规则，x 和 y 对应数据中的字段，color 对应 region 字段
+        encode: { x: 'x', y: 'y', color: 'region' },
+        scale: {
+          color: {
+            range: ['#d8d0c0', '#a3dda1'],
+            independent: true,
+            guide: null,
+          },
+        },
 
-chart
-  .point()
-  .encode('x', 'change in female rate')
-  .encode('y', 'change in male rate')
-  .encode('size', 'pop')
-  .encode('color', 'continent')
-  .encode('shape', 'point')
-  .scale('color', {
-    range: ['#ffd500', '#82cab2', '#193442', '#d18768', '#7e827a'],
-  })
-  .axis('x', { title: false })
-  .axis('y', { title: false })
-  .scale('x', { domain: [-25, 5] })
-  .scale('y', { domain: [-30, 20] })
-  .scale('size', { range: [4, 30] })
-  .style('stroke', '#bbb')
-  .style('fillOpacity', 0.8);
+        style: {
+          fillOpacity: 0.2,
+        },
+      },
+      {
+        type: 'point',
+        encode: {
+          x: 'change in female rate',
+          y: 'change in male rate',
+          size: 'pop',
+          color: 'continent',
+          shape: 'point',
+        },
+        scale: {
+          color: {
+            range: ['#ffd500', '#82cab2', '#193442', '#d18768', '#7e827a'],
+          },
+          x: { domain: [-25, 5] },
+          y: { domain: [-30, 20] },
+          size: { range: [4, 30] },
+        },
+        style: { stroke: '#bbb', fillOpacity: 0.8 },
+        axis: { x: { title: false }, y: { title: false } },
+      },
+    ],
+  });
 
-chart.render();
+  chart.render();
+
+  return chart.getContainer();
+})();
 ```
 
-更多的案例，可以查看[图表示例](/examples)页面。
+## 配置项
 
-## 选项
+| 属性   | 描述                                                                                                | 类型              | 默认值 | 必选 |
+| ------ | --------------------------------------------------------------------------------------------------- | ----------------- | ------ | ---- |
+| encode | 配置 `range` 标记的视觉通道，包括`x`、`y`、`color`、`shape`等，用于指定视觉元素属性和数据之间的关系 | [encode](#encode) | -      | ✓    |
+| style  | 配置 `range` 标记的图形样式                                                                         | [style](#style)   | -      |      |
 
-目前 range 只有一种同名的 shape 图形。
+### encode
 
-### range
+配置 `range` 标记的视觉通道。
 
-| 属性            | 描述                                           | 类型                 | 默认值      |
-|----------------|------------------------------------------------|---------------------|------------|
-| fill          | 图形的填充色                                      | `string` \| `Function<string>`              |   -   |
-| fillOpacity   | 图形的填充透明度                                   | `number` \| `Function<number>`              |   -   |
-| stroke        | 图形的描边                                        | `string` \| `Function<string>`              |   -   |
-| strokeOpacity   | 描边透明度                                        | `number` \| `Function<number>`              |   -   |
-| lineWidth     | 图形描边的宽度                                    | `number` \| `Function<number>`               |   -   |
-| lineDash      | 描边的虚线配置，第一个值为虚线每个分段的长度，第二个值为分段间隔的距离。lineDash 设为[0, 0]的效果为没有描边。 | `[number,number]` \| `Function<[number, number]>` |   -   |
-| opacity       | 图形的整体透明度                                   | `number` \| `Function<number>`              |   -   |
-| shadowColor   | 图形阴影颜色                                      | `string` \| `Function<string>`              |   -   |
-| shadowBlur    | 图形阴影的高斯模糊系数                              | `number` \| `Function<number>`              |   -   |
-| shadowOffsetX | 设置阴影距图形的水平距离                            | `number` \| `Function<number>`              |   -   |
-| shadowOffsetY | 设置阴影距图形的垂直距离                            | `number` \| `Function<number>`              |   -   |
-| cursor        | 鼠标样式。同 css 的鼠标样式，默认 'default'。        | `string` \| `Function<string>`               |   'default'  |
+| 属性 | 描述                                                                   | 类型     | 默认值 | 必选 |
+| ---- | ---------------------------------------------------------------------- | -------- | ------ | ---- |
+| x    | 绑定 `range` 标记的 `x` 属性通道，一般是 `data` 中的时间或有序名词字段 | `string` | -      | ✓    |
+| y    | 绑定 `range` 标记的 `y` 属性通道，一般是 `data` 中的数值或数组字段     | `string` | -      | ✓    |
+
+更多的 `encode` 配置，可以查看 [编码（Encode）](/manual/core/encode) 介绍页面。
+
+### style
+
+配置 `range` 标记的样式。
+
+| 属性          | 描述                                                                                                          | 类型                                              | 默认值    | 必选 |
+| ------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | --------- | ---- |
+| fill          | 图形的填充色                                                                                                  | `string` \| `Function<string>`                    | -         |      |
+| fillOpacity   | 图形的填充透明度                                                                                              | `number` \| `Function<number>`                    | -         |      |
+| stroke        | 图形的描边                                                                                                    | `string` \| `Function<string>`                    | -         |      |
+| strokeOpacity | 描边透明度                                                                                                    | `number` \| `Function<number>`                    | -         |      |
+| lineWidth     | 图形描边的宽度                                                                                                | `number` \| `Function<number>`                    | -         |      |
+| lineDash      | 描边的虚线配置，第一个值为虚线每个分段的长度，第二个值为分段间隔的距离。lineDash 设为[0, 0]的效果为没有描边。 | `[number,number]` \| `Function<[number, number]>` | -         |      |
+| opacity       | 图形的整体透明度                                                                                              | `number` \| `Function<number>`                    | -         |      |
+| shadowColor   | 图形阴影颜色                                                                                                  | `string` \| `Function<string>`                    | -         |      |
+| shadowBlur    | 图形阴影的高斯模糊系数                                                                                        | `number` \| `Function<number>`                    | -         |      |
+| shadowOffsetX | 设置阴影距图形的水平距离                                                                                      | `number` \| `Function<number>`                    | -         |      |
+| shadowOffsetY | 设置阴影距图形的垂直距离                                                                                      | `number` \| `Function<number>`                    | -         |      |
+| cursor        | 鼠标样式。同 css 的鼠标样式，默认 'default'。                                                                 | `string` \| `Function<string>`                    | 'default' |      |
+
+更多的 `style` 配置，可以查看 [样式（Style）](/manual/core/style) 介绍页面。
+
+## 示例
+
+更多的案例，可以查看 [图表示例 - 数据标注](/examples#annotation-range) 页面。

--- a/site/docs/manual/core/mark/rangeX.zh.md
+++ b/site/docs/manual/core/mark/rangeX.zh.md
@@ -3,89 +3,106 @@ title: rangeX
 order: 21
 ---
 
+## 概述
+
 使用一组 `x`(x1, x2) 来定位一个绘制于 x 轴的矩形区域，常用于对特定区域进行高亮显示。
 
-## 开始使用
-
-<img alt="rangeX" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*dmYgTY3kxDoAAAAAAAAAAAAADmJ7AQ/original" width="600" />
-
-```ts
+```js | ob
 /**
  * A recreation of this demo: https://vega.github.io/vega-lite/examples/layer_falkensee.html
  */
-import { Chart } from '@antv/g2';
+(() => {
+  const chart = new G2.Chart();
 
-const chart = new Chart({
-  container: 'container',
-  height: 360,
-  paddingLeft: 60,
-});
+  chart.options({
+    type: 'view',
+    width: 600,
+    height: 360,
+    paddingLeft: 60,
+    data: {
+      type: 'fetch',
+      value: 'https://assets.antv.antgroup.com/g2/year-population.json',
+    },
+    children: [
+      {
+        type: 'rangeX',
+        data: [
+          { year: [new Date('1933'), new Date('1945')], event: 'Nazi Rule' },
+          {
+            year: [new Date('1948'), new Date('1989')],
+            event: 'GDR (East Germany)',
+          },
+        ],
+        encode: { x: 'year', color: 'event' },
+        scale: { color: { independent: true, range: ['#FAAD14', '#30BF78'] } },
+        style: { fillOpacity: 0.75 },
+      },
+      {
+        type: 'line',
+        encode: { x: (d) => new Date(d.year), y: 'population', color: '#333' },
+      },
+      {
+        type: 'point',
+        encode: { x: (d) => new Date(d.year), y: 'population', color: '#333' },
+        style: { lineWidth: 1.5 },
+      },
+    ],
+  });
 
-chart.data({
-  type: 'fetch',
-  value: 'https://assets.antv.antgroup.com/g2/year-population.json',
-});
+  chart.render();
 
-chart
-  .rangeX()
-  .data([
-    { year: [new Date('1933'), new Date('1945')], event: 'Nazi Rule' },
-    { year: [new Date('1948'), new Date('1989')], event: 'GDR (East Germany)' },
-  ])
-  .encode('x', 'year')
-  .encode('color', 'event')
-  .scale('color', { independent: true, range: ['#FAAD14', '#30BF78'] })
-  .style('fillOpacity', 0.75);
-
-chart
-  .line()
-  .encode('x', (d) => new Date(d.year))
-  .encode('y', 'population')
-  .encode('color', '#333');
-
-chart
-  .point()
-  .encode('x', (d) => new Date(d.year))
-  .encode('y', 'population')
-  .encode('color', '#333')
-  .style('lineWidth', 1.5);
-
-chart.render();
-
+  return chart.getContainer();
+})();
 ```
+
 此外，rangeX 还提供了简便写法：
 
 ```ts
 chart
   .rangeX()
   .data([[new Date('2010'), new Date('2011')]])
-  .encode('x', d => d);  
+  .encode('x', (d) => d);
 
 // it can be simplified as follows:
-chart
-  .rangeX()
-  .data([new Date('2010'), new Date('2011')]);
+chart.rangeX().data([new Date('2010'), new Date('2011')]);
 ```
 
-更多的案例，可以查看[图表示例](/examples)页面。
+## 配置项
 
-## 选项
+| 属性   | 描述                                                                                                 | 类型              | 默认值 | 必选 |
+| ------ | ---------------------------------------------------------------------------------------------------- | ----------------- | ------ | ---- |
+| encode | 配置 `rangeX` 标记的视觉通道，包括`x`、`y`、`color`、`shape`等，用于指定视觉元素属性和数据之间的关系 | [encode](#encode) | -      | ✓    |
+| style  | 配置 `rangeX` 标记的图形样式                                                                         | [style](#style)   | -      |      |
 
-目前 rangeX 只有 range 一种 shape 图形。
+### encode
 
-### range
+配置 `rangeX` 标记的视觉通道。
 
-| 属性          | 描述                                                                                                          | 类型                                              | 默认值    |
-| ------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | --------- |
-| fill          | 图形的填充色                                                                                                  | `string` \| `Function<string>`                    | -         |
-| fillOpacity   | 图形的填充透明度                                                                                              | `number` \| `Function<number>`                    | -         |
-| stroke        | 图形的描边                                                                                                    | `string` \| `Function<string>`                    | -         |
-| strokeOpacity | 描边透明度                                                                                                    | `number` \| `Function<number>`                    | -         |
-| lineWidth     | 图形描边的宽度                                                                                                | `number` \| `Function<number>`                    | -         |
-| lineDash      | 描边的虚线配置，第一个值为虚线每个分段的长度，第二个值为分段间隔的距离。lineDash 设为[0, 0]的效果为没有描边。 | `[number,number]` \| `Function<[number, number]>` | -         |
-| opacity       | 图形的整体透明度                                                                                              | `number` \| `Function<number>`                    | -         |
-| shadowColor   | 图形阴影颜色                                                                                                  | `string` \| `Function<string>`                    | -         |
-| shadowBlur    | 图形阴影的高斯模糊系数                                                                                        | `number` \| `Function<number>`                    | -         |
-| shadowOffsetX | 设置阴影距图形的水平距离                                                                                      | `number` \| `Function<number>`                    | -         |
-| shadowOffsetY | 设置阴影距图形的垂直距离                                                                                      | `number` \| `Function<number>`                    | -         |
-| cursor        | 鼠标样式。同 css 的鼠标样式，默认 'default'。                                                                 | `string` \| `Function<string>`                    | 'default' |
+| 属性 | 描述                                                                    | 类型     | 默认值 | 必选 |
+| ---- | ----------------------------------------------------------------------- | -------- | ------ | ---- |
+| x    | 绑定 `rangeX` 标记的 `x` 属性通道，一般是 `data` 中的时间或有序名词字段 | `string` | -      | ✓    |
+
+更多的 `encode` 配置，可以查看 [编码（Encode）](/manual/core/encode) 介绍页面。
+
+### style
+
+| 属性          | 描述                                                                                                          | 类型                                              | 默认值    | 必选 |
+| ------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | --------- | ---- |
+| fill          | 图形的填充色                                                                                                  | `string` \| `Function<string>`                    | -         |      |
+| fillOpacity   | 图形的填充透明度                                                                                              | `number` \| `Function<number>`                    | -         |      |
+| stroke        | 图形的描边                                                                                                    | `string` \| `Function<string>`                    | -         |      |
+| strokeOpacity | 描边透明度                                                                                                    | `number` \| `Function<number>`                    | -         |      |
+| lineWidth     | 图形描边的宽度                                                                                                | `number` \| `Function<number>`                    | -         |      |
+| lineDash      | 描边的虚线配置，第一个值为虚线每个分段的长度，第二个值为分段间隔的距离。lineDash 设为[0, 0]的效果为没有描边。 | `[number,number]` \| `Function<[number, number]>` | -         |      |
+| opacity       | 图形的整体透明度                                                                                              | `number` \| `Function<number>`                    | -         |      |
+| shadowColor   | 图形阴影颜色                                                                                                  | `string` \| `Function<string>`                    | -         |      |
+| shadowBlur    | 图形阴影的高斯模糊系数                                                                                        | `number` \| `Function<number>`                    | -         |      |
+| shadowOffsetX | 设置阴影距图形的水平距离                                                                                      | `number` \| `Function<number>`                    | -         |      |
+| shadowOffsetY | 设置阴影距图形的垂直距离                                                                                      | `number` \| `Function<number>`                    | -         |      |
+| cursor        | 鼠标样式。同 css 的鼠标样式，默认 'default'。                                                                 | `string` \| `Function<string>`                    | 'default' |      |
+
+更多的 `style` 配置，可以查看 [样式（Style）](/manual/core/style) 介绍页面。
+
+## 示例
+
+更多的案例，可以查看 [图表示例 - 数据标注](/examples#annotation-range) 页面。

--- a/site/docs/manual/core/mark/rangeY.zh.md
+++ b/site/docs/manual/core/mark/rangeY.zh.md
@@ -3,36 +3,36 @@ title: rangeY
 order: 22
 ---
 
+## 概述
+
 使用一组 `y`(y1, y2) 来定位一个绘制于 y 轴的矩形区域，常用于对特定区域进行高亮显示。
 
-## 开始使用
+```js | ob
+(() => {
+  const chart = new G2.Chart();
 
-<img alt="rangeY" src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*5KeuR781ubMAAAAAAAAAAAAADmJ7AQ/original" width="600" />
+  chart.options({
+    width: 600,
+    height: 470,
+    type: 'view',
+    children: [
+      {
+        type: 'point',
+        data: {
+          type: 'fetch',
+          value:
+            'https://gw.alipayobjects.com/os/basement_prod/6b4aa721-b039-49b9-99d8-540b3f87d339.json',
+        },
+        encode: { x: 'height', y: 'weight', color: 'gender' },
+      },
+      { type: 'rangeY', data: [{ y: [54, 72] }], encode: { y: 'y' } },
+    ],
+  });
 
-```ts
-import { Chart } from '@antv/g2';
+  chart.render();
 
-const chart = new Chart({
-  container: 'container',
-});
-
-chart
-  .point()
-  .data({
-    type: 'fetch',
-    value:
-      'https://gw.alipayobjects.com/os/basement_prod/6b4aa721-b039-49b9-99d8-540b3f87d339.json',
-  })
-  .encode('x', 'height')
-  .encode('y', 'weight')
-  .encode('color', 'gender');
-
-chart
-  .rangeY()
-  .data([{ y: [54, 72] }])
-  .encode('y', 'y');
-
-chart.render();
+  return chart.getContainer();
+})();
 ```
 
 此外，rangeY 还提供了简便写法：
@@ -40,34 +40,55 @@ chart.render();
 ```ts
 chart
   .rangeY()
-  .data([[54, 60], [65, 72]])
-  .encode('y', d => d);
+  .data([
+    [54, 60],
+    [65, 72],
+  ])
+  .encode('y', (d) => d);
 
 // it can be simplified as follows:
-chart
-  .rangeY()
-  .data([[54, 60], [65, 72]]);
+chart.rangeY().data([
+  [54, 60],
+  [65, 72],
+]);
 ```
 
-更多的案例，可以查看[图表示例](/examples)页面。
+## 配置项
 
-## 选项
+| 属性   | 描述                                                                                                 | 类型              | 默认值 | 必选 |
+| ------ | ---------------------------------------------------------------------------------------------------- | ----------------- | ------ | ---- |
+| encode | 配置 `rangeY` 标记的视觉通道，包括`x`、`y`、`color`、`shape`等，用于指定视觉元素属性和数据之间的关系 | [encode](#encode) | -      | ✓    |
+| style  | 配置 `rangeY` 标记的图形样式                                                                         | [style](#style)   | -      |      |
 
-目前 rangeY 只有 range 一种 shape 图形。
+### encode
 
-### range
+配置 `rangeY` 标记的视觉通道。
 
-| 属性          | 描述                                                                                                          | 类型                                              | 默认值    |
-| ------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | --------- |
-| fill          | 图形的填充色                                                                                                  | `string` \| `Function<string>`                    | -         |
-| fillOpacity   | 图形的填充透明度                                                                                              | `number` \| `Function<number>`                    | -         |
-| stroke        | 图形的描边                                                                                                    | `string` \| `Function<string>`                    | -         |
-| strokeOpacity | 描边透明度                                                                                                    | `number` \| `Function<number>`                    | -         |
-| lineWidth     | 图形描边的宽度                                                                                                | `number` \| `Function<number>`                    | -         |
-| lineDash      | 描边的虚线配置，第一个值为虚线每个分段的长度，第二个值为分段间隔的距离。lineDash 设为[0, 0]的效果为没有描边。 | `[number,number]` \| `Function<[number, number]>` | -         |
-| opacity       | 图形的整体透明度                                                                                              | `number` \| `Function<number>`                    | -         |
-| shadowColor   | 图形阴影颜色                                                                                                  | `string` \| `Function<string>`                    | -         |
-| shadowBlur    | 图形阴影的高斯模糊系数                                                                                        | `number` \| `Function<number>`                    | -         |
-| shadowOffsetX | 设置阴影距图形的水平距离                                                                                      | `number` \| `Function<number>`                    | -         |
-| shadowOffsetY | 设置阴影距图形的垂直距离                                                                                      | `number` \| `Function<number>`                    | -         |
-| cursor        | 鼠标样式。同 css 的鼠标样式，默认 'default'。                                                                 | `string` \| `Function<string>`                    | 'default' |
+| 属性 | 描述                                                                    | 类型     | 默认值 | 必选 |
+| ---- | ----------------------------------------------------------------------- | -------- | ------ | ---- |
+| y    | 绑定 `rangeY` 标记的 `y` 属性通道，一般是 `data` 中的时间或有序名词字段 | `string` | -      | ✓    |
+
+更多的 `encode` 配置，可以查看 [编码（Encode）](/manual/core/encode) 介绍页面。
+
+### style
+
+| 属性          | 描述                                                                                                          | 类型                                              | 默认值    | 必选 |
+| ------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | --------- | ---- |
+| fill          | 图形的填充色                                                                                                  | `string` \| `Function<string>`                    | -         |      |
+| fillOpacity   | 图形的填充透明度                                                                                              | `number` \| `Function<number>`                    | -         |      |
+| stroke        | 图形的描边                                                                                                    | `string` \| `Function<string>`                    | -         |      |
+| strokeOpacity | 描边透明度                                                                                                    | `number` \| `Function<number>`                    | -         |      |
+| lineWidth     | 图形描边的宽度                                                                                                | `number` \| `Function<number>`                    | -         |      |
+| lineDash      | 描边的虚线配置，第一个值为虚线每个分段的长度，第二个值为分段间隔的距离。lineDash 设为[0, 0]的效果为没有描边。 | `[number,number]` \| `Function<[number, number]>` | -         |      |
+| opacity       | 图形的整体透明度                                                                                              | `number` \| `Function<number>`                    | -         |      |
+| shadowColor   | 图形阴影颜色                                                                                                  | `string` \| `Function<string>`                    | -         |      |
+| shadowBlur    | 图形阴影的高斯模糊系数                                                                                        | `number` \| `Function<number>`                    | -         |      |
+| shadowOffsetX | 设置阴影距图形的水平距离                                                                                      | `number` \| `Function<number>`                    | -         |      |
+| shadowOffsetY | 设置阴影距图形的垂直距离                                                                                      | `number` \| `Function<number>`                    | -         |      |
+| cursor        | 鼠标样式。同 css 的鼠标样式，默认 'default'。                                                                 | `string` \| `Function<string>`                    | 'default' |      |
+
+更多的 `style` 配置，可以查看 [样式（Style）](/manual/core/style) 介绍页面。
+
+## 示例
+
+更多的案例，可以查看 [图表示例 - 数据标注](/examples#annotation-range) 页面。


### PR DESCRIPTION


> mark-range
![Kapture 2025-03-11 at 17 25 29](https://github.com/user-attachments/assets/2156bae9-be3b-4a39-bf4b-d0a6c140c896)


> mark-rangeX
![Kapture 2025-03-11 at 17 25 59](https://github.com/user-attachments/assets/e34df5e3-3275-45d1-81e5-43f835e9042c)


> mark-rangeY

![Kapture 2025-03-11 at 17 26 28](https://github.com/user-attachments/assets/0f914f8a-4a9d-41b2-9bea-0b6c6fbbde5d)


