### PR TITLE
fix：1、修改g2绘制图表设置label时，如果不配置fillOpacity就默认fillOpacity为1

### DIFF
--- a/src/runtime/plot.ts
+++ b/src/runtime/plot.ts
@@ -1,17 +1,17 @@
 import { Vector2 } from '@antv/coord';
 import { DisplayObject, IAnimation as GAnimation, Rect } from '@antv/g';
-import { deepMix, upperFirst, isArray } from '@antv/util';
+import { deepMix, isArray, upperFirst } from '@antv/util';
 import { group, groups } from '@antv/vendor/d3-array';
 import { format } from '@antv/vendor/d3-format';
 import { mapObject } from '../utils/array';
 import { ChartEvent } from '../utils/event';
 import {
-  isStrictObject,
   appendTransform,
   compose,
   copyAttributes,
   defined,
   error,
+  isStrictObject,
   maybeSubObject,
   subObject,
   useMemo,
@@ -46,10 +46,10 @@ import {
   applyScale,
   assignScale,
   collectScales,
+  groupTransform,
   inferScale,
   syncFacetsScales,
   useRelationScale,
-  groupTransform,
 } from './scale';
 import { applyDataTransform } from './transform';
 import {
@@ -1697,10 +1697,75 @@ function createExitFunction(
   return createAnimationFunction('exit', mark, state, view, library);
 }
 
+// function inferTheme(theme: G2ThemeOptions = {}): G2ThemeOptions {
+//   if (typeof theme === 'string') return { type: theme };
+//   const { type = 'light', ...rest } = theme;
+//   return { ...rest, type };
+// }
+
+// 主题推断函数，设置fillOpacity默认值
 function inferTheme(theme: G2ThemeOptions = {}): G2ThemeOptions {
-  if (typeof theme === 'string') return { type: theme };
-  const { type = 'light', ...rest } = theme;
-  return { ...rest, type };
+  // 处理字符串类型的主题
+  if (typeof theme === 'string') {
+    return { type: theme };
+  }
+
+  // 深拷贝原始主题对象
+  const newTheme = deepMix({}, theme);
+
+  // 确保主题类型存在
+  newTheme.type = newTheme.type !== undefined ? newTheme.type : 'light';
+
+  // 特别处理label的默认样式
+  if (!newTheme.label) {
+    newTheme.label = {};
+  }
+
+  // 确保label的fillOpacity为1（如果未设置）
+  if (newTheme.label.fillOpacity === undefined) {
+    newTheme.label.fillOpacity = 1;
+  }
+
+  // 处理每个markType下的label默认值
+  const markTypes = [
+    'interval',
+    'rect',
+    'line',
+    'point',
+    'text',
+    'cell',
+    'area',
+    'link',
+    'image',
+    'polygon',
+    'box',
+    'vector',
+    'edge',
+    'node',
+    'lineX',
+    'lineY',
+    'range',
+    'rangeX',
+    'rangeY',
+    'connector',
+  ];
+
+  markTypes.forEach((markType) => {
+    if (!newTheme[markType]) {
+      newTheme[markType] = {};
+    }
+
+    if (!newTheme[markType].label) {
+      newTheme[markType].label = {};
+    }
+
+    // 确保mark特定的label fillOpacity为1（如果未设置）
+    if (newTheme[markType].label.fillOpacity === undefined) {
+      newTheme[markType].label.fillOpacity = 1;
+    }
+  });
+
+  return newTheme;
 }
 
 /**


### PR DESCRIPTION
修改g2绘制图表设置label时，如果不配置fillOpacity就默认fillOpacity为1，这样用户使用友好

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] benchmarks are included
- [ ] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change

<!-- Provide a description of the change below this comment. -->
