### PR TITLE
Revert "fix: 多轴图使用滚动条后会导致折线点位错乱"

### DIFF
--- a/src/interaction/scrollbarFilter.ts
+++ b/src/interaction/scrollbarFilter.ts
@@ -16,6 +16,10 @@ export function ScrollbarFilter(options: any = {}) {
       y: [...scaleY.getOptions().domain],
     };
 
+    // The ordinal domain for each channel.
+    scaleX.update({ domain: scaleX.getOptions().expectedDomain });
+    scaleY.update({ domain: scaleY.getOptions().expectedDomain });
+
     const interaction = SliderFilter({
       initDomain,
       className: SCROLLBAR_CLASS_NAME,

--- a/src/interaction/sliderFilter.ts
+++ b/src/interaction/sliderFilter.ts
@@ -1,4 +1,4 @@
-import { deepMix, throttle, upperFirst, get } from '@antv/util';
+import { deepMix, throttle, upperFirst } from '@antv/util';
 import { CustomEvent } from '@antv/g';
 import { isTranspose } from '../utils/coordinate';
 import { invert, domainOf, abstractOf } from '../utils/scale';
@@ -143,23 +143,6 @@ export function SliderFilter({
           filtering = true;
 
           const { nativeEvent = true } = event;
-
-          // The ordinal domain for each channel.
-          const scaleXOptions = scaleX.getOptions();
-          if (
-            get(scaleXOptions, 'domain.length') !==
-            get(scaleXOptions, 'expectedDomain.length')
-          ) {
-            scaleX.update({ domain: scaleXOptions.expectedDomain });
-          }
-
-          const scaleYOptions = scaleY.getOptions();
-          if (
-            get(scaleYOptions, 'domain.length') !==
-            get(scaleYOptions, 'expectedDomain.length')
-          ) {
-            scaleY.update({ domain: scaleYOptions.expectedDomain });
-          }
 
           // Get and update domain.
           const [domain0, domain1] = domainsOf(event);


### PR DESCRIPTION
Reverts antvis/G2#7038

<img width="2078" height="746" alt="image" src="https://github.com/user-attachments/assets/590bfe05-33a9-4b2d-b976-cdbd6c517189" />

pr有点问题