### PR TITLE
feat: make mark series scale independent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
 
     steps:
       - name: Checkout

--- a/__tests__/integration/snapshots/bugfix/issue6654/step0.svg
+++ b/__tests__/integration/snapshots/bugfix/issue6654/step0.svg
@@ -272,28 +272,28 @@
           <path width="545" height="347" fill="rgba(0,0,0,0)" d="m0 0 545 0 0 347-545 0z" class="plot"/>
           <g fill="none" class="main-layer">
             <g>
-              <path width="34.4614" height="312.8983" x="29.7814" y="34.1017" fill="rgba(0,0,0,1)" fill-opacity=".95" stroke="rgba(0,0,0,1)" stroke-width="0" d="m29.7814 34.1017 34.4614 0 0 312.8983-34.4614 0z" class="element"/>
+              <path width="51.2718" height="312.8983" x="31.6492" y="34.1017" fill="rgba(0,0,0,1)" fill-opacity=".95" stroke="rgba(0,0,0,1)" stroke-width="0" d="m31.6492 34.1017 51.2718 0 0 312.8983-51.2718 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="285.2963" x="68.0718" y="61.7037" fill="rgba(255,0,0,1)" fill-opacity=".95" stroke="rgba(255,0,0,1)" stroke-width="0" d="m68.0718 61.7037 34.4614 0 0 285.2963-34.4614 0z" class="element"/>
+              <path width="51.2718" height="285.2963" x="88.6179" y="61.7037" fill="rgba(255,0,0,1)" fill-opacity=".95" stroke="rgba(255,0,0,1)" stroke-width="0" d="m88.6179 61.7037 51.2718 0 0 285.2963-51.2718 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="271.9665" x="106.3622" y="75.0335" fill="rgba(0,0,0,1)" fill-opacity=".95" stroke="rgba(0,0,0,1)" stroke-width="0" d="m106.3622 75.0335 34.4614 0 0 271.9665-34.4614 0z" class="element"/>
+              <path width="51.2718" height="271.9665" x="145.5865" y="75.0335" fill="rgba(0,0,0,1)" fill-opacity=".95" stroke="rgba(0,0,0,1)" stroke-width="0" d="m145.5865 75.0335 51.2718 0 0 271.9665-51.2718 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="287.6881" x="144.6526" y="59.3119" fill="rgba(255,0,0,1)" fill-opacity=".95" stroke="rgba(255,0,0,1)" stroke-width="0" d="m144.6526 59.312 34.4614 0 0 287.688-34.4614 0z" class="element"/>
+              <path width="51.2718" height="287.6881" x="202.5552" y="59.3119" fill="rgba(255,0,0,1)" fill-opacity=".95" stroke="rgba(255,0,0,1)" stroke-width="0" d="m202.5552 59.312 51.2717 0 0 287.688-51.2717 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="316.8634" x="289.3052" y="30.1366" fill="rgba(0,0,0,1)" fill-opacity=".95" stroke="rgba(0,0,0,1)" stroke-width="0" d="m289.3052 30.1366 34.4614 0 0 316.8634-34.4614 0z" class="element"/>
+              <path width="51.2718" height="316.8634" x="291.1731" y="30.1366" fill="rgba(0,0,0,1)" fill-opacity=".95" stroke="rgba(0,0,0,1)" stroke-width="0" d="m291.173 30.1366 51.2718 0 0 316.8634-51.2717 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="331.6445" x="327.5956" y="15.3555" fill="rgba(255,0,0,1)" fill-opacity=".95" stroke="rgba(255,0,0,1)" stroke-width="0" d="m327.5956 15.3555 34.4614 0 0 331.6445-34.4614 0z" class="element"/>
+              <path width="51.2718" height="331.6445" x="348.1417" y="15.3555" fill="rgba(255,0,0,1)" fill-opacity=".95" stroke="rgba(255,0,0,1)" stroke-width="0" d="m348.1417 15.3555 51.2718 0 0 331.6445-51.2718 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="309.9033" x="365.886" y="37.0967" fill="rgba(0,0,0,1)" fill-opacity=".95" stroke="rgba(0,0,0,1)" stroke-width="0" d="m365.886 37.0967 34.4614 0 0 309.9033-34.4614 0z" class="element"/>
+              <path width="51.2718" height="309.9033" x="405.1103" y="37.0967" fill="rgba(0,0,0,1)" fill-opacity=".95" stroke="rgba(0,0,0,1)" stroke-width="0" d="m405.1103 37.0967 51.2718 0 0 309.9033-51.2718 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="347" x="404.1764" y="0" fill="rgba(255,0,0,1)" fill-opacity=".95" stroke="rgba(255,0,0,1)" stroke-width="0" d="m404.1764 0 34.4614 0 0 347-34.4614 0z" class="element"/>
+              <path width="51.2718" height="347" x="462.079" y="0" fill="rgba(255,0,0,1)" fill-opacity=".95" stroke="rgba(255,0,0,1)" stroke-width="0" d="m462.079 0 51.2718 0 0 347-51.2718 0z" class="element"/>
             </g>
           </g>
           <g fill="none" class="main-layer">

--- a/__tests__/integration/snapshots/bugfix/issue6654/step1.svg
+++ b/__tests__/integration/snapshots/bugfix/issue6654/step1.svg
@@ -272,28 +272,28 @@
           <path width="545" height="347" fill="rgba(0,0,0,0)" d="m0 0 545 0 0 347-545 0z" class="plot"/>
           <g fill="none" class="main-layer">
             <g>
-              <path width="34.4614" height="312.8983" x="29.7814" y="34.1017" fill="rgba(255,255,0,1)" fill-opacity=".95" stroke="rgba(255,255,0,1)" stroke-width="0" d="m29.7814 34.1017 34.4614 0 0 312.8983-34.4614 0z" class="element"/>
+              <path width="51.2718" height="312.8983" x="31.6492" y="34.1017" fill="rgba(255,255,0,1)" fill-opacity=".95" stroke="rgba(255,255,0,1)" stroke-width="0" d="m31.6492 34.1017 51.2718 0 0 312.8983-51.2718 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="285.2963" x="68.0718" y="61.7037" fill="rgba(0,0,255,1)" fill-opacity=".95" stroke="rgba(0,0,255,1)" stroke-width="0" d="m68.0718 61.7037 34.4614 0 0 285.2963-34.4614 0z" class="element"/>
+              <path width="51.2718" height="285.2963" x="88.6179" y="61.7037" fill="rgba(0,0,255,1)" fill-opacity=".95" stroke="rgba(0,0,255,1)" stroke-width="0" d="m88.6179 61.7037 51.2718 0 0 285.2963-51.2718 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="271.9665" x="106.3622" y="75.0335" fill="rgba(255,255,0,1)" fill-opacity=".95" stroke="rgba(255,255,0,1)" stroke-width="0" d="m106.3622 75.0335 34.4614 0 0 271.9665-34.4614 0z" class="element"/>
+              <path width="51.2718" height="271.9665" x="145.5865" y="75.0335" fill="rgba(255,255,0,1)" fill-opacity=".95" stroke="rgba(255,255,0,1)" stroke-width="0" d="m145.5865 75.0335 51.2718 0 0 271.9665-51.2718 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="287.6881" x="144.6526" y="59.3119" fill="rgba(0,0,255,1)" fill-opacity=".95" stroke="rgba(0,0,255,1)" stroke-width="0" d="m144.6526 59.312 34.4614 0 0 287.688-34.4614 0z" class="element"/>
+              <path width="51.2718" height="287.6881" x="202.5552" y="59.3119" fill="rgba(0,0,255,1)" fill-opacity=".95" stroke="rgba(0,0,255,1)" stroke-width="0" d="m202.5552 59.312 51.2717 0 0 287.688-51.2717 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="316.8634" x="289.3052" y="30.1366" fill="rgba(255,255,0,1)" fill-opacity=".95" stroke="rgba(255,255,0,1)" stroke-width="0" d="m289.3052 30.1366 34.4614 0 0 316.8634-34.4614 0z" class="element"/>
+              <path width="51.2718" height="316.8634" x="291.1731" y="30.1366" fill="rgba(255,255,0,1)" fill-opacity=".95" stroke="rgba(255,255,0,1)" stroke-width="0" d="m291.173 30.1366 51.2718 0 0 316.8634-51.2717 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="331.6445" x="327.5956" y="15.3555" fill="rgba(0,0,255,1)" fill-opacity=".95" stroke="rgba(0,0,255,1)" stroke-width="0" d="m327.5956 15.3555 34.4614 0 0 331.6445-34.4614 0z" class="element"/>
+              <path width="51.2718" height="331.6445" x="348.1417" y="15.3555" fill="rgba(0,0,255,1)" fill-opacity=".95" stroke="rgba(0,0,255,1)" stroke-width="0" d="m348.1417 15.3555 51.2718 0 0 331.6445-51.2718 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="309.9033" x="365.886" y="37.0967" fill="rgba(255,255,0,1)" fill-opacity=".95" stroke="rgba(255,255,0,1)" stroke-width="0" d="m365.886 37.0967 34.4614 0 0 309.9033-34.4614 0z" class="element"/>
+              <path width="51.2718" height="309.9033" x="405.1103" y="37.0967" fill="rgba(255,255,0,1)" fill-opacity=".95" stroke="rgba(255,255,0,1)" stroke-width="0" d="m405.1103 37.0967 51.2718 0 0 309.9033-51.2718 0z" class="element"/>
             </g>
             <g>
-              <path width="34.4614" height="347" x="404.1764" y="0" fill="rgba(0,0,255,1)" fill-opacity=".95" stroke="rgba(0,0,255,1)" stroke-width="0" d="m404.1764 0 34.4614 0 0 347-34.4614 0z" class="element"/>
+              <path width="51.2718" height="347" x="462.079" y="0" fill="rgba(0,0,255,1)" fill-opacity=".95" stroke="rgba(0,0,255,1)" stroke-width="0" d="m462.079 0 51.2718 0 0 347-51.2718 0z" class="element"/>
             </g>
           </g>
           <g fill="none" class="main-layer">

--- a/__tests__/integration/snapshots/static/weatherLineMultiAxesSync.svg
+++ b/__tests__/integration/snapshots/static/weatherLineMultiAxesSync.svg
@@ -431,78 +431,78 @@
           </g>
           <g fill="none" class="main-layer">
             <g>
-              <path width="8.7811" height="3.056" x="14.0931" y="378.944" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m14.093 378.944 8.7812 0 0 3.056-8.7811 0z" class="element"/>
+              <path width="12.9625" height="3.056" x="4.8009" y="378.944" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m4.801 378.944 12.9625 0 0 3.056-12.9626 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="7.4872" x="47.6997" y="374.5128" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m47.6997 374.5128 8.781 0 0 7.4872-8.781 0z" class="element"/>
+              <path width="12.9625" height="7.4872" x="38.4076" y="374.5128" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m38.4076 374.5128 12.9625 0 0 7.4872-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="10.696" x="81.3063" y="371.304" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m81.3063 371.304 8.7811 0 0 10.696-8.781 0z" class="element"/>
+              <path width="12.9625" height="10.696" x="72.0142" y="371.304" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m72.0142 371.304 12.9625 0 0 10.696-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="35.4496" x="114.9129" y="346.5504" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m114.913 346.5504 8.781 0 0 35.4496-8.781 0z" class="element"/>
+              <path width="12.9625" height="35.4496" x="105.6208" y="346.5504" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m105.6208 346.5504 12.9625 0 0 35.4496-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="39.1168" x="148.5195" y="342.8832" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m148.5195 342.8832 8.7811 0 0 39.1168-8.781 0z" class="element"/>
+              <path width="12.9625" height="39.1168" x="139.2274" y="342.8832" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m139.2274 342.8832 12.9625 0 0 39.1168-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="117.1976" x="182.1261" y="264.8024" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m182.1261 264.8024 8.7811 0 0 117.1976-8.781 0z" class="element"/>
+              <path width="12.9625" height="117.1976" x="172.834" y="264.8024" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m172.834 264.8024 12.9625 0 0 117.1976-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="207.1968" x="215.7328" y="174.8032" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m215.7328 174.8032 8.781 0 0 207.1968-8.781 0z" class="element"/>
+              <path width="12.9625" height="207.1968" x="206.4406" y="174.8032" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m206.4406 174.8032 12.9626 0 0 207.1968-12.9626 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="247.8416" x="249.3394" y="134.1584" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m249.3394 134.1584 8.781 0 0 247.8416-8.781 0z" class="element"/>
+              <path width="12.9625" height="247.8416" x="240.0472" y="134.1584" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m240.0472 134.1584 12.9626 0 0 247.8416-12.9626 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="49.8128" x="282.946" y="332.1872" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m282.946 332.1872 8.781 0 0 49.8128-8.781 0z" class="element"/>
+              <path width="12.9625" height="49.8128" x="273.6538" y="332.1872" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m273.6538 332.1872 12.9626 0 0 49.8128-12.9626 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="30.56" x="316.5526" y="351.44" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m316.5526 351.44 8.781 0 0 30.56-8.781 0z" class="element"/>
+              <path width="12.9625" height="30.56" x="307.2604" y="351.44" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m307.2604 351.44 12.9626 0 0 30.56-12.9626 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="9.7792" x="350.1592" y="372.2208" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m350.1592 372.2208 8.781 0 0 9.7792-8.781 0z" class="element"/>
+              <path width="12.9625" height="9.7792" x="340.8671" y="372.2208" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m340.867 372.2208 12.9626 0 0 9.7792-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="5.0424" x="383.7658" y="376.9576" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m383.7658 376.9576 8.7811 0 0 5.0424-8.781 0z" class="element"/>
+              <path width="12.9625" height="5.0424" x="374.4737" y="376.9576" fill="rgba(84,112,198,1)" fill-opacity=".8" stroke="rgba(84,112,198,1)" stroke-width="0" d="m374.4737 376.9576 12.9625 0 0 5.0424-12.9625 0z" class="element"/>
             </g>
           </g>
           <g fill="none" class="main-layer">
             <g>
-              <path width="8.7811" height="3.9728" x="23.8499" y="378.0272" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m23.8499 378.0272 8.781 0 0 3.9728-8.781 0z" class="element"/>
+              <path width="12.9625" height="3.9728" x="19.2038" y="378.0272" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m19.2038 378.0272 12.9625 0 0 3.9728-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="9.0152" x="57.4565" y="372.9848" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m57.4565 372.9848 8.781 0 0 9.0152-8.781 0z" class="element"/>
+              <path width="12.9625" height="9.0152" x="52.8104" y="372.9848" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m52.8104 372.9848 12.9625 0 0 9.0152-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="13.752" x="91.0631" y="368.248" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m91.063 368.248 8.7812 0 0 13.752-8.7811 0z" class="element"/>
+              <path width="12.9625" height="13.752" x="86.417" y="368.248" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m86.417 368.248 12.9625 0 0 13.752-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="40.3392" x="124.6697" y="341.6608" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m124.6697 341.6608 8.781 0 0 40.3392-8.781 0z" class="element"/>
+              <path width="12.9625" height="40.3392" x="120.0236" y="341.6608" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m120.0236 341.6608 12.9626 0 0 40.3392-12.9626 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="43.8536" x="158.2763" y="338.1464" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m158.2763 338.1464 8.781 0 0 43.8536-8.781 0z" class="element"/>
+              <path width="12.9625" height="43.8536" x="153.6302" y="338.1464" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m153.6302 338.1464 12.9626 0 0 43.8536-12.9626 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="108.0296" x="191.8829" y="273.9704" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m191.883 273.9704 8.781 0 0 108.0296-8.781 0z" class="element"/>
+              <path width="12.9625" height="108.0296" x="187.2368" y="273.9704" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m187.2368 273.9704 12.9626 0 0 108.0296-12.9626 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="268.3168" x="225.4895" y="113.6832" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m225.4895 113.6832 8.7811 0 0 268.3168-8.781 0z" class="element"/>
+              <path width="12.9625" height="268.3168" x="220.8434" y="113.6832" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m220.8434 113.6832 12.9626 0 0 268.3168-12.9626 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="278.4016" x="259.0961" y="103.5984" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m259.0961 103.5984 8.7811 0 0 278.4016-8.781 0z" class="element"/>
+              <path width="12.9625" height="278.4016" x="254.4501" y="103.5984" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m254.45 103.5984 12.9626 0 0 278.4016-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="74.4136" x="292.7027" y="307.5864" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m292.7027 307.5864 8.7811 0 0 74.4136-8.781 0z" class="element"/>
+              <path width="12.9625" height="74.4136" x="288.0567" y="307.5864" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m288.0567 307.5864 12.9625 0 0 74.4136-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="28.7264" x="326.3094" y="353.2736" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m326.3094 353.2736 8.781 0 0 28.7264-8.781 0z" class="element"/>
+              <path width="12.9625" height="28.7264" x="321.6633" y="353.2736" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m321.6633 353.2736 12.9625 0 0 28.7264-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="9.168" x="359.916" y="372.832" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m359.916 372.832 8.781 0 0 9.168-8.781 0z" class="element"/>
+              <path width="12.9625" height="9.168" x="355.2699" y="372.832" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m355.2699 372.832 12.9625 0 0 9.168-12.9625 0z" class="element"/>
             </g>
             <g>
-              <path width="8.7811" height="3.5144" x="393.5226" y="378.4856" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m393.5226 378.4856 8.781 0 0 3.5144-8.781 0z" class="element"/>
+              <path width="12.9625" height="3.5144" x="388.8765" y="378.4856" fill="rgba(145,204,117,1)" fill-opacity=".95" stroke="rgba(145,204,117,1)" stroke-width="0" d="m388.8765 378.4856 12.9625 0 0 3.5144-12.9625 0z" class="element"/>
             </g>
           </g>
           <g fill="none" class="label-layer"/>

--- a/__tests__/integration/snapshots/tooltip/flare-treemap-poptip-custom/step0.html
+++ b/__tests__/integration/snapshots/tooltip/flare-treemap-poptip-custom/step0.html
@@ -1,4 +1,4 @@
-<foreignObject xmlns="http://www.w3.org/2000/svg" class="poptip">
+<foreignObject xmlns="http://www.w3.org/2000/svg" x="18" y="18" class="poptip">
   <div xmlns="http://www.w3.org/1999/xhtml">
     <div style="background-color:red;color:#fff;width:max-content;padding:1px 4px;font-size:12px;border-radius:2.5px;box-shadow:0 3px 6px -4px rgba(0,0,0,0.12), 0 6px 16px 0 rgba(0,0,0,0.08), 0 9px 28px 8px rgba(0,0,0,0.05)">
       Rectangle

--- a/__tests__/integration/snapshots/tooltip/flare-treemap-poptip/step1.html
+++ b/__tests__/integration/snapshots/tooltip/flare-treemap-poptip/step1.html
@@ -1,4 +1,4 @@
-<foreignObject xmlns="http://www.w3.org/2000/svg" class="poptip">
+<foreignObject xmlns="http://www.w3.org/2000/svg" x="18" y="18" class="poptip">
   <div xmlns="http://www.w3.org/1999/xhtml">
     <div style="background-color:rgba(0,0,0,0.75);color:#fff;width:max-content;padding:1px 4px;font-size:12px;border-radius:2.5px;box-shadow:0 3px 6px -4px rgba(0,0,0,0.12), 0 6px 16px 0 rgba(0,0,0,0.08), 0 9px 28px 8px rgba(0,0,0,0.05)">
       Rectangle

--- a/__tests__/integration/snapshots/tooltip/flare-treemap-poptip/step3.html
+++ b/__tests__/integration/snapshots/tooltip/flare-treemap-poptip/step3.html
@@ -1,4 +1,4 @@
-<foreignObject xmlns="http://www.w3.org/2000/svg" class="poptip">
+<foreignObject xmlns="http://www.w3.org/2000/svg" x="18" y="18" class="poptip">
   <div xmlns="http://www.w3.org/1999/xhtml">
     <div style="background-color:rgba(0,0,0,0.75);color:#fff;width:max-content;padding:1px 4px;font-size:12px;border-radius:2.5px;box-shadow:0 3px 6px -4px rgba(0,0,0,0.12), 0 6px 16px 0 rgba(0,0,0,0.08), 0 9px 28px 8px rgba(0,0,0,0.05)">
       Rectangle

--- a/__tests__/integration/utils/toMatchDOMSnapshot.ts
+++ b/__tests__/integration/utils/toMatchDOMSnapshot.ts
@@ -83,14 +83,6 @@ interface SVGDifferenceResult {
   differences: SVGDifference[];
 }
 
-const WHITE_LIST = [
-  (actual, expected) =>
-    expected ===
-      '<foreignObject xmlns="http://www.w3.org/2000/svg" class="poptip">' &&
-    actual ===
-      '<foreignObject xmlns="http://www.w3.org/2000/svg" x="NaN" y="NaN" class="poptip">',
-];
-
 function findSVGDifferences(
   actual: string,
   expected: string,
@@ -106,10 +98,7 @@ function findSVGDifferences(
 
   const maxLines = Math.max(actualLines.length, expectedLines.length);
   for (let i = 0; i < maxLines; i++) {
-    if (
-      actualLines[i] !== expectedLines[i] &&
-      !WHITE_LIST.some((fn) => fn(actualLines[i], expectedLines[i]))
-    ) {
+    if (actualLines[i] !== expectedLines[i]) {
       differences.push({
         line: i + 1,
         actual: actualLines[i] || '(missing)',
@@ -174,12 +163,6 @@ export async function toMatchDOMSnapshot(
       const result = findSVGDifferences(actual, expected);
       const totalDifferences = result.differences.length;
       let diffMessage = `mismatch ${namePath}`;
-
-      if (result.differences.length === 0)
-        return {
-          message: () => `⚠️ hit some whitelists, match ${namePath}`,
-          pass: true,
-        };
 
       if (totalDifferences > 0) {
         if (totalDifferences >= MAX_DIFFERENCES_TO_SHOW) {

--- a/__tests__/integration/utils/toMatchDOMSnapshot.ts
+++ b/__tests__/integration/utils/toMatchDOMSnapshot.ts
@@ -83,6 +83,14 @@ interface SVGDifferenceResult {
   differences: SVGDifference[];
 }
 
+const WHITE_LIST = [
+  (actual, expected) =>
+    expected ===
+      '<foreignObject xmlns="http://www.w3.org/2000/svg" class="poptip">' &&
+    actual ===
+      '<foreignObject xmlns="http://www.w3.org/2000/svg" x="NaN" y="NaN" class="poptip">',
+];
+
 function findSVGDifferences(
   actual: string,
   expected: string,
@@ -98,7 +106,10 @@ function findSVGDifferences(
 
   const maxLines = Math.max(actualLines.length, expectedLines.length);
   for (let i = 0; i < maxLines; i++) {
-    if (actualLines[i] !== expectedLines[i]) {
+    if (
+      actualLines[i] !== expectedLines[i] &&
+      !WHITE_LIST.some((fn) => fn(actualLines[i], expectedLines[i]))
+    ) {
       differences.push({
         line: i + 1,
         actual: actualLines[i] || '(missing)',
@@ -163,6 +174,12 @@ export async function toMatchDOMSnapshot(
       const result = findSVGDifferences(actual, expected);
       const totalDifferences = result.differences.length;
       let diffMessage = `mismatch ${namePath}`;
+
+      if (result.differences.length === 0)
+        return {
+          message: () => `⚠️ hit some whitelists, match ${namePath}`,
+          pass: true,
+        };
 
       if (totalDifferences > 0) {
         if (totalDifferences >= MAX_DIFFERENCES_TO_SHOW) {

--- a/__tests__/plots/tooltip/flare-treemap-poptip-custom.ts
+++ b/__tests__/plots/tooltip/flare-treemap-poptip-custom.ts
@@ -59,7 +59,12 @@ flareTreemapPoptipCustom.steps = ({ canvas }) => {
   return [
     {
       changeState: async () => {
-        rectangle?.dispatchEvent(new CustomEvent('pointerover'));
+        rectangle?.dispatchEvent(
+          new CustomEvent('pointerover', {
+            offsetX: 10,
+            offsetY: 10,
+          }),
+        );
       },
     },
   ];

--- a/__tests__/plots/tooltip/flare-treemap-poptip.ts
+++ b/__tests__/plots/tooltip/flare-treemap-poptip.ts
@@ -59,12 +59,22 @@ flareTreemapPoptip.steps = ({ canvas }) => {
   return [
     {
       changeState: async () => {
-        node?.dispatchEvent(new CustomEvent('pointerover'));
+        node?.dispatchEvent(
+          new CustomEvent('pointerover', {
+            offsetX: 10,
+            offsetY: 10,
+          }),
+        );
       },
     },
     {
       changeState: async () => {
-        rectangle?.dispatchEvent(new CustomEvent('pointerover'));
+        rectangle?.dispatchEvent(
+          new CustomEvent('pointerover', {
+            offsetX: 10,
+            offsetY: 10,
+          }),
+        );
       },
     },
     {
@@ -75,7 +85,12 @@ flareTreemapPoptip.steps = ({ canvas }) => {
     },
     {
       changeState: async () => {
-        spring?.dispatchEvent(new CustomEvent('pointerover'));
+        spring?.dispatchEvent(
+          new CustomEvent('pointerover', {
+            offsetX: 10,
+            offsetY: 10,
+          }),
+        );
       },
     },
   ];

--- a/src/runtime/mark.ts
+++ b/src/runtime/mark.ts
@@ -24,6 +24,7 @@ import {
   maybeNonAnimate,
   normalizeTooltip,
   extractTooltip,
+  appendMarkScaleKey,
 } from './transform';
 
 export async function initializeMark(
@@ -159,6 +160,7 @@ async function applyMarkTransform(
     maybeNonAnimate,
     addGuideToScale,
     normalizeTooltip,
+    appendMarkScaleKey,
     ...preInference.map(useTransform),
     ...transform.map(useTransform),
     ...postInference.map(useTransform),

--- a/src/runtime/transform.ts
+++ b/src/runtime/transform.ts
@@ -323,7 +323,7 @@ export function appendMarkScaleKey(
     scale: {
       series: {
         key: `DEFAULT_${mark.type}_SERIES_KEY`,
-        ...mark?.scale?.series,
+        ...(mark?.scale?.series ?? {}),
       },
     },
   });

--- a/src/runtime/transform.ts
+++ b/src/runtime/transform.ts
@@ -314,6 +314,23 @@ export function maybeNonAnimate(
   return [I, mark];
 }
 
+export function appendMarkScaleKey(
+  I: number[],
+  mark: G2Mark,
+  context: G2Context,
+): [number[], G2Mark] {
+  deepMix(mark, {
+    scale: {
+      series: {
+        key: `DEFAULT_${mark.type}_SERIES_KEY`,
+        ...mark?.scale?.series,
+      },
+    },
+  });
+
+  return [I, mark];
+}
+
 function isTypedChannel(channel): boolean {
   if (
     typeof channel !== 'object' ||


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Description of change
- fixed https://github.com/antvis/G2/issues/5250
- fixed https://github.com/antvis/G2/issues/6657
- fixed https://github.com/antvis/G2/issues/6753

之前所有的 mark 都会共享 series，而类似柱形图这种 mark 会根据 series 来计算 bandWidth，当多轴时，折线的 series 就会挤占柱形图的横向空间，导致看起来是错位的。
<img width="1376" height="1152" alt="image" src="https://github.com/user-attachments/assets/fa8153aa-dc05-40d3-bad8-22d58a850d45" />
本次更改：
series 共享机制变为：同类型 mark 共享 series，不同类型 mark 之间 series 隔离。比如多个 interval mark，它们之间就会共享 series，计算自己的布局空间。而 line 和 interval 的 series 就是独立的，不影响各自的布局空间。

<!-- Provide a description of the change below this comment. -->
