### PR TITLE
chore: lock the dumi version

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -34,7 +34,7 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-voronoi": "^1.1.4",
     "dirichlet": "^1.0.1",
-    "dumi": "^2.4.18",
+    "dumi": "2.4.17",
     "fecha": "^4.2.3",
     "fmin": "0.0.2",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Lock the dumi version to prevent errors on the official website.  