### PR TITLE
fix(docs): fix a render error of char '|'

### DIFF
--- a/site/docs/manual/core/scale/ordinal.zh.md
+++ b/site/docs/manual/core/scale/ordinal.zh.md
@@ -29,7 +29,7 @@ chart
 | domain      | 设置数据的定义域范围                                            | `any[]` | `[]` |
 | range       | 设置数据映射的值域范围                                           | `any[]` | `[]` |
 | unknown     | 对于 `undefined`， `NaN`，`null` 空值，返回的数据                | `any` | `undefined` |
-| compare     | 比较两个值，用于排序的比较器                                      | `(a: number | string, b: number | string) => number`      | `undefined` |
+| compare     | 比较两个值，用于排序的比较器                                      | `(a: number \| string, b: number \| string) => number`      | `undefined` |
 
 ## FAQ
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] benchmarks are included
- [ ] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change

<!-- Provide a description of the change below this comment. -->

修复了 [Scale 文档中 ordinal 表格](https://g2.antv.antgroup.com/manual/core/scale/ordinal#%E9%80%89%E9%A1%B9) 渲染 ts 类型定义时的错误