### PR TITLE
feat: exceedAdjust新增bounds参数，支持自定义边界区域，默认为view

### DIFF
--- a/__tests__/integration/snapshots/static/labelExceedAdjustBoundsMain.svg
+++ b/__tests__/integration/snapshots/static/labelExceedAdjustBoundsMain.svg
@@ -1,0 +1,171 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="654" height="310" color-interpolation-filters="sRGB" style="background: transparent;">
+  <defs>
+    <linearGradient id="c" x1="24" x2="24" y1="230" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1677FF5B"/>
+      <stop offset="1" stop-color="#1677FF"/>
+    </linearGradient>
+    <linearGradient id="d" x1="536.54" x2="536.54" y1="230" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1677FF5B"/>
+      <stop offset="1" stop-color="#1677FF"/>
+    </linearGradient>
+    <linearGradient id="a" x1="280.27" x2="280.27" y1="690" y2="7.667" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="rgba(255,255,255,0)"/>
+      <stop offset=".5" stop-color="rgba(255,255,255,0)"/>
+      <stop offset="1" stop-color="rgba(105,168,255,0.61)"/>
+    </linearGradient>
+    <linearGradient id="b" x1="24" x2="536.54" y1="118.8335" y2="118.8335" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#91BDFF"/>
+      <stop offset=".2415" stop-color="#1777FF"/>
+      <stop offset=".7517" stop-color="#1777FF"/>
+      <stop offset="1" stop-color="#1677FF32"/>
+    </linearGradient>
+    <filter id="e" data-type="outer" filterUnits="userSpaceOnUse">
+      <feDropShadow dx="0" dy="0" flood-color="rgba(42,102,187,0.17)" stdDeviation="5.5"/>
+    </filter>
+    <filter id="f" data-type="outer" filterUnits="userSpaceOnUse">
+      <feDropShadow dx="0" dy="0" flood-color="rgba(42,102,187,0.17)" stdDeviation="5.5"/>
+    </filter>
+  </defs>
+  <g>
+    <g fill="none">
+      <g fill="none" class="view">
+        <g>
+          <path width="654" height="310" x="0" y="0" fill="rgba(0,0,0,0)" stroke="rgba(255,0,0,1)" d="m0 0 654 0 0 310-654 0z" class="area"/>
+        </g>
+        <g>
+          <path width="624" height="270" x="10" y="20" fill="rgba(0,0,0,0)" stroke="rgba(255,255,0,1)" d="m10 20 624 0 0 270-624 0z" class="area"/>
+        </g>
+        <g>
+          <path width="560.54" height="254" x="73.46" y="20" fill="rgba(0,0,0,0)" stroke="rgba(0,128,0,1)" d="m73.46 20 560.54 0 0 254-560.54 0z" class="area"/>
+        </g>
+        <g>
+          <path width="512.54" height="230" x="97.46" y="20" fill="rgba(0,0,0,0)" stroke="rgba(0,0,255,1)" d="m97.46 20 512.54 0 0 230-512.54 0z" class="area"/>
+        </g>
+        <g fill="none" class="component">
+          <g fill="none" class="axis">
+            <g fill="none" class="axis-grid-group"/>
+            <g fill="none" class="axis-main-group">
+              <g fill="none" class="axis-line-group">
+                <g>
+                  <line x1="73.46" x2="634" y1="274" y2="274" fill="none" stroke="rgba(222,227,235,1)" stroke-opacity=".45" stroke-width="1.5" class="axis-line axis-line"/>
+                </g>
+              </g>
+              <g fill="none" class="axis-tick-group"/>
+              <g fill="none" class="axis-label-group">
+                <g fill="none" class="axis-label" transform="matrix(1 0 0 1 97.46 278)">
+                  <g>
+                    <text fill="rgba(84,92,103,1)" stroke-width="1" class="axis-label-item" dominant-baseline="central" dx=".5" dy="20.5" font-family="sans-serif" font-size="22" font-style="normal" font-variant="normal" font-weight="500" opacity=".45" paint-order="stroke" style="transform:translate(0px, 8px);" text-anchor="middle">7月1日</text>
+                  </g>
+                </g>
+                <g fill="none" class="axis-label" transform="matrix(1 0 0 1 610 278)">
+                  <g>
+                    <text fill="rgba(84,92,103,1)" stroke-width="1" class="axis-label-item" dominant-baseline="central" dx=".5" dy="20.5" font-family="sans-serif" font-size="22" font-style="normal" font-variant="normal" font-weight="500" opacity=".45" paint-order="stroke" style="transform:translate(0px, 8px);" text-anchor="middle">8月31日</text>
+                  </g>
+                </g>
+              </g>
+            </g>
+            <g fill="none" class="axis-title-group"/>
+          </g>
+        </g>
+        <g fill="none" class="component">
+          <g fill="none" class="axis">
+            <g fill="none" class="axis-grid-group"/>
+            <g fill="none" class="axis-main-group">
+              <g fill="none" class="axis-line-group">
+                <g>
+                  <line x1="73.46" x2="73.46" y1="274" y2="20" fill="none" stroke="rgba(222,227,235,1)" stroke-opacity=".45" stroke-width="1.5" class="axis-line axis-line"/>
+                </g>
+              </g>
+              <g fill="none" class="axis-tick-group"/>
+              <g fill="none" class="axis-label-group">
+                <g fill="none" class="axis-label" transform="matrix(1 0 0 1 69.46 250)">
+                  <g>
+                    <text fill="rgba(84,92,103,1)" stroke-width="1" class="axis-label-item" dominant-baseline="central" dx=".5" dy="0" font-family="sans-serif" font-size="22" font-style="normal" font-variant="normal" font-weight="500" opacity=".45" paint-order="stroke" style="transform:translate(-8px, 0px);" text-anchor="end" visibility="visible">600</text>
+                  </g>
+                </g>
+                <g fill="none" class="axis-label" transform="matrix(1 0 0 1 69.46 211.6667)">
+                  <g>
+                    <text fill="rgba(84,92,103,1)" stroke-width="1" class="axis-label-item" dominant-baseline="central" dx=".5" dy="0" font-family="sans-serif" font-size="22" font-style="normal" font-variant="normal" font-weight="500" opacity=".45" paint-order="stroke" style="transform:translate(-8px, 0px);" text-anchor="end" visibility="hidden">650</text>
+                  </g>
+                </g>
+                <g fill="none" class="axis-label" transform="matrix(1 0 0 1 69.46 173.3333)">
+                  <g>
+                    <text fill="rgba(84,92,103,1)" stroke-width="1" class="axis-label-item" dominant-baseline="central" dx=".5" dy="0" font-family="sans-serif" font-size="22" font-style="normal" font-variant="normal" font-weight="500" opacity=".45" paint-order="stroke" style="transform:translate(-8px, 0px);" text-anchor="end" visibility="visible">700</text>
+                  </g>
+                </g>
+                <g fill="none" class="axis-label" transform="matrix(1 0 0 1 69.46 135)">
+                  <g>
+                    <text fill="rgba(84,92,103,1)" stroke-width="1" class="axis-label-item" dominant-baseline="central" dx=".5" dy="0" font-family="sans-serif" font-size="22" font-style="normal" font-variant="normal" font-weight="500" opacity=".45" paint-order="stroke" style="transform:translate(-8px, 0px);" text-anchor="end" visibility="hidden">750</text>
+                  </g>
+                </g>
+                <g fill="none" class="axis-label" transform="matrix(1 0 0 1 69.46 96.6667)">
+                  <g>
+                    <text fill="rgba(84,92,103,1)" stroke-width="1" class="axis-label-item" dominant-baseline="central" dx=".5" dy="0" font-family="sans-serif" font-size="22" font-style="normal" font-variant="normal" font-weight="500" opacity=".45" paint-order="stroke" style="transform:translate(-8px, 0px);" text-anchor="end" visibility="visible">800</text>
+                  </g>
+                </g>
+                <g fill="none" class="axis-label" transform="matrix(1 0 0 1 69.46 58.3333)">
+                  <g>
+                    <text fill="rgba(84,92,103,1)" stroke-width="1" class="axis-label-item" dominant-baseline="central" dx=".5" dy="0" font-family="sans-serif" font-size="22" font-style="normal" font-variant="normal" font-weight="500" opacity=".45" paint-order="stroke" style="transform:translate(-8px, 0px);" text-anchor="end" visibility="hidden">850</text>
+                  </g>
+                </g>
+                <g fill="none" class="axis-label" transform="matrix(1 0 0 1 69.46 20)">
+                  <g>
+                    <text fill="rgba(84,92,103,1)" stroke-width="1" class="axis-label-item" dominant-baseline="central" dx=".5" dy="0" font-family="sans-serif" font-size="22" font-style="normal" font-variant="normal" font-weight="500" opacity=".45" paint-order="stroke" style="transform:translate(-8px, 0px);" text-anchor="end" visibility="visible">900</text>
+                  </g>
+                </g>
+              </g>
+            </g>
+            <g fill="none" class="axis-title-group"/>
+          </g>
+        </g>
+        <g transform="matrix(1 0 0 1 73.46 20)">
+          <path width="560.54" height="254" fill="rgba(0,0,0,0)" d="m0 0 560.54 0 0 254-560.54 0z" class="plot"/>
+          <g fill="none" class="main-layer">
+            <g>
+              <path fill="url(#a)" fill-opacity=".85" stroke="rgba(23,131,255,1)" stroke-width="0" d="M24 230c2.801-11.628 5.602-23.256 8.402-46 2.801-22.744 5.602-89.444 8.403-90.467 2.8-1.022 5.601-.511 8.402-1.533 2.801-1.022 5.601-20.444 8.402-23 2.801-2.556 5.602-3.833 8.402-3.833 2.801 0 5.602 28.366 8.403 28.366 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601-85.866 8.402-85.866 2.801 0 5.601 58.266 8.402 58.266 2.801 0 5.602-58.266 8.403-58.266 2.8 0 5.601 40.889 8.402 53.666 2.801 12.778 5.601 23 8.402 23 2.801 0 5.602-15.333 8.402-15.333 2.801 0 5.602 15.333 8.403 15.333 2.8 0 5.601-53.666 8.402-53.666 2.801 0 5.602 61.333 8.402 61.333 2.801 0 5.602-61.333 8.403-61.333 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 92 8.403 92 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0l0 567.333c-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0-2.801 0-5.601 0-8.402 0-2.801 0-5.602 0-8.402 0-2.801 0-5.602 0-8.403 0-2.8 0-5.601 0-8.402 0Z" class="element"/>
+            </g>
+          </g>
+          <g fill="none" class="main-layer">
+            <g>
+              <path fill="none" stroke="url(#b)" stroke-linecap="round" stroke-width="6" d="M24 230c2.801-11.628 5.602-23.256 8.402-46 2.801-22.744 5.602-89.444 8.403-90.467 2.8-1.022 5.601-.511 8.402-1.533 2.801-1.022 5.601-20.444 8.402-23 2.801-2.556 5.602-3.833 8.402-3.833 2.801 0 5.602 28.366 8.403 28.366 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601-85.866 8.402-85.866 2.801 0 5.601 58.266 8.402 58.266 2.801 0 5.602-58.266 8.403-58.266 2.8 0 5.601 40.889 8.402 53.666 2.801 12.778 5.601 23 8.402 23 2.801 0 5.602-15.333 8.402-15.333 2.801 0 5.602 15.333 8.403 15.333 2.8 0 5.601-53.666 8.402-53.666 2.801 0 5.602 61.333 8.402 61.333 2.801 0 5.602-61.333 8.403-61.333 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 92 8.403 92 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0 2.801 0 5.601 0 8.402 0 2.801 0 5.602 0 8.402 0 2.801 0 5.602 0 8.403 0 2.8 0 5.601 0 8.402 0" class="element"/>
+            </g>
+          </g>
+          <g fill="none" class="main-layer">
+            <g>
+              <path fill="none" stroke="url(#c)" stroke-dasharray="3,3" stroke-opacity=".45" stroke-width="3" d="m24 230 0-230" class="element"/>
+            </g>
+          </g>
+          <g fill="none" class="main-layer">
+            <g>
+              <path fill="none" stroke="url(#d)" stroke-dasharray="3,3" stroke-opacity=".45" stroke-width="3" d="m536.54 230 0-230" class="element"/>
+            </g>
+          </g>
+          <g fill="none" class="label-layer">
+            <g fill="none" class="label" transform="matrix(1 0 0 1 106.42 32)">
+              <g>
+                <path width="169.84" height="61" x="-84.42" y="-10" fill="rgba(255,255,255,1)" d="m-60.42-10 121.84 0a24 24 0 0 1 24 24l0 13a24 24 0 0 1-24 24l-121.84 0a24 24 0 0 1-24-24l0-13a24 24 0 0 1 24-24z" filter="url(#e)" visibility="visible"/>
+              </g>
+              <g>
+                <text fill="rgba(0,0,0,1)" dominant-baseline="central" dx=".5" dy="20.5" font-size="22" font-weight="500" paint-order="stroke" style="transform:translate(0px, 0px);" text-anchor="middle" visibility="visible">最低价 ￥600</text>
+              </g>
+              <g>
+                <path fill="none" d="m0 0 0 0" visibility="visible"/>
+              </g>
+            </g>
+            <g fill="none" class="label" transform="matrix(1 0 0 1 453.67 32)">
+              <g>
+                <path width="168.74" height="61" x="-83.87" y="-10" fill="rgba(255,255,255,1)" d="m-59.87-10 120.74 0a24 24 0 0 1 24 24l0 13a24 24 0 0 1-24 24l-120.74 0a24 24 0 0 1-24-24l0-13a24 24 0 0 1 24-24z" filter="url(#f)" visibility="visible"/>
+              </g>
+              <g>
+                <text fill="rgba(0,0,0,1)" dominant-baseline="central" dx=".5" dy="20.5" font-size="22" font-weight="500" paint-order="stroke" style="transform:translate(0px, 0px);" text-anchor="middle" visibility="visible">最高价 ￥740</text>
+              </g>
+              <g>
+                <path fill="none" d="m0 0 0 0" visibility="visible"/>
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/__tests__/plots/static/index.ts
+++ b/__tests__/plots/static/index.ts
@@ -357,3 +357,4 @@ export { stackPointCoincide } from './stack-point-coincide';
 export { helixBasic } from './helix-basic';
 export { helixGene } from './helix-gene';
 export { expr } from './expr';
+export { labelExceedAdjustBoundsMain } from './label-exceed-adjust-bounds-main';

--- a/__tests__/plots/static/label-exceed-adjust-bounds-main.ts
+++ b/__tests__/plots/static/label-exceed-adjust-bounds-main.ts
@@ -1,0 +1,388 @@
+import { G2Spec } from '../../../src';
+
+export function labelExceedAdjustBoundsMain(): G2Spec {
+  const data = [
+    {
+      date: '2025-07-01',
+      price: 600,
+      showLabel: 1,
+      tooltip: '最低价 ￥600',
+    },
+    {
+      date: '2025-07-02',
+      price: 660,
+    },
+    {
+      date: '2025-07-03',
+      price: 778,
+    },
+    {
+      date: '2025-07-04',
+      price: 780,
+    },
+    {
+      date: '2025-07-05',
+      price: 810,
+    },
+    {
+      date: '2025-07-06',
+      price: 815,
+    },
+    {
+      date: '2025-07-07',
+      price: 778,
+    },
+    {
+      date: '2025-07-08',
+      price: 778,
+    },
+    {
+      date: '2025-07-09',
+      price: 778,
+    },
+    {
+      date: '2025-07-10',
+      price: 778,
+    },
+    {
+      date: '2025-07-11',
+      price: 890,
+    },
+    {
+      date: '2025-07-12',
+      price: 814,
+    },
+    {
+      date: '2025-07-13',
+      price: 890,
+    },
+    {
+      date: '2025-07-14',
+      price: 820,
+    },
+    {
+      date: '2025-07-15',
+      price: 790,
+    },
+    {
+      date: '2025-07-16',
+      price: 810,
+    },
+    {
+      date: '2025-07-17',
+      price: 790,
+    },
+    {
+      date: '2025-07-18',
+      price: 860,
+    },
+    {
+      date: '2025-07-19',
+      price: 780,
+    },
+    {
+      date: '2025-07-20',
+      price: 860,
+    },
+    {
+      date: '2025-07-21',
+      price: 860,
+    },
+    {
+      date: '2025-07-22',
+      price: 860,
+    },
+    {
+      date: '2025-07-23',
+      price: 860,
+    },
+    {
+      date: '2025-07-24',
+      price: 860,
+    },
+    {
+      date: '2025-07-25',
+      price: 860,
+    },
+    {
+      date: '2025-07-26',
+      price: 860,
+    },
+    {
+      date: '2025-07-27',
+      price: 860,
+    },
+    {
+      date: '2025-07-28',
+      price: 860,
+    },
+    {
+      date: '2025-07-29',
+      price: 860,
+    },
+    {
+      date: '2025-07-30',
+      price: 860,
+    },
+    {
+      date: '2025-07-31',
+      price: 860,
+    },
+    {
+      date: '2025-08-01',
+      price: 860,
+    },
+    {
+      date: '2025-08-02',
+      price: 860,
+    },
+    {
+      date: '2025-08-03',
+      price: 860,
+    },
+    {
+      date: '2025-08-04',
+      price: 860,
+    },
+    {
+      date: '2025-08-05',
+      price: 860,
+    },
+    {
+      date: '2025-08-06',
+      price: 860,
+    },
+    {
+      date: '2025-08-07',
+      price: 860,
+    },
+    {
+      date: '2025-08-08',
+      price: 860,
+    },
+    {
+      date: '2025-08-09',
+      price: 860,
+    },
+    {
+      date: '2025-08-10',
+      price: 860,
+    },
+    {
+      date: '2025-08-11',
+      price: 860,
+    },
+    {
+      date: '2025-08-12',
+      price: 860,
+    },
+    {
+      date: '2025-08-13',
+      price: 860,
+    },
+    {
+      date: '2025-08-14',
+      price: 860,
+    },
+    {
+      date: '2025-08-15',
+      price: 860,
+    },
+    {
+      date: '2025-08-16',
+      price: 740,
+    },
+    {
+      date: '2025-08-17',
+      price: 740,
+    },
+    {
+      date: '2025-08-18',
+      price: 740,
+    },
+    {
+      date: '2025-08-19',
+      price: 740,
+    },
+    {
+      date: '2025-08-20',
+      price: 740,
+    },
+    {
+      date: '2025-08-21',
+      price: 740,
+    },
+    {
+      date: '2025-08-22',
+      price: 740,
+    },
+    {
+      date: '2025-08-23',
+      price: 740,
+    },
+    {
+      date: '2025-08-24',
+      price: 740,
+    },
+    {
+      date: '2025-08-25',
+      price: 740,
+    },
+    {
+      date: '2025-08-26',
+      price: 740,
+    },
+    {
+      date: '2025-08-27',
+      price: 740,
+    },
+    {
+      date: '2025-08-28',
+      price: 740,
+    },
+    {
+      date: '2025-08-29',
+      price: 740,
+    },
+    {
+      date: '2025-08-30',
+      price: 740,
+    },
+    {
+      date: '2025-08-31',
+      price: 740,
+      showLabel: 1,
+      tooltip: '最高价 ￥740',
+    },
+  ];
+  const result = (data.filter((item) => item.showLabel) || []).map((item) => {
+    return {
+      type: 'lineX',
+      data: [item],
+      encode: {
+        x: 'date',
+        y: 'price',
+        color: 'linear-gradient(-90deg, #1677FF5B 0%,#1677FF 100%)',
+      },
+      style: {
+        lineWidth: 3,
+        lineDash: [3, 3],
+      },
+      labels: item.tooltip
+        ? [
+            {
+              text: 'tooltip',
+              fill: '#000000',
+              fillOpacity: 1,
+              fontSize: 22,
+              fontWeight: 500,
+              lineHeight: 30,
+              textAlign: 'center',
+              background: true,
+              backgroundFill: '#ffffff',
+              backgroundRadius: 24,
+              backgroundOpacity: 1,
+              backgroundPadding: [10, 16],
+              backgroundShadowColor: 'rgba(42,102,187,0.17)',
+              backgroundShadowBlur: 22,
+              transform: [{ type: 'exceedAdjust', bounds: 'main' }],
+            },
+          ]
+        : [],
+    };
+  });
+  return {
+    width: 654,
+    height: 310,
+    type: 'view',
+    margin: 20,
+    // marginBottom: 20,
+    marginLeft: 10,
+    insetLeft: 24,
+    insetRight: 24,
+    insetBottom: 24,
+    axis: {
+      x: {
+        title: '',
+        size: 16,
+        line: true,
+        lineLineWidth: 1.5,
+        lineStroke: '#DEE3EB',
+        tick: false,
+        labelFontSize: 22,
+        labelFill: '#545C67',
+        labelFontWeight: 500,
+        labelDy: 8,
+        labelFormatter: (str) => {
+          if (/^\d{4}-\d{2}-\d{2}$/.test(str)) {
+            const [year, month, day] = str.split('-');
+            return `${+month}月${+day}日`;
+          }
+          return str;
+        },
+        tickFilter: (d, index) => {
+          if (data[index]?.showLabel) {
+            return true;
+          }
+          return false;
+        },
+      },
+      y: {
+        title: '',
+        tick: false,
+        line: true,
+        lineStroke: '#DEE3EB',
+        lineLineWidth: 1.5,
+        labelDx: -8,
+        labelFontSize: 22,
+        labelFill: '#545C67',
+        labelFontWeight: 500,
+        grid: false,
+      },
+    },
+    style: {
+      viewFill: 'rgba(22,119,255,0)',
+      // viewStroke: 'red',
+      // plotStroke: 'yellow',
+      // contentStroke: 'blue',
+      // mainStroke: 'green',
+    },
+    scale: {
+      y: {
+        type: 'linear',
+        tickCount: 5,
+        domain: [600, 860],
+        nice: true,
+      },
+    },
+    children: [
+      {
+        type: 'area',
+        data: data,
+        encode: {
+          x: 'date',
+          y: 'price',
+          shape: 'smooth',
+        },
+        style: {
+          fill: `linear-gradient(-90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0) 50%,rgba(105, 168, 255, 0.61) 100%)`,
+        },
+      },
+      {
+        type: 'line',
+        data: data,
+        encode: {
+          x: 'date',
+          y: 'price',
+          shape: 'smooth',
+        },
+        style: {
+          stroke:
+            'linear-gradient(0deg, #91BDFF 0%, #1777FF 24.148%, #1777FF 75.172%,#1677FF32 100%)',
+          lineWidth: 6,
+        },
+      },
+      ...result,
+    ],
+  };
+}

--- a/site/docs/manual/component/label.en.md
+++ b/site/docs/manual/component/label.en.md
@@ -513,7 +513,16 @@ chart.render();
 
 #### exceedAdjust
 
-`exceedAdjust` automatically detects and corrects label overflow, moving labels in the reverse direction when they exceed the view area.
+`exceedAdjust` automatically detects and corrects label overflow, moving labels in the reverse direction when they exceed the specified area.
+
+##### Configuration Options
+
+| Property | Description | Type | Default |
+| --- | --- | --- | --- |
+| bounds | Specifies the boundary area type for overflow detection, supported since version `5.3.4`.   | `'view' \| 'main'` | `'view'` |
+
+- `'view'`: Check if labels exceed the entire view area (including margins and paddings)
+- `'main'`: Check if labels exceed the main area (excluding margins and paddings)
 
 ##### Problem Case
 
@@ -546,7 +555,7 @@ chart.options({
 chart.render();
 ```
 
-##### Configure `exceedAdjust` Label Transformation
+##### Configure `exceedAdjust` Label Transformation - Default View Boundary
 
 Optimizes direction for `label` that exceeds the view.
 
@@ -573,6 +582,39 @@ chart.options({
   },
   transform: [{ type: 'groupX', y: 'mean' }],
   labels: [{ text: 'price', transform: [{ type: 'exceedAdjust' }] }],
+});
+
+chart.render();
+```
+
+##### Configure `exceedAdjust` Label Transformation - Main Boundary
+
+Using `bounds: 'main'` configuration, only adjusts labels when they exceed the main area (excluding margins and paddings).
+
+```js | ob { inject: true }
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  margin: 60, // Set larger margin to show the difference
+});
+
+chart.options({
+  type: 'line',
+  autoFit: true,
+  height: 300,
+  data: {
+    type: 'fetch',
+    value:
+      'https://gw.alipayobjects.com/os/bmw-prod/cb99c4ab-e0a3-4c76-9586-fe7fa2ff1a8c.csv',
+  },
+  encode: {
+    x: (d) => new Date(d.date).getFullYear(),
+    y: 'price',
+    color: 'symbol',
+  },
+  transform: [{ type: 'groupX', y: 'mean' }],
+  labels: [{ text: 'price', transform: [{ type: 'exceedAdjust', bounds: 'main' }] }],
 });
 
 chart.render();

--- a/site/docs/manual/component/label.zh.md
+++ b/site/docs/manual/component/label.zh.md
@@ -241,7 +241,7 @@ chart.render();
 | contrastReverse | 标签颜色在图形背景上对比度低的情况下，从指定色板选择一个对比度最优的颜色         |
 | overflowHide    | 对于标签在图形上放置不下的时候，隐藏标签                                         |
 | overlapHide     | 对位置碰撞的标签进行隐藏，默认保留前一个，隐藏后一个                             |
-| exceedAdjust    | 会自动对标签做溢出检测和矫正，即当标签超出视图区域时，会对标签自动做反方向的位移 |
+| exceedAdjust    | 会自动对标签做溢出检测和矫正，即当标签超出指定区域时，会对标签自动做反方向的位移 |
 
 不同的转化类型，针对不同的标签问题情况。所以明确每个 `transform` 标签转化的区别十分有必要。
 
@@ -513,7 +513,16 @@ chart.render();
 
 #### exceedAdjust
 
-`exceedAdjust` 会自动对标签做溢出检测和矫正，即当标签超出视图区域时，会对标签自动做反方向的位移。
+`exceedAdjust` 会自动对标签做溢出检测和矫正，即当标签超出指定区域时，会对标签自动做反方向的位移。
+
+##### 配置项
+
+| 属性 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| bounds | 指定检测边界的区域类型,`5.3.4` 开始支持 | `'view' \| 'main'` | `'view'` |
+
+- `'view'`：检测标签是否超出整个视图区域（包含 margin 和 padding）
+- `'main'`：检测标签是否超出主区域（不包含 margin 和 padding）
 
 ##### 问题案例
 
@@ -546,7 +555,7 @@ chart.options({
 chart.render();
 ```
 
-##### 配置 `exceedAdjust` 转化标签
+##### 配置 `exceedAdjust` 转化标签 - 默认 view 边界
 
 对超出视图的 `label` 标签进行方向优化。
 
@@ -573,6 +582,39 @@ chart.options({
   },
   transform: [{ type: 'groupX', y: 'mean' }],
   labels: [{ text: 'price', transform: [{ type: 'exceedAdjust' }] }],
+});
+
+chart.render();
+```
+
+##### 配置 `exceedAdjust` 转化标签 - main 边界
+
+使用 `bounds: 'plot'` 配置，仅在标签超出绘制区域（不包含 margin）时进行调整。
+
+```js | ob { inject: true }
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  margin: 60, // 设置较大的 margin 以显示区别
+});
+
+chart.options({
+  type: 'line',
+  autoFit: true,
+  height: 300,
+  data: {
+    type: 'fetch',
+    value:
+      'https://gw.alipayobjects.com/os/bmw-prod/cb99c4ab-e0a3-4c76-9586-fe7fa2ff1a8c.csv',
+  },
+  encode: {
+    x: (d) => new Date(d.date).getFullYear(),
+    y: 'price',
+    color: 'symbol',
+  },
+  transform: [{ type: 'groupX', y: 'mean' }],
+  labels: [{ text: 'price', transform: [{ type: 'exceedAdjust', bounds: 'main' }] }],
 });
 
 chart.render();

--- a/src/spec/labelTransform.ts
+++ b/src/spec/labelTransform.ts
@@ -40,4 +40,10 @@ export type OverflowHideLabelTransform = {
 
 export type ExceedAdjustLabel = {
   type: 'exceedAdjust';
+  /**
+   * The boundary area to check for label overflow.
+   * - 'view': Check against the entire view area (default)
+   * - 'main': Check against the main area (excluding margins and paddings)
+   */
+  bounds?: 'view' | 'main';
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] benchmarks are included
- [x] commit message follows commit guidelines
- [x] documents are updated

##### Description of change
修改前：
边界碰撞区域为 view，会遮挡坐标轴刻度值标签
![image](https://github.com/user-attachments/assets/a3eb6cc3-711a-4d39-9622-f11b64788aac)
现在 exceedAdjust 新增 bounds 参数，支持自定义边界区域，默认为 view，支持配置为 main，指定碰撞区域为主区域
![image](https://github.com/user-attachments/assets/adf3632d-ef5f-4b6c-ad39-591ab2516b75)
写法：
```
      labels: [
        {
          text: 'tooltip',
          transform: [{ type: 'exceedAdjust', bounds: 'main' }],
        },
      ]
```
效果：
![image](https://github.com/user-attachments/assets/0953f0d6-a055-4684-bc4c-fc28fac29eac)
