### PR TITLE
chore: export some useful utils func

### DIFF
--- a/__tests__/unit/utils/helper.test.ts
+++ b/__tests__/unit/utils/helper.test.ts
@@ -1,0 +1,144 @@
+import { Band, Constant } from '@antv/scale';
+import { groupNameOf, dataOf, seriesOf } from '../../../src/utils/helper';
+import { Chart } from '../../../src';
+import { createNodeGCanvas } from '../../integration/utils/createNodeGCanvas';
+import { G2Element } from '../../../src/utils/selection';
+
+describe('groupNameOf', () => {
+  it('should handle band series scale', () => {
+    const seriesScale = new Band();
+    seriesScale.update({ domain: ['A', 'B', 'C', 'D'], range: [0, 1] });
+    const scale = { series: seriesScale };
+    const datum = { series: 0.25 };
+    expect(groupNameOf(scale, datum)).toBe('B');
+  });
+
+  it('should return null for constant scale', () => {
+    const seriesScale = new Constant();
+    seriesScale.update({ domain: [1], range: [1] });
+    const scale = { series: seriesScale };
+    const datum = { series: 1 };
+    expect(groupNameOf(scale, datum)).toBeNull();
+  });
+});
+
+describe('seriesOf', () => {
+  const chart = new Chart({
+    canvas: createNodeGCanvas(640, 480),
+  });
+
+  it('should return null for non-series mark', async () => {
+    const data = [
+      { x: 1, y: 10 },
+      { x: 2, y: 20 },
+    ];
+    chart.options({
+      type: 'interval',
+      data,
+      encode: {
+        x: 'x',
+        y: 'y',
+      },
+    });
+
+    await chart.render();
+
+    const rects = chart
+      .getContext()
+      ?.canvas?.document.getElementsByClassName('element');
+    const firstRect = rects?.[0] as G2Element;
+    const name = seriesOf(firstRect);
+
+    expect(name).toBe(null);
+  });
+
+  it('should get series value from grouped data', async () => {
+    const data = [
+      { year: '2020', value: 10, type: 'A' },
+      { year: '2020', value: 20, type: 'B' },
+      { year: '2021', value: 15, type: 'A' },
+      { year: '2021', value: 25, type: 'B' },
+    ];
+
+    chart.options({
+      type: 'interval',
+      data,
+      encode: {
+        x: 'year',
+        y: 'value',
+        color: 'type',
+        series: 'type',
+      },
+    });
+
+    await chart.render();
+
+    const rects = chart
+      .getContext()
+      ?.canvas?.document.getElementsByClassName('element');
+    const firstRect = rects?.[1] as G2Element;
+    const name = seriesOf(firstRect);
+
+    expect(name).toBe('B');
+  });
+});
+
+describe('dataOf', () => {
+  const chart = new Chart({
+    canvas: createNodeGCanvas(640, 480),
+  });
+
+  it('should get single data point from interval element', async () => {
+    const data = [
+      { x: 1, y: 10 },
+      { x: 2, y: 20 },
+    ];
+    chart.options({
+      type: 'interval',
+      data,
+      encode: {
+        x: 'x',
+        y: 'y',
+      },
+    });
+
+    await chart.render();
+
+    const rects = chart
+      .getContext()
+      ?.canvas?.document.getElementsByClassName('element');
+    const firstRect = rects?.[0] as G2Element;
+    const originalData = dataOf(firstRect);
+
+    expect(originalData).toEqual(data[0]);
+  });
+
+  it('should get series data from grouped interval element', async () => {
+    const data = [
+      { year: '2020', value: 10, type: 'A' },
+      { year: '2020', value: 20, type: 'B' },
+      { year: '2021', value: 15, type: 'A' },
+      { year: '2021', value: 25, type: 'B' },
+    ];
+
+    chart.options({
+      type: 'interval',
+      data,
+      encode: {
+        x: 'year',
+        y: 'value',
+        color: 'type',
+      },
+    });
+
+    await chart.render();
+
+    const rects = chart
+      .getContext()
+      ?.canvas?.document.getElementsByClassName('element');
+    const firstRect = rects?.[0] as G2Element;
+    const seriesData = dataOf(firstRect);
+
+    expect(seriesData).toEqual({ year: '2020', value: 10, type: 'A' });
+  });
+});

--- a/src/api/runtime.ts
+++ b/src/api/runtime.ts
@@ -75,6 +75,9 @@ export class Runtime<Spec extends G2Spec = G2Spec> extends CompositionNode {
     if (!this._context.canvas) this._createCanvas();
     this._bindAutoFit();
     this._rendering = true;
+
+    // @fixme The cancel render is not marked, which will cause additional rendered event.
+    // @ref src/runtime/render.ts
     const finished = new Promise<Runtime<Spec>>((resolve, reject) =>
       render(
         this._computedOptions(),

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -37,6 +37,9 @@ export type {
   Channel,
 } from './runtime';
 export { select, Selection } from './utils/selection';
+export { dataOf, seriesOf } from './utils/helper';
+export { selectG2Elements, selectPlotArea } from './interaction/utils';
+
 export * from './transform';
 export { LinearAxis } from './component/axis';
 export type { AxisOptions } from './component/axis';

--- a/src/interaction/event.ts
+++ b/src/interaction/event.ts
@@ -1,19 +1,6 @@
 import { ChartEvent } from '../utils/event';
+import { dataOf } from '../utils/helper';
 import { maybeRoot } from './utils';
-
-export function dataOf(element, view) {
-  const { __data__: datum } = element;
-  const { markKey, index, seriesIndex } = datum;
-  const { markState } = view;
-  const selectedMark: any = Array.from(markState.keys()).find(
-    (mark) => (mark as any).key === markKey,
-  );
-  if (!selectedMark) return;
-  if (seriesIndex) {
-    return seriesIndex.map((i) => selectedMark.data[i]);
-  }
-  return selectedMark.data[index];
-}
 
 // For extended component
 function maybeComponentRoot(node) {
@@ -63,7 +50,7 @@ function bubblesEvent(eventType, view, emitter, predicate = (event) => true) {
       nativeEvent: true,
     };
     if (elementType === 'element') {
-      e1['data'] = { data: dataOf(root, view) };
+      e1['data'] = { data: dataOf(root) };
       emitter.emit(`element:${eventType}`, e1);
       emitter.emit(`${markType}:${eventType}`, e1);
     } else if (elementType === 'label') {

--- a/src/interaction/tooltip.ts
+++ b/src/interaction/tooltip.ts
@@ -2,8 +2,7 @@ import { Circle, DisplayObject, IElement, Line } from '@antv/g';
 import { sort, group, mean, bisector, minIndex } from '@antv/vendor/d3-array';
 import { deepMix, lowerFirst, throttle } from '@antv/util';
 import { Tooltip as TooltipComponent } from '@antv/component';
-import { Constant, Band } from '@antv/scale';
-import { defined, subObject } from '../utils/helper';
+import { defined, groupNameOf, subObject, dataOf } from '../utils/helper';
 import { isTranspose, isPolar } from '../utils/coordinate';
 import { angle, sub, dist } from '../utils/vector';
 import { invert } from '../utils/scale';
@@ -19,7 +18,6 @@ import {
   bboxOf,
   maybeRoot,
 } from './utils';
-import { dataOf } from './event';
 
 function getContainer(
   group: IElement,
@@ -206,39 +204,6 @@ function singleItem(element) {
     ...(title && { title }),
     items: newItems,
   };
-}
-
-function groupNameOf(scale, datum) {
-  const { color: scaleColor, series: scaleSeries, facet = false } = scale;
-  const { color, series } = datum;
-  const invertAble = (scale) => {
-    return (
-      scale &&
-      scale.invert &&
-      !(scale instanceof Band) &&
-      !(scale instanceof Constant)
-    );
-  };
-  // For non constant color channel.
-  if (invertAble(scaleSeries)) {
-    const cloned = scaleSeries.clone();
-    return cloned.invert(series);
-  }
-  if (
-    series &&
-    scaleSeries instanceof Band &&
-    scaleSeries.invert(series) !== color &&
-    !facet
-  ) {
-    return scaleSeries.invert(series);
-  }
-  if (invertAble(scaleColor)) {
-    const name = scaleColor.invert(color);
-    // For threshold scale.
-    if (Array.isArray(name)) return null;
-    return name;
-  }
-  return null;
 }
 
 function itemColorOf(element) {
@@ -1097,7 +1062,7 @@ export function tooltip(
         nativeEvent: true,
         data: {
           ...data,
-          data: dataOf(element, view),
+          data: dataOf(element),
         },
       });
     },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change
1. 导出一些常用的工具方法，调整了工具函数的目录结构
2. 简化 dataOf 函数，支持直接传入 element 得到原始数据
```tsx
import { dataOf } from '@antv/g2'
...
chart.on('plot:click', e => {
  console.log(dataOf(e.target)) // do something with original data
})
```
<!-- Provide a description of the change below this comment. -->
