### PR TITLE
fix: wordCloud default tooltip config

### DIFF
--- a/__tests__/plots/static/words-wordCloud-basic.ts
+++ b/__tests__/plots/static/words-wordCloud-basic.ts
@@ -39,6 +39,14 @@ export function wordsWordCloudBasic(): G2Spec {
     },
     axis: false,
     legend: false,
+    tooltip: {
+      items: [
+        (datum) => ({
+          name: datum.text,
+          value: datum.value,
+        }),
+      ],
+    },
   };
 }
 

--- a/src/mark/wordCloud.ts
+++ b/src/mark/wordCloud.ts
@@ -1,4 +1,5 @@
 import { deepMix } from '@antv/util';
+import { itemsOf } from 'interaction/legendFilter';
 import { CompositeMarkComponent as CC } from '../runtime';
 import { WordCloudMark } from '../spec';
 
@@ -30,6 +31,14 @@ const GET_DEFAULT_OPTIONS = () => ({
   },
   style: {
     fontFamily: (d) => d.fontFamily,
+  },
+  tooltip: {
+    items: [
+      (datum) => ({
+        name: datum.text,
+        value: datum.value,
+      }),
+    ],
   },
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->
词云图默认的 tooltip 不合适。

![image](https://github.com/user-attachments/assets/4f49dcc3-b244-4f30-88d5-4804f51c3d6e)

改成如下：

![image](https://github.com/user-attachments/assets/7fba67fe-47af-4d54-91c7-9caa7ed11444)


##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] benchmarks are included
- [ ] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change

<!-- Provide a description of the change below this comment. -->
