### PR TITLE
fix(tooltip): tooltip with one element

### DIFF
--- a/__tests__/plots/bugfix/index.ts
+++ b/__tests__/plots/bugfix/index.ts
@@ -11,3 +11,4 @@ export { issue6699 } from './issue-6699';
 export { issue6714 } from './issue-6714';
 export { issue6710 } from './issue-6710';
 export { issue6747 } from './issue-6747';
+export { issue6762 } from './issue-6762';

--- a/__tests__/plots/bugfix/issue-6762.ts
+++ b/__tests__/plots/bugfix/issue-6762.ts
@@ -1,0 +1,32 @@
+import { Chart } from '../../../src';
+
+export function issue6762(context) {
+  const { container, canvas, callback } = context;
+  const chart = new Chart({
+    container,
+    canvas,
+  });
+
+  chart
+    .data({
+      type: 'fetch',
+      value:
+        ' https://gw.alipayobjects.com/os/bmw-prod/474e51c8-b47b-4bb6-b3ed-87813a960df2.csv',
+    })
+    .encode('x', 'mpg')
+    .encode('y', 'hp')
+    .encode('color', 'mpg');
+
+  chart.point().encode('shape', 'point').encode('size', 6).tooltip(false);
+
+  chart.line().interaction('tooltip', {
+    crosshairs: true,
+  });
+
+  const finished = chart.render();
+
+  return {
+    chart,
+    finished,
+  };
+}

--- a/src/interaction/tooltip.ts
+++ b/src/interaction/tooltip.ts
@@ -674,7 +674,9 @@ export function seriesTooltip(
     const i = search(I, finalX);
     if (isOnlyOneElement) {
       // if is only one element, find the closest x to focusX
-      const sortedDomain: number[] = scaleX.adjustedRange;
+      // the scale also can be linear in complex chart
+      const sortedDomain: number[] =
+        scaleX.adjustedRange || scaleX.getOptions().range;
       if (
         // consider oneElementLine, if only one element of one XDomain, must return one element, related test case: tooltip/one-element-line
         // else if multi elements, determine whether it is between the minimum scope and the maximum scope


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] benchmarks are included
- [x] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change

- fixed: #6762 
- 之前对于单一element的tooltip拾取只考虑了scale为point的情况，在linear情况下没有参数adjustedRange，会报错
