### PR TITLE
fix: update triggered height increase

### DIFF
--- a/src/api/runtime.ts
+++ b/src/api/runtime.ts
@@ -468,6 +468,11 @@ export class Runtime<Spec extends G2Spec = G2Spec> extends CompositionNode {
       height,
       renderer: this._renderer,
     });
+
+    const dom = this._context.canvas
+      ?.getContextService()
+      ?.getDomElement() as HTMLCanvasElement;
+    if (dom) dom.style.display = 'block';
   }
 
   private _addToTrailing(): Promise<Runtime<Spec>> {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
 - fixed https://github.com/antvis/G2/issues/7030

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Description of change

<!-- Provide a description of the change below this comment. -->
修复之前的重渲染一直增加6px问题
主要就是 canvas 是行内元素，会与 container 有间隙
