### PR TITLE
fix: sourcemap issue #6807

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ site/server
 # Package
 package-lock.json
 pnpm-lock.yaml
+
+bun.lock

--- a/package.json
+++ b/package.json
@@ -23,8 +23,14 @@
     },
     "./package.json": "./package.json"
   },
-  "sideEffects": ["./esm/exports.js"],
-  "files": ["lib", "esm", "dist"],
+  "sideEffects": [
+    "./esm/exports.js"
+  ],
+  "files": [
+    "lib",
+    "esm",
+    "dist"
+  ],
   "scripts": {
     "start": "cd site && npm run start",
     "dev": "cross-env TZ=Asia/Shanghai vite",
@@ -49,7 +55,16 @@
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "translate": "translate -d"
   },
-  "keywords": ["antv", "g2", "visualization", "chart", "grammar", "graphics", "interaction", "animation"],
+  "keywords": [
+    "antv",
+    "g2",
+    "visualization",
+    "chart",
+    "grammar",
+    "graphics",
+    "interaction",
+    "animation"
+  ],
   "dependencies": {
     "@antv/component": "^2.1.2",
     "@antv/coord": "^0.4.7",
@@ -115,7 +130,11 @@
     "xmlserializer": "^0.6.1"
   },
   "lint-staged": {
-    "*.{ts,tsx}": ["eslint --fix", "prettier --write", "git add"]
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write",
+      "git add"
+    ]
   },
   "limit-size": [
     {

--- a/package.json
+++ b/package.json
@@ -23,15 +23,8 @@
     },
     "./package.json": "./package.json"
   },
-  "sideEffects": [
-    "./esm/exports.js"
-  ],
-  "files": [
-    "src",
-    "lib",
-    "esm",
-    "dist"
-  ],
+  "sideEffects": ["./esm/exports.js"],
+  "files": ["lib", "esm", "dist"],
   "scripts": {
     "start": "cd site && npm run start",
     "dev": "cross-env TZ=Asia/Shanghai vite",
@@ -56,16 +49,7 @@
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "translate": "translate -d"
   },
-  "keywords": [
-    "antv",
-    "g2",
-    "visualization",
-    "chart",
-    "grammar",
-    "graphics",
-    "interaction",
-    "animation"
-  ],
+  "keywords": ["antv", "g2", "visualization", "chart", "grammar", "graphics", "interaction", "animation"],
   "dependencies": {
     "@antv/component": "^2.1.2",
     "@antv/coord": "^0.4.7",
@@ -131,11 +115,7 @@
     "xmlserializer": "^0.6.1"
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
-      "eslint --fix",
-      "prettier --write",
-      "git add"
-    ]
+    "*.{ts,tsx}": ["eslint --fix", "prettier --write", "git add"]
   },
   "limit-size": [
     {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "./esm/exports.js"
   ],
   "files": [
+    "src",
     "lib",
     "esm",
     "dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "pretty": true,
     "lib": ["dom", "esnext"],
     "skipLibCheck": true,
-    "sourceRoot": "src",
     "baseUrl": "src",
     "resolveJsonModule": true
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes. jest 总是把我电脑搞崩，16GB 内存都不够跑的
- [ ] benchmarks are included
- [x] commit message follows commit guidelines
- [ ] documents are updated 无需更新

##### Description of change
主要是删除 tsconfig 中的 sourceRoot，这样生成的 map 文件的 sources 数组会是["../src/xxx.ts"]，从而能被 vite 正确加载
<!-- Provide a description of the change below this comment. -->
