### PR TITLE
feat: support region highlight

### DIFF
--- a/__tests__/plots/api/chart-element-highlight-region.ts
+++ b/__tests__/plots/api/chart-element-highlight-region.ts
@@ -1,0 +1,70 @@
+import { Chart } from '../../../src';
+
+export function chartElementHighlightRegion(context) {
+  const { container, canvas } = context;
+
+  const wrapperDiv = document.createElement('div');
+  container.appendChild(wrapperDiv);
+
+  const chart = new Chart({
+    container: wrapperDiv,
+    canvas,
+  });
+
+  chart.options({
+    type: 'view',
+    autoFit: true,
+    interaction: {
+      elementSelect: {
+        region: true,
+        multipleSelectHotkey: 'ShiftLeft',
+        background: true,
+      },
+      elementHighlight: {
+        background: true,
+        region: true,
+      },
+    },
+    data: [
+      { time: '10:10', call: 4, waiting: 2, people: 2 },
+      { time: '10:15', call: 2, waiting: 6, people: 3 },
+      { time: '10:20', call: 13, waiting: 2, people: 5 },
+      { time: '10:25', call: 9, waiting: 9, people: 1 },
+      { time: '10:30', call: 5, waiting: 2, people: 3 },
+      { time: '10:35', call: 8, waiting: 2, people: 1 },
+      { time: '10:40', call: 13, waiting: 1, people: 2 },
+    ],
+    children: [
+      {
+        type: 'interval',
+        encode: { x: 'time', y: 'waiting', series: () => '0' },
+        axis: { y: { title: 'Waiting', titleFill: '#5B8FF9' } },
+        state: {
+          selected: {
+            fill: 'red',
+          },
+        },
+      },
+      {
+        type: 'interval',
+        encode: { x: 'time', y: 'people', series: () => '1' },
+        scale: { y: { independent: true } },
+        state: {
+          selected: {
+            fill: 'red',
+          },
+        },
+      },
+      {
+        type: 'line',
+        encode: { x: 'time', y: 'people', shape: 'smooth' },
+        scale: { y: { independent: true } },
+        style: { stroke: '#fdae6b', lineWidth: 2 },
+      },
+    ],
+  });
+
+  const finished = chart.render();
+
+  return { chart, finished };
+}

--- a/__tests__/plots/api/chart-element-highlight-region.ts
+++ b/__tests__/plots/api/chart-element-highlight-region.ts
@@ -1,5 +1,15 @@
 import { Chart } from '../../../src';
 
+const state = {
+  selected: {
+    fill: 'red',
+  },
+  active: {
+    stroke: '#000000',
+    lineWidth: 2,
+  },
+};
+
 export function chartElementHighlightRegion(context) {
   const { container, canvas } = context;
 
@@ -16,50 +26,32 @@ export function chartElementHighlightRegion(context) {
     autoFit: true,
     interaction: {
       elementSelect: {
+        state,
         region: true,
         multipleSelectHotkey: 'ShiftLeft',
-        background: true,
       },
       elementHighlight: {
+        state,
         background: true,
         region: true,
       },
     },
     data: [
-      { time: '10:10', call: 4, waiting: 2, people: 2 },
-      { time: '10:15', call: 2, waiting: 6, people: 3 },
-      { time: '10:20', call: 13, waiting: 2, people: 5 },
-      { time: '10:25', call: 9, waiting: 9, people: 1 },
-      { time: '10:30', call: 5, waiting: 2, people: 3 },
-      { time: '10:35', call: 8, waiting: 2, people: 1 },
-      { time: '10:40', call: 13, waiting: 1, people: 2 },
+      { name: 'London', 月份: 'Jan.', 月均降雨量: 18.9 },
+      { name: 'London', 月份: 'Feb.', 月均降雨量: 28.8 },
+      { name: 'Berlin', 月份: 'Jan.', 月均降雨量: 12.4 },
+      { name: 'Berlin', 月份: 'Feb.', 月均降雨量: 23.2 },
     ],
     children: [
       {
+        encode: { x: '月份', y: '月均降雨量', series: 'name' },
         type: 'interval',
-        encode: { x: 'time', y: 'waiting', series: () => '0' },
         axis: { y: { title: 'Waiting', titleFill: '#5B8FF9' } },
         state: {
           selected: {
             fill: 'red',
           },
         },
-      },
-      {
-        type: 'interval',
-        encode: { x: 'time', y: 'people', series: () => '1' },
-        scale: { y: { independent: true } },
-        state: {
-          selected: {
-            fill: 'red',
-          },
-        },
-      },
-      {
-        type: 'line',
-        encode: { x: 'time', y: 'people', shape: 'smooth' },
-        scale: { y: { independent: true } },
-        style: { stroke: '#fdae6b', lineWidth: 2 },
       },
     ],
   });

--- a/__tests__/plots/api/chart-element-highlight-region.ts
+++ b/__tests__/plots/api/chart-element-highlight-region.ts
@@ -47,11 +47,6 @@ export function chartElementHighlightRegion(context) {
         encode: { x: '月份', y: '月均降雨量', series: 'name' },
         type: 'interval',
         axis: { y: { title: 'Waiting', titleFill: '#5B8FF9' } },
-        state: {
-          selected: {
-            fill: 'red',
-          },
-        },
       },
     ],
   });

--- a/__tests__/plots/api/index.ts
+++ b/__tests__/plots/api/index.ts
@@ -55,3 +55,4 @@ export { chartChangeSizeLabelRotate } from './chart-change-size-label-rotate';
 export { chartWordCloudCanvas } from './chart-word-cloud-canvas';
 export { chartElementMultipleSelect } from './chart-emit-element-multiple-select';
 export { chartMultipleMarkSelectRegion } from './chart-multiple-mark-select-region';
+export { chartElementHighlightRegion } from './chart-element-highlight-region';

--- a/site/docs/manual/core/interaction/elementHighlight.zh.md
+++ b/site/docs/manual/core/interaction/elementHighlight.zh.md
@@ -40,6 +40,7 @@ chart.render();
 | ------------------------- | -------------- | ------------ | ------ |
 | background                | 是否高亮背景   | `boolean`    | false  |
 | offset                    | 主方向的偏移量 | `number`     | 0      |
+| region                    | 空白区域是否触发       | `boolean`    | false  |
 | `background${StyleAttrs}` | 背景的样式     | `StyleAttrs` | -      |
 
 ## 案例

--- a/site/docs/manual/core/state.zh.md
+++ b/site/docs/manual/core/state.zh.md
@@ -91,3 +91,49 @@ chart.interval().state({
   return chart.getContainer();
 })();
 ```
+
+## 状态优先级
+
+g2 支持多个状态同时生效，当状态配置产生冲突时，会按照优先级选择生效的配置
+
+考虑如下配置
+
+```js | ob
+(() => {
+  const chart = new G2.Chart();
+  const state = {
+    selected: { fill: 'red' },
+    active: { fill: 'green', stroke: 'black', lineWidth: 1 },
+  };
+
+  chart
+    .interval()
+    .data({
+      type: 'fetch',
+      value:
+        'https://gw.alipayobjects.com/os/bmw-prod/fb9db6b7-23a5-4c23-bbef-c54a55fee580.csv',
+    })
+    .encode('x', 'letter')
+    .encode('y', 'frequency')
+    .interaction('elementHighlight', { state }) // 设置高亮交互;
+    .interaction('elementSelect', { state }); // 设置选择交互;
+
+  chart.render();
+
+  return chart.getContainer();
+})();
+```
+
+hover 时，active 状态生效，会有边框（stroke）和绿色背景色（fill）。
+
+点击时，active 与 selected 状态同时生效，但两者都配置了 fill 产生冲突，此时 selected 状态的优先级更高，最终生效的是红色 red。
+
+具体的状态优先级为
+
+```
+selected: 3
+unselected: 3
+active: 2
+inactive: 2
+default: 1
+```

--- a/src/interaction/elementHighlight.ts
+++ b/src/interaction/elementHighlight.ts
@@ -7,7 +7,6 @@ import {
   createFindElementByEvent,
   createValueof,
   createXKey,
-  getElementSelectState,
   mergeState,
   offsetTransform,
   renderBackground,

--- a/src/interaction/elementHighlight.ts
+++ b/src/interaction/elementHighlight.ts
@@ -27,7 +27,7 @@ export function elementHighlight(
   {
     elements: elementsof, // given the root of chart returns elements to be manipulated
     datum, // given each element returns the datum of it
-    groupKey: _groupKey = (d) => d, // group elements by specified key
+    groupKey: eleGroupKey = (d) => d, // group elements by specified key
     regionGroupKey = (d) => d, // how to group elements when hover region
     link = false, // draw link or not
     background = false, // draw background or not
@@ -37,14 +37,13 @@ export function elementHighlight(
     emitter,
     state = {},
     region = false,
+    regionEleFilter = (el) => VALID_FIND_BY_X_MARKS.includes(el.markType), // some elements can not be highlighted by region, like shapes in pie.
   }: Record<string, any>,
 ) {
-  const allElements = elementsof(root);
-  const elements = region
-    ? allElements?.filter((el) => VALID_FIND_BY_X_MARKS.includes(el.markType))
-    : allElements;
+  const allElements = elementsof(root) ?? [];
+  const elements = region ? allElements.filter(regionEleFilter) : allElements;
   const elementSet = new Set(elements);
-  const groupKey = region ? regionGroupKey : _groupKey;
+  const groupKey = region ? regionGroupKey : eleGroupKey;
   const keyGroup = group(elements, groupKey);
   const findElement = createFindElementByEvent({
     elementsof,

--- a/src/interaction/elementHighlight.ts
+++ b/src/interaction/elementHighlight.ts
@@ -39,7 +39,9 @@ export function elementHighlight(
     region = false,
   }: Record<string, any>,
 ) {
-  const elements = elementsof(root);
+  const elements = elementsof(root)?.filter((el) =>
+    VALID_FIND_BY_X_MARKS.includes(el.markType),
+  );
   const elementSet = new Set(elements);
   const groupKey = regionGroupKey || _groupKey;
   const keyGroup = group(elements, regionGroupKey) || group(elements, groupKey);
@@ -96,9 +98,6 @@ export function elementHighlight(
   const pointerover = (event) => {
     const { nativeEvent = true } = event;
     let element = event.target;
-    const filteredElements = elements.filter((el) =>
-      VALID_FIND_BY_X_MARKS.includes(el.markType),
-    );
     if (region) {
       element = findElement(event);
     }
@@ -107,7 +106,7 @@ export function elementHighlight(
     const k = groupKey(element);
     const group = keyGroup.get(k);
     const groupSet = new Set(group);
-    for (const e of filteredElements) {
+    for (const e of elements) {
       if (groupSet.has(e)) {
         if (!hasState(e, 'active'))
           setState(e, 'active', ...getElementSelectState(e, hasState));

--- a/src/interaction/elementSelect.ts
+++ b/src/interaction/elementSelect.ts
@@ -82,7 +82,10 @@ export function elementSelect(
     },
   });
 
-  const { setState, removeState, hasState } = useState(elementStyle, valueof);
+  const { updateState, removeState, hasState } = useState(
+    elementStyle,
+    valueof,
+  );
   let isMultiSelectMode = !single; // "single" determines whether to multi-select by default
   let activeHotkey = null; // Track the currently active hotkey
 
@@ -112,9 +115,9 @@ export function elementSelect(
       const group = groupMap.get(k);
       const groupSet = new Set(group);
       for (const e of filteredElements) {
-        if (groupSet.has(e)) setState(e, 'selected');
+        if (groupSet.has(e)) updateState(e, 'selected');
         else {
-          setState(e, 'unselected');
+          updateState(e, 'unselected');
           removeLink(e);
         }
         if (e !== element) removeBackground(e);
@@ -149,8 +152,8 @@ export function elementSelect(
     if (!hasState(element, 'selected')) {
       const hasSelectedGroup = group.some((e) => hasState(e, 'selected'));
       for (const e of filteredElements) {
-        if (groupSet.has(e)) setState(e, 'selected');
-        else if (!hasState(e, 'selected')) setState(e, 'unselected');
+        if (groupSet.has(e)) updateState(e, 'selected');
+        else if (!hasState(e, 'selected')) updateState(e, 'unselected');
       }
       // Append link for each group only once.
       if (!hasSelectedGroup && link) appendLink(group);
@@ -165,7 +168,7 @@ export function elementSelect(
       // If there are still some selected elements after resetting this group,
       // only remove the link.
       for (const e of group) {
-        setState(e, 'unselected');
+        updateState(e, 'unselected');
         removeLink(e);
         removeBackground(e);
       }

--- a/src/interaction/elementSelect.ts
+++ b/src/interaction/elementSelect.ts
@@ -37,6 +37,7 @@ export function elementSelect(
     emitter,
     state = {},
     region = false,
+    regionEleFilter = (el) => VALID_FIND_BY_X_MARKS.includes(el.markType),
   }: Record<string, any>,
 ) {
   const elements = elementsof(root);
@@ -206,7 +207,7 @@ export function elementSelect(
         event,
         element: el,
         nativeEvent,
-        filter: (el) => VALID_FIND_BY_X_MARKS.includes(el.markType),
+        filter: regionEleFilter,
         groupBy: regionGroupKey,
         groupMap: regionGroup,
       });

--- a/src/interaction/utils.ts
+++ b/src/interaction/utils.ts
@@ -591,3 +591,9 @@ export function createFindElementByEvent({
     });
   };
 }
+
+export const getElementSelectState = (element, hasState) => {
+  if (hasState(element, 'selected')) return ['selected'];
+  if (hasState(element, 'unselected')) return ['unselected'];
+  return [];
+};

--- a/src/interaction/utils.ts
+++ b/src/interaction/utils.ts
@@ -666,9 +666,3 @@ export function createFindElementByEvent({
     });
   };
 }
-
-export const getElementSelectState = (element, hasState) => {
-  if (hasState(element, 'selected')) return ['selected'];
-  if (hasState(element, 'unselected')) return ['unselected'];
-  return [];
-};

--- a/src/spec/interaction.ts
+++ b/src/spec/interaction.ts
@@ -101,7 +101,7 @@ export type ElementHighlightInteraction = {
   background?: boolean;
   offset?: number;
   region?: boolean;
-} & Record<`${'link' | 'background'}${any}`, any>;
+} & Record<`${'link' | 'background' | 'state'}${any}`, any>;
 
 export type ElementSelectInteraction = {
   type?: 'elementSelect';
@@ -110,7 +110,7 @@ export type ElementSelectInteraction = {
   offset?: number;
   multipleSelectHotkey?: string;
   region?: boolean;
-} & Record<`${'link' | 'background'}${any}`, any>;
+} & Record<`${'link' | 'background' | 'state'}${any}`, any>;
 
 export type ElementSelectByColorInteraction = {
   type?: 'elementSelectByColor';

--- a/src/spec/interaction.ts
+++ b/src/spec/interaction.ts
@@ -100,6 +100,7 @@ export type ElementHighlightInteraction = {
   link?: boolean;
   background?: boolean;
   offset?: number;
+  region?: boolean;
 } & Record<`${'link' | 'background'}${any}`, any>;
 
 export type ElementSelectInteraction = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documents are updated

##### Description of change
1. 参考 https://github.com/antvis/G2/pull/6724 ，增加 region 参数使 elementHighligh 支持在空白处触发，达到类似 v4 版本 active-region 的效果，解决 https://github.com/antvis/G2/issues/6582
2. 定义多交互共存时优先级，让多交互之间效果可共存，冲突时根据优先级排序，解决 https://github.com/antvis/G2/issues/6803
![Apr-21-2025 23-14-35](https://github.com/user-attachments/assets/11a09a4f-a6ef-42d2-a5b6-722d837f4ef0)

# 文档
![image](https://github.com/user-attachments/assets/be1c22b8-4875-4255-be56-d0505b916696)



<!-- Provide a description of the change below this comment. -->
