### PR TITLE
feat(interaction): add support for merging styles in interaction

### DIFF
--- a/__tests__/integration/snapshots/interaction/multiple-interactions-coexist/step0.svg
+++ b/__tests__/integration/snapshots/interaction/multiple-interactions-coexist/step0.svg
@@ -1,0 +1,136 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="640"
+  height="480"
+  style="background: transparent;"
+  color-interpolation-filters="sRGB"
+>
+  <defs />
+  <g id="g-svg-camera">
+    <g id="g-root" fill="none">
+      <g id="g-svg-1" fill="none" class="view">
+        <g>
+          <path
+            id="g-svg-2"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 640,0 l 0,480 l-640 0 z"
+            x="0"
+            y="0"
+            width="640"
+            height="480"
+          />
+        </g>
+        <g>
+          <path
+            id="g-svg-3"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 16,16 l 608,0 l 0,448 l-608 0 z"
+            x="16"
+            y="16"
+            width="608"
+            height="448"
+          />
+        </g>
+        <g>
+          <path
+            id="g-svg-4"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 16,16 l 608,0 l 0,448 l-608 0 z"
+            x="16"
+            y="16"
+            width="608"
+            height="448"
+          />
+        </g>
+        <g>
+          <path
+            id="g-svg-5"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 16,16 l 608,0 l 0,448 l-608 0 z"
+            x="16"
+            y="16"
+            width="608"
+            height="448"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,16,16)">
+          <path
+            id="g-svg-6"
+            fill="rgba(0,0,0,0)"
+            class="plot"
+            d="M 0,0 l 608,0 l 0,448 l-608 0 z"
+            width="608"
+            height="448"
+          />
+          <g id="g-svg-7" fill="none" class="main-layer">
+            <g>
+              <path
+                id="g-svg-9"
+                fill="rgba(23,131,255,1)"
+                d="M 41.36054421768712,154.00000000000006 l 111.6734693877551,0 l 0,293.99999999999994 l-111.6734693877551 0 z"
+                x="41.36054421768712"
+                y="154.00000000000006"
+                width="111.6734693877551"
+                height="293.99999999999994"
+                fill-opacity="0.95"
+                stroke-width="1"
+                stroke="rgba(0,0,0,1)"
+                class="element"
+              />
+            </g>
+            <g>
+              <path
+                id="g-svg-10"
+                fill="rgba(23,131,255,1)"
+                d="M 330.8843537414966,0 l 111.67346938775512,0 l 0,448 l-111.67346938775512 0 z"
+                x="330.8843537414966"
+                y="0"
+                width="111.67346938775512"
+                height="448"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+            <g>
+              <path
+                id="g-svg-11"
+                fill="rgba(23,131,255,1)"
+                d="M 165.44217687074834,255.1111111111111 l 111.67346938775509,0 l 0,192.8888888888889 l-111.67346938775509 0 z"
+                x="165.44217687074834"
+                y="255.1111111111111"
+                width="111.67346938775509"
+                height="192.8888888888889"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+            <g>
+              <path
+                id="g-svg-12"
+                fill="rgba(23,131,255,1)"
+                d="M 454.96598639455783,87.11111111111114 l 111.67346938775506,0 l 0,360.88888888888886 l-111.67346938775506 0 z"
+                x="454.96598639455783"
+                y="87.11111111111114"
+                width="111.67346938775506"
+                height="360.88888888888886"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+          </g>
+          <g id="g-svg-8" fill="none" class="label-layer" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/__tests__/integration/snapshots/interaction/multiple-interactions-coexist/step1.svg
+++ b/__tests__/integration/snapshots/interaction/multiple-interactions-coexist/step1.svg
@@ -1,0 +1,136 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="640"
+  height="480"
+  style="background: transparent;"
+  color-interpolation-filters="sRGB"
+>
+  <defs />
+  <g id="g-svg-camera">
+    <g id="g-root" fill="none">
+      <g id="g-svg-1" fill="none" class="view">
+        <g>
+          <path
+            id="g-svg-2"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 0,0 l 640,0 l 0,480 l-640 0 z"
+            x="0"
+            y="0"
+            width="640"
+            height="480"
+          />
+        </g>
+        <g>
+          <path
+            id="g-svg-3"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 16,16 l 608,0 l 0,448 l-608 0 z"
+            x="16"
+            y="16"
+            width="608"
+            height="448"
+          />
+        </g>
+        <g>
+          <path
+            id="g-svg-4"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 16,16 l 608,0 l 0,448 l-608 0 z"
+            x="16"
+            y="16"
+            width="608"
+            height="448"
+          />
+        </g>
+        <g>
+          <path
+            id="g-svg-5"
+            fill="rgba(0,0,0,0)"
+            class="area"
+            d="M 16,16 l 608,0 l 0,448 l-608 0 z"
+            x="16"
+            y="16"
+            width="608"
+            height="448"
+          />
+        </g>
+        <g transform="matrix(1,0,0,1,16,16)">
+          <path
+            id="g-svg-6"
+            fill="rgba(0,0,0,0)"
+            class="plot"
+            d="M 0,0 l 608,0 l 0,448 l-608 0 z"
+            width="608"
+            height="448"
+          />
+          <g id="g-svg-7" fill="none" class="main-layer">
+            <g>
+              <path
+                id="g-svg-9"
+                fill="rgba(23,131,255,1)"
+                d="M 41.36054421768712,154.00000000000006 l 111.6734693877551,0 l 0,293.99999999999994 l-111.6734693877551 0 z"
+                x="41.36054421768712"
+                y="154.00000000000006"
+                width="111.6734693877551"
+                height="293.99999999999994"
+                fill-opacity="0.95"
+                stroke-width="1"
+                stroke="rgba(0,0,0,1)"
+                class="element"
+              />
+            </g>
+            <g>
+              <path
+                id="g-svg-10"
+                fill="rgba(255,0,0,1)"
+                d="M 330.8843537414966,0 l 111.67346938775512,0 l 0,448 l-111.67346938775512 0 z"
+                x="330.8843537414966"
+                y="0"
+                width="111.67346938775512"
+                height="448"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+            <g>
+              <path
+                id="g-svg-11"
+                fill="rgba(23,131,255,1)"
+                d="M 165.44217687074834,255.1111111111111 l 111.67346938775509,0 l 0,192.8888888888889 l-111.67346938775509 0 z"
+                x="165.44217687074834"
+                y="255.1111111111111"
+                width="111.67346938775509"
+                height="192.8888888888889"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+            <g>
+              <path
+                id="g-svg-12"
+                fill="rgba(23,131,255,1)"
+                d="M 454.96598639455783,87.11111111111114 l 111.67346938775506,0 l 0,360.88888888888886 l-111.67346938775506 0 z"
+                x="454.96598639455783"
+                y="87.11111111111114"
+                width="111.67346938775506"
+                height="360.88888888888886"
+                fill-opacity="0.95"
+                stroke-width="0"
+                stroke="rgba(23,131,255,1)"
+                class="element"
+              />
+            </g>
+          </g>
+          <g id="g-svg-8" fill="none" class="label-layer" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/__tests__/plots/interaction/index.ts
+++ b/__tests__/plots/interaction/index.ts
@@ -85,3 +85,4 @@ export { mockPieLegendFilter } from './mock-pie-legend-filter';
 export { commitIntervalFixedCornerFilterNoElement } from './commit-interval-fixed-corner-filter-no-element';
 export { changeSizePolarCrosshairsXYNoElements } from './change-size-polar-crosshairsXY-no-elements';
 export { intervalLegendFilterWithText } from './interval-legend-filter-with-text';
+export { multipleInteractionsCoexist } from './multiple-interactions-coexist';

--- a/__tests__/plots/interaction/multiple-interactions-coexist.ts
+++ b/__tests__/plots/interaction/multiple-interactions-coexist.ts
@@ -1,0 +1,53 @@
+import { ELEMENT_CLASS_NAME, G2Spec } from '../../../src';
+import { disableDelay, step } from './utils';
+
+const state = {
+  selected: {
+    fill: 'red',
+  },
+  active: {
+    stroke: '#000000',
+    lineWidth: 2,
+  },
+};
+
+export function multipleInteractionsCoexist(): G2Spec {
+  return {
+    type: 'view',
+    autoFit: true,
+    state,
+    interaction: {
+      elementSelect: {},
+      elementHighlight: {},
+    },
+    data: [
+      { name: 'London', 月份: 'Jan.', 月均降雨量: 18.9 },
+      { name: 'London', 月份: 'Feb.', 月均降雨量: 28.8 },
+      { name: 'Berlin', 月份: 'Jan.', 月均降雨量: 12.4 },
+      { name: 'Berlin', 月份: 'Feb.', 月均降雨量: 23.2 },
+    ],
+    children: [
+      {
+        encode: { x: '月份', y: '月均降雨量', series: 'name' },
+        type: 'interval',
+        axis: { y: { title: 'Waiting', titleFill: '#5B8FF9' } },
+        state: {
+          selected: {
+            fill: 'red',
+          },
+        },
+      },
+    ],
+  };
+}
+
+multipleInteractionsCoexist.preprocess = disableDelay;
+
+multipleInteractionsCoexist.steps = ({ canvas }) => {
+  const { document } = canvas;
+  const elements = document.getElementsByClassName(ELEMENT_CLASS_NAME);
+
+  const e1 = elements[0];
+  const e2 = elements[1];
+  return [step(e1, 'pointerover'), step(e2, 'click')];
+};

--- a/src/interaction/elementHighlight.ts
+++ b/src/interaction/elementHighlight.ts
@@ -5,6 +5,7 @@ import { subObject } from '../utils/helper';
 import {
   createDatumof,
   createFindElementByEvent,
+  createUseState,
   createValueof,
   createXKey,
   mergeState,
@@ -14,7 +15,6 @@ import {
   selectElementByData,
   selectG2Elements,
   selectPlotArea,
-  useState,
   VALID_FIND_BY_X_MARKS,
 } from './utils';
 
@@ -81,11 +81,11 @@ export function elementHighlight(
     },
   });
 
+  const useState = createUseState(elementStyle, elements);
+
   const { updateState, removeState, hasState } = useState(
     elementStyle,
     valueof,
-    undefined,
-    false,
   );
 
   let out; // Timer for delaying unhighlighted.

--- a/src/interaction/elementHighlight.ts
+++ b/src/interaction/elementHighlight.ts
@@ -83,10 +83,7 @@ export function elementHighlight(
 
   const useState = createUseState(elementStyle, elements);
 
-  const { updateState, removeState, hasState } = useState(
-    elementStyle,
-    valueof,
-  );
+  const { updateState, removeState, hasState } = useState(valueof);
 
   let out; // Timer for delaying unhighlighted.
   const pointerover = (event) => {

--- a/src/interaction/elementHighlight.ts
+++ b/src/interaction/elementHighlight.ts
@@ -84,6 +84,8 @@ export function elementHighlight(
   const { updateState, removeState, hasState } = useState(
     elementStyle,
     valueof,
+    undefined,
+    false,
   );
 
   let out; // Timer for delaying unhighlighted.

--- a/src/interaction/elementSelect.ts
+++ b/src/interaction/elementSelect.ts
@@ -6,7 +6,6 @@ import {
   createValueof,
   createDatumof,
   selectG2Elements,
-  useState,
   renderLink,
   renderBackground,
   selectPlotArea,
@@ -16,6 +15,7 @@ import {
   createXKey,
   createFindElementByEvent,
   VALID_FIND_BY_X_MARKS,
+  createUseState,
 } from './utils';
 
 /**
@@ -83,11 +83,11 @@ export function elementSelect(
     },
   });
 
+  const useState = createUseState(elementStyle, elements);
+
   const { updateState, removeState, hasState } = useState(
     elementStyle,
     valueof,
-    undefined,
-    false,
   );
   let isMultiSelectMode = !single; // "single" determines whether to multi-select by default
   let activeHotkey = null; // Track the currently active hotkey

--- a/src/interaction/elementSelect.ts
+++ b/src/interaction/elementSelect.ts
@@ -85,10 +85,7 @@ export function elementSelect(
 
   const useState = createUseState(elementStyle, elements);
 
-  const { updateState, removeState, hasState } = useState(
-    elementStyle,
-    valueof,
-  );
+  const { updateState, removeState, hasState } = useState(valueof);
   let isMultiSelectMode = !single; // "single" determines whether to multi-select by default
   let activeHotkey = null; // Track the currently active hotkey
 

--- a/src/interaction/elementSelect.ts
+++ b/src/interaction/elementSelect.ts
@@ -86,6 +86,8 @@ export function elementSelect(
   const { updateState, removeState, hasState } = useState(
     elementStyle,
     valueof,
+    undefined,
+    false,
   );
   let isMultiSelectMode = !single; // "single" determines whether to multi-select by default
   let activeHotkey = null; // Track the currently active hotkey

--- a/src/interaction/utils.ts
+++ b/src/interaction/utils.ts
@@ -146,16 +146,16 @@ export function useState(
   valueof = (d, element) => d,
   setAttribute = (element, key, v) => element.setAttribute(key, v),
   /**
-   *  if is not reset, the style will be merged, the default is true.
-   *  now only elementSelect & elementHightLight is not reset, only they will merge styles.
+   *  if useIsolatedStyles is false, the style will be merged with global styles.
+   *  now only elementSelect & elementHightLight use non-isolated styles (false), only they will merge styles.
    *  related test: multipleInteractionsCoexist.
    */
-  isReset = true,
+  useIsolatedStyles = true,
 ) {
   const STATES = '__states__';
   const ORIGINAL = '__ordinal__';
 
-  if (!isReset)
+  if (!useIsolatedStyles)
     Object.entries(style).forEach(([key, value]) => {
       STATE_STYLES[key] = value;
     });
@@ -185,7 +185,8 @@ export function useState(
 
     // Iterate through all states to find the highest priority state for each style attribute.
     for (const state of sortedStates) {
-      const stateStyles = (isReset ? style : STATE_STYLES)[state] || {};
+      const stateStyles =
+        (useIsolatedStyles ? style : STATE_STYLES)[state] || {};
       for (const [key, value] of Object.entries(stateStyles)) {
         if (!styleAttributeMap.has(key)) {
           styleAttributeMap.set(key, value);

--- a/src/interaction/utils.ts
+++ b/src/interaction/utils.ts
@@ -143,6 +143,7 @@ export function createUseState(
   style: Record<string, any>,
   elements: Element[],
 ) {
+  // Apply interaction style to all elements.
   elements.forEach((element) => {
     // @ts-ignore
     const currentStyle = element.__interactionStyle__;
@@ -156,11 +157,14 @@ export function createUseState(
     }
   });
 
-  return useState;
+  return (
+    valueof = (d, element) => d,
+    setAttribute = (element, key, v) => element.setAttribute(key, v),
+  ) => useState(undefined, valueof, setAttribute);
 }
 
 export function useState(
-  style: Record<string, any>,
+  style: Record<string, any> | undefined,
   valueof = (d, element) => d,
   setAttribute = (element, key, v) => element.setAttribute(key, v),
 ) {
@@ -192,7 +196,9 @@ export function useState(
 
     // Iterate through all states to find the highest priority state for each style attribute.
     for (const state of sortedStates) {
-      const stateStyles = (element.__interactionStyle__ ?? style)[state] || {};
+      // If style exists, use it directly, else use interaction style on element.
+      const stateStyles =
+        (style ?? element.__interactionStyle__)?.[state] || {};
       for (const [key, value] of Object.entries(stateStyles)) {
         if (!styleAttributeMap.has(key)) {
           styleAttributeMap.set(key, value);

--- a/src/interaction/utils.ts
+++ b/src/interaction/utils.ts
@@ -147,7 +147,8 @@ export function useState(
   setAttribute = (element, key, v) => element.setAttribute(key, v),
   /**
    *  if is not reset, the style will be merged, the default is true.
-   *  now only elementSelect & elementHightLight is not reset, only they will merged styles.
+   *  now only elementSelect & elementHightLight is not reset, only they will merge styles.
+   *  related test: multipleInteractionsCoexist.
    */
   isReset = true,
 ) {

--- a/src/interaction/utils.ts
+++ b/src/interaction/utils.ts
@@ -139,13 +139,25 @@ const STATE_GROUPS = {
   highlight: ['active', 'inactive'],
 };
 
+const STATE_STYLES: Record<string, Record<string, any>> = {};
+
 export function useState(
   style: Record<string, any>,
   valueof = (d, element) => d,
   setAttribute = (element, key, v) => element.setAttribute(key, v),
+  /**
+   *  if is not reset, the style will be merged, the default is true.
+   *  now only elementSelect & elementHightLight is not reset, only they will merged styles.
+   */
+  isReset = true,
 ) {
   const STATES = '__states__';
   const ORIGINAL = '__ordinal__';
+
+  if (!isReset)
+    Object.entries(style).forEach(([key, value]) => {
+      STATE_STYLES[key] = value;
+    });
 
   // Get state priority.
   const getStatePriority = (stateName) =>
@@ -172,7 +184,7 @@ export function useState(
 
     // Iterate through all states to find the highest priority state for each style attribute.
     for (const state of sortedStates) {
-      const stateStyles = style[state] || {};
+      const stateStyles = (isReset ? style : STATE_STYLES)[state] || {};
       for (const [key, value] of Object.entries(stateStyles)) {
         if (!styleAttributeMap.has(key)) {
           styleAttributeMap.set(key, value);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines
<img width="652" alt="image" src="https://github.com/user-attachments/assets/474d281b-865b-4956-b670-8ed95ed73719" />


##### Description of change

<!-- Provide a description of the change below this comment. -->
- related: https://github.com/antvis/G2/issues/6803
- 引入了新的 `isReset` 参数到 `useState` 实用程序中，只有当 `isReset` 为 `false` ，才会融合 style，用于控制样式的合并或重置行为。  
- 目前只有`elementSelect` 和 `elementHighlight` 的样式将合并而非被重置，确保最小改动。  
- 添加了新的测试用例 `multipleInteractionsCoexist`，用于验证多个交互状态可以共存的情况。
