### PR TITLE
fix: 开启 scrollbar 组件，出现间距问题。

### DIFF
--- a/src/interaction/sliderFilter.ts
+++ b/src/interaction/sliderFilter.ts
@@ -171,10 +171,6 @@ export function SliderFilter({
               channel0,
               channel1,
             ),
-            paddingLeft,
-            paddingTop,
-            paddingBottom,
-            paddingRight,
           }));
 
           await update();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### 问题描述
- 使用scrollbar 组件 ，并且触发 scrollbar 会发现图片会闪一下，然后间距会改变。#6617
- 如果图例放在右侧，触发 scrollbar，图例被挤压。
- <img width="841" height="622" alt="image" src="https://github.com/user-attachments/assets/c9a636ea-39f1-444b-8941-6bec2d565ced" />


##### 问题原因- 将错误的padding值进行重新赋值
- [源码#L89](https://github.com/antvis/G2/blob/v5/src/interaction/sliderFilter.ts#L89)可以看出从layout中取了padding值,在[源码#L174-#L177](https://github.com/antvis/G2/blob/v5/src/interaction/sliderFilter.ts#L174)存起来随后更新。当用户没有给padding值layout 中也会存在默认padding，这应该是自适应的padding，这个padding传入就会出错。
- <img width="2560" height="1378" alt="image" src="https://github.com/user-attachments/assets/d4efcad7-82dd-42f1-9fef-3f61be0fc504" />

- [源码#271](https://github.com/antvis/G2/blob/v5/src/runtime/plot.ts#L271)更新时会将初始化参数与上一步更新参数进行合并，合并的时候根本不需要将layout 的间距参数再存一遍。
<img width="2560" height="1374" alt="image" src="https://github.com/user-attachments/assets/a38fc752-c518-45aa-bfa4-0c74f416a251" />


<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] benchmarks are included
- [x] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change

<!-- Provide a description of the change below this comment. -->
