### PR TITLE
feat: make tooltip series scale independent

### DIFF
--- a/__tests__/integration/snapshots/tooltip/multiple-series/step0.html
+++ b/__tests__/integration/snapshots/tooltip/multiple-series/step0.html
@@ -1,0 +1,51 @@
+<div xmlns="http://www.w3.org/1999/xhtml" class="g2-tooltip" style="pointer-events: none; position: absolute; visibility: visible; z-index: 8; transition: visibility 0.2s cubic-bezier(0.23, 1, 0.32, 1), left 0.4s cubic-bezier(0.23, 1, 0.32, 1), top 0.4s cubic-bezier(0.23, 1, 0.32, 1); background-color: rgba(255, 255, 255, 0.96); box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12); border-radius: 4px; color: rgba(0, 0, 0, 0.65); font-size: 12px; line-height: 20px; padding: 12px; min-width: 120px; max-width: 360px; font-family: sans-serif; left: 110px; top: 110px;">
+  <div class="g2-tooltip-title" style="color: rgba(0, 0, 0, 0.45); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;">
+    10:10
+  </div>
+  <ul class="g2-tooltip-list" style="margin: 0px; list-style-type: none; padding: 0px;">
+    <li class="g2-tooltip-list-item" data-index="0" style="list-style-type: none; display: flex; line-height: 2em; align-items: center; justify-content: space-between; white-space: nowrap;">
+      <span class="g2-tooltip-list-item-name" style="display: flex; align-items: center; max-width: 216px;">
+        <span class="g2-tooltip-list-item-marker" style="background: rgb(253, 174, 107); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"/>
+        <span class="g2-tooltip-list-item-name-label" style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;" title="1">
+          1
+        </span>
+      </span>
+      <span class="g2-tooltip-list-item-value" style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;" title="2">
+        2
+      </span>
+    </li>
+    <li class="g2-tooltip-list-item" data-index="1" style="list-style-type: none; display: flex; line-height: 2em; align-items: center; justify-content: space-between; white-space: nowrap;">
+      <span class="g2-tooltip-list-item-name" style="display: flex; align-items: center; max-width: 216px;">
+        <span class="g2-tooltip-list-item-marker" style="background: rgb(253, 174, 107); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"/>
+        <span class="g2-tooltip-list-item-name-label" style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;" title="2">
+          2
+        </span>
+      </span>
+      <span class="g2-tooltip-list-item-value" style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;" title="2">
+        2
+      </span>
+    </li>
+    <li class="g2-tooltip-list-item" data-index="2" style="list-style-type: none; display: flex; line-height: 2em; align-items: center; justify-content: space-between; white-space: nowrap;">
+      <span class="g2-tooltip-list-item-name" style="display: flex; align-items: center; max-width: 216px;">
+        <span class="g2-tooltip-list-item-marker" style="background: rgb(23, 131, 255); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"/>
+        <span class="g2-tooltip-list-item-name-label" style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;" title="i1">
+          i1
+        </span>
+      </span>
+      <span class="g2-tooltip-list-item-value" style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;" title="2">
+        2
+      </span>
+    </li>
+    <li class="g2-tooltip-list-item" data-index="3" style="list-style-type: none; display: flex; line-height: 2em; align-items: center; justify-content: space-between; white-space: nowrap;">
+      <span class="g2-tooltip-list-item-name" style="display: flex; align-items: center; max-width: 216px;">
+        <span class="g2-tooltip-list-item-marker" style="background: rgb(23, 131, 255); width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 4px;"/>
+        <span class="g2-tooltip-list-item-name-label" style="flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;" title="i2">
+          i2
+        </span>
+      </span>
+      <span class="g2-tooltip-list-item-value" style="display: inline-block; float: right; flex: 1; text-align: right; min-width: 28px; margin-left: 30px; color: rgba(0, 0, 0, 0.85); overflow: hidden; white-space: nowrap; text-overflow: ellipsis;" title="2">
+        2
+      </span>
+    </li>
+  </ul>
+</div>

--- a/__tests__/plots/tooltip/index.ts
+++ b/__tests__/plots/tooltip/index.ts
@@ -82,3 +82,4 @@ export { mockGroupInterval } from './mock-group-interval';
 export { temperatureLineMarker } from './temperatures-line-marker';
 export { itemsCallback } from './items-callback';
 export { reverseScaleRange } from './reverse-scale-range';
+export { multipleSeries } from './multiple-series';

--- a/__tests__/plots/tooltip/multiple-series.ts
+++ b/__tests__/plots/tooltip/multiple-series.ts
@@ -1,0 +1,44 @@
+import { seriesTooltipSteps } from './utils';
+
+export function multipleSeries() {
+  return {
+    type: 'view',
+    autoFit: true,
+    children: [
+      {
+        data: [
+          { time: '10:10', waiting: 2, s: 'i1' },
+          { time: '10:10', waiting: 2, s: 'i2' },
+          { time: '10:15', waiting: 6, s: 'i1' },
+          { time: '10:15', waiting: 6, s: 'i2' },
+        ],
+        type: 'interval',
+        encode: { x: 'time', y: 'waiting', series: 's' },
+        scale: { series: { key: 'interval' } },
+        axis: { y: { title: 'Waiting', titleFill: '#5B8FF9' } },
+      },
+      {
+        data: [
+          { time: '10:10', people: 2, s: '1' },
+          { time: '10:10', people: 2, s: '2' },
+          { time: '10:15', people: 3, s: '1' },
+          { time: '10:15', people: 3, s: '2' },
+        ],
+        type: 'line',
+        encode: { x: 'time', y: 'people', shape: 'smooth', series: 's' },
+        scale: { series: { key: 'line' } },
+        style: { stroke: '#fdae6b', lineWidth: 2 },
+        axis: {
+          y: {
+            position: 'right',
+            grid: null,
+            title: 'People',
+            titleFill: '#fdae6b',
+          },
+        },
+      },
+    ],
+  };
+}
+
+multipleSeries.steps = seriesTooltipSteps([100, 100]);

--- a/src/runtime/mark.ts
+++ b/src/runtime/mark.ts
@@ -39,7 +39,7 @@ export async function initializeMark(
     context,
   );
 
-  const { encode, scale, data, tooltip } = transformedMark;
+  const { encode, scale, data, tooltip, key: markerKey } = transformedMark;
 
   // Skip mark with non-tabular data. Do not skip empty
   // data, they are useful for facet to display axes.
@@ -107,6 +107,7 @@ export async function initializeMark(
           scaleKey: independent || isConstant ? Symbol('independent') : key,
           scale: {
             type,
+            markerKey,
             range: finalRange,
             ...scaleOptions,
             quantitative,

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -62,11 +62,29 @@ export function seriesOf(elemenet: G2Element): string {
 }
 
 /**
+ * Get series scale by markerKey
+ */
+function getSeriesByMarkerKey(scale: Record<string, Base<any>>, datum) {
+  // For path mark, markerKey is in datum.element?.__data__?.markKey.
+  const markerKey = datum.markKey ?? datum.element?.__data__?.markKey;
+
+  const seriesKey = Object.keys(scale).find((channel) => {
+    if (channel.startsWith('series')) {
+      const options = scale[channel].getOptions();
+      return options.name === 'series' && options.markerKey === markerKey;
+    }
+  });
+  return scale[seriesKey] ?? scale.series;
+}
+
+/**
  * Get group name with view's scale and element's datum.
  */
 export function groupNameOf(scale: Record<string, Base<any>>, datum) {
-  const { color: scaleColor, series: scaleSeries, facet = false } = scale;
+  const { color: scaleColor, facet = false } = scale;
   const { color, series } = datum;
+  const scaleSeries = getSeriesByMarkerKey(scale, datum);
+
   const invertAble = (scale) => {
     return (
       scale &&


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Description of change
问题：
scale 有独立 key 场景下，比如设置了 `scale: { series: { key: 'line' } }` 时，scale 中会有多个 series，但 `groupNameOf` 之前是直接取的 `series`，没有关心其他 mark 的 `series1`，导致获取到的 `series` 永远都是第一个 mark 的，会造成 tooltip 展示错误。
<img width="654" height="508" alt="image" src="https://github.com/user-attachments/assets/e2042517-8d7c-4a3c-b599-0bde058d63fd" />
<img width="1290" height="424" alt="image" src="https://github.com/user-attachments/assets/4550c21f-ecf0-4eac-885e-1e787ed4c07d" />
改造：
1. 为 scale 添加 markerKey 标记，指明当前 scale 归属于哪个 mark
2. `groupNameOf` 通过 markerKey 准确获取对应 series scale


<!-- Provide a description of the change below this comment. -->
