### PR TITLE
fix(build): resolve tslib not found error in UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "rollup-plugin-visualizer": "^5.12.0",
     "topojson": "^3.0.2",
     "ts-jest": "^26.5.6",
+    "tslib": "^2.8.1",
     "typescript": "^4.9.5",
     "vite": "^3.2.11",
     "xmlserializer": "^0.6.1"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] benchmarks are included
- [x] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change

<!-- Provide a description of the change below this comment. -->
整个过程是在 Github CodeSpace 进行的，使用的是 [linux-universal](https://github.com/microsoft/vscode-dev-containers/blob/main/containers/codespaces-linux/README.md) 环境。

以下步骤会出错：
``` bash
pnpm install
pnpm build 
```

报错如下
```bash
 ➜ /workspaces/antp/G2 (v5) $ pnpm build 

> @antv/g2@5.3.2 build /workspaces/antp/G2
> run-p build:*


> @antv/g2@5.3.2 build:esm /workspaces/antp/G2
> rimraf ./esm && tsc --module ESNext --outDir esm


> @antv/g2@5.3.2 build:cjs /workspaces/antp/G2
> rimraf ./lib && tsc --module commonjs --outDir lib


> @antv/g2@5.3.2 build:umd /workspaces/antp/G2
> rimraf ./dist && node node_modules/rollup/dist/bin/rollup -c && npm run size


bundle/g2.std.ts → dist/g2.min.js...
[!] (plugin rpt2) Error: src/utils/helper.ts:112:23 - error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.

112     (composed, fn) => async (x) => {
                          ~~~~~~~~~~~~~~

bundle/g2.std.ts

    at error (/workspaces/antp/G2/node_modules/.pnpm/rollup@2.79.2/node_modules/rollup/dist/shared/rollup.js:198:30)
    at throwPluginError (/workspaces/antp/G2/node_modules/.pnpm/rollup@2.79.2/node_modules/rollup/dist/shared/rollup.js:21718:12)
    at Object.error (/workspaces/antp/G2/node_modules/.pnpm/rollup@2.79.2/node_modules/rollup/dist/shared/rollup.js:22672:20)
    at RollupContext.error (/workspaces/antp/G2/node_modules/.pnpm/rollup-plugin-typescript2@0.35.0_rollup@2.79.2_typescript@4.9.5/node_modules/rollup-plugin-typescript2/src/context.ts:35:17)
    at /workspaces/antp/G2/node_modules/.pnpm/rollup-plugin-typescript2@0.35.0_rollup@2.79.2_typescript@4.9.5/node_modules/rollup-plugin-typescript2/src/diagnostics.ts:70:17
    at Array.forEach (<anonymous>)
    at printDiagnostics (/workspaces/antp/G2/node_modules/.pnpm/rollup-plugin-typescript2@0.35.0_rollup@2.79.2_typescript@4.9.5/node_modules/rollup-plugin-typescript2/src/diagnostics.ts:42:14)
    at typecheckFile (/workspaces/antp/G2/node_modules/.pnpm/rollup-plugin-typescript2@0.35.0_rollup@2.79.2_typescript@4.9.5/node_modules/rollup-plugin-typescript2/src/index.ts:67:3)
    at Object.<anonymous> (/workspaces/antp/G2/node_modules/.pnpm/rollup-plugin-typescript2@0.35.0_rollup@2.79.2_typescript@4.9.5/node_modules/rollup-plugin-typescript2/src/index.ts:260:5)
    at Generator.next (<anonymous>)

 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed.
 ELIFECYCLE  Command failed.
ERROR: "build:umd" exited with 1.
 ELIFECYCLE  Command failed with exit code 1.
```


装完这个 `tslib` 依赖就好了