### PR TITLE
fix: corner radius abnormal of the pie chart

### DIFF
--- a/__tests__/integration/snapshots/static/mockPieRadius.svg
+++ b/__tests__/integration/snapshots/static/mockPieRadius.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" color-interpolation-filters="sRGB" style="background: transparent;">
+  <defs>
+    <clipPath id="b" transform="matrix(1 0 0 1 -16 -16)">
+      <use href="#a" transform="matrix(1 0 0 1 16 16)"/>
+    </clipPath>
+  </defs>
+  <g>
+    <g fill="none">
+      <g fill="none" class="view">
+        <g>
+          <path width="640" height="480" x="0" y="0" fill="rgba(0,0,0,0)" d="m0 0 640 0 0 480-640 0z" class="area"/>
+        </g>
+        <g>
+          <path width="608" height="448" x="16" y="16" fill="rgba(0,0,0,0)" d="m16 16 608 0 0 448-608 0z" class="area"/>
+        </g>
+        <g>
+          <path width="608" height="413" x="16" y="51" fill="rgba(0,0,0,0)" d="m16 51 608 0 0 413-608 0z" class="area"/>
+        </g>
+        <g>
+          <path width="608" height="413" x="16" y="51" fill="rgba(0,0,0,0)" d="m16 51 608 0 0 413-608 0z" class="area"/>
+        </g>
+        <g fill="none" class="component">
+          <g fill="none" transform="matrix(1 0 0 1 16 16)">
+            <g fill="none" class="legend-category">
+              <g fill="none" class="legend-title-group">
+                <g fill="none" class="legend-title"/>
+              </g>
+              <g fill="none" class="legend-items-group">
+                <g fill="none" class="legend-items">
+                  <g fill="none" class="items-navigator">
+                    <g fill="none" class="navigator-content-group" clip-path="url(#b)">
+                      <g fill="none" class="navigator-play-window">
+                        <g fill="none" class="items-item-page">
+                          <g fill="none" class="items-item">
+                            <g fill="none" class="legend-category-item-background-group">
+                              <g>
+                                <path width="41" height="23" fill="rgba(0,0,0,0)" d="m0 0 41 0 0 23-41 0z" class="legend-category-item-background" visibility="visible"/>
+                              </g>
+                            </g>
+                            <g fill="none" class="legend-category-item-marker-group" transform="matrix(.5 0 0 .5 4 11.5)">
+                              <g>
+                                <path fill="rgba(23,131,255,1)" stroke-width="0" d="m-8-8 16 0 0 16-16 0Z" class="legend-category-item-marker" visibility="visible"/>
+                              </g>
+                            </g>
+                            <g fill="none" class="legend-category-item-label-group" transform="matrix(1 0 0 1 16 11.5)">
+                              <g>
+                                <text fill="rgba(29,33,41,1)" fill-opacity=".9" stroke-width="1" class="legend-category-item-label" dominant-baseline="central" dx=".5" dy="0" font-family="sans-serif" font-size="12" font-style="normal" font-variant="normal" font-weight="normal" paint-order="stroke" style="transform:translate(0px, 0px);" text-anchor="left" visibility="visible">微博</text>
+                              </g>
+                            </g>
+                            <g fill="none" class="legend-category-item-value-group"/>
+                          </g>
+                          <g fill="none" class="items-item" transform="matrix(1 0 0 1 53 0)">
+                            <g fill="none" class="legend-category-item-background-group">
+                              <g>
+                                <path width="41" height="23" fill="rgba(0,0,0,0)" d="m0 0 41 0 0 23-41 0z" class="legend-category-item-background" visibility="visible"/>
+                              </g>
+                            </g>
+                            <g fill="none" class="legend-category-item-marker-group" transform="matrix(.5 0 0 .5 4 11.5)">
+                              <g>
+                                <path fill="rgba(0,201,201,1)" stroke-width="0" d="m-8-8 16 0 0 16-16 0Z" class="legend-category-item-marker" visibility="visible"/>
+                              </g>
+                            </g>
+                            <g fill="none" class="legend-category-item-label-group" transform="matrix(1 0 0 1 16 11.5)">
+                              <g>
+                                <text fill="rgba(29,33,41,1)" fill-opacity=".9" stroke-width="1" class="legend-category-item-label" dominant-baseline="central" dx=".5" dy="0" font-family="sans-serif" font-size="12" font-style="normal" font-variant="normal" font-weight="normal" paint-order="stroke" style="transform:translate(0px, 0px);" text-anchor="left" visibility="visible">其他</text>
+                              </g>
+                            </g>
+                            <g fill="none" class="legend-category-item-value-group"/>
+                          </g>
+                        </g>
+                      </g>
+                    </g>
+                    <g fill="none" class="navigator-controller"/>
+                    <g>
+                      <path id="a" width="94" height="23" fill="none" d="m0 0 94 0 0 23-94 0z" class="navigator-clip-path"/>
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+        <g transform="matrix(1 0 0 1 16 51)">
+          <path width="608" height="413" fill="rgba(0,0,0,0)" d="m0 0 608 0 0 413-608 0z" class="plot"/>
+          <g fill="none" class="main-layer">
+            <g transform="matrix(1 0 0 1 304 206.5)">
+              <path fill="rgba(23,131,255,1)" fill-opacity=".95" stroke="rgba(23,131,255,1)" stroke-width="0" d="M3.445-196.215a10 10 0 0 1 10.682-9.801 206.5 206.5 0 0 1 0 412.032 10 10 0 0 1-10.682-9.801l-3.445-196.215Z" class="element"/>
+            </g>
+            <g transform="matrix(1 0 0 1 304 206.5)">
+              <path fill="rgba(0,201,201,1)" fill-opacity=".95" stroke="rgba(0,201,201,1)" stroke-width="0" d="M-3.445 196.215a10 10 0 0 1-10.682 9.801 206.5 206.5 0 0 1 0-412.032 10 10 0 0 1 10.682 9.801l3.445 196.215Z" class="element"/>
+            </g>
+          </g>
+          <g fill="none" class="label-layer"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/__tests__/plots/static/index.ts
+++ b/__tests__/plots/static/index.ts
@@ -346,6 +346,7 @@ export { githubStarIntervalDarkThemeTransparent } from './github-star-interval-d
 export { diamondIntervalGroupX } from './diamond-interval-group-x';
 export { mockIntervalSeriesOrder } from './mock-interval-series-order';
 export { mockPieSpider } from './mock-pie-spider';
+export { mockPieRadius } from './mock-pie-radius';
 export { mockPieSpiderRight } from './mock-pie-spider-right';
 export { mockPieSpiderMany } from './mock-pie-spider-many';
 export { mockPieSpiderHide } from './mock-pie-spider-hide';

--- a/__tests__/plots/static/mock-pie-radius.ts
+++ b/__tests__/plots/static/mock-pie-radius.ts
@@ -1,0 +1,21 @@
+import { G2Spec } from '../../../src';
+
+export function mockPieRadius(): G2Spec {
+  return {
+    type: 'interval',
+    data: [
+      { type: '微博', value: 20 },
+      { type: '其他', value: 20 },
+    ],
+    encode: {
+      y: 'value',
+      color: 'type',
+    },
+    transform: [{ type: 'stackY' }],
+    coordinate: { type: 'theta' },
+    style: {
+      radius: 10,
+      inset: 2,
+    },
+  };
+}

--- a/src/shape/utils.ts
+++ b/src/shape/utils.ts
@@ -193,9 +193,10 @@ export function getArcObject(
   // 2. |a1 - a2| = Math.PI * 2
   // Distinguish them by y and y1:
   const a3 = a2 === a1 && y !== y1 ? a2 + Math.PI * 2 : a2;
+  const epsilon = 1e-4;
   return {
-    startAngle: a1,
-    endAngle: a3 - a1 >= 0 ? a3 : Math.PI * 2 + a3,
+    startAngle: a1 + epsilon,
+    endAngle: (a3 - a1 >= 0 ? a3 : Math.PI * 2 + a3) - epsilon,
     innerRadius: dist(p3, center),
     outerRadius: dist(p0, center),
   };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Description of change

https://github.com/ant-design/ant-design-charts/issues/2732

`d3.arc` 有个隐藏 BUG，如果两个相邻扇形之间连接点（p0 和 p1）是完全连续的（同一个点），D3 只在「某一边」绘制圆角，另一边会退化为尖角。

解决方案：通过 `epsilon` 手动打断两个连接点。

<!-- Provide a description of the change below this comment. -->
