### PR TITLE
fix: pass labels to label callbacks

### DIFF
--- a/__tests__/unit/runtime/component.spec.ts
+++ b/__tests__/unit/runtime/component.spec.ts
@@ -1,0 +1,66 @@
+import { vi } from 'vitest';
+import { Band } from '@antv/scale';
+import { computeLabelsBBox } from '../../../src/runtime/component';
+import { createNodeGCanvas } from '../../integration/utils/createNodeGCanvas';
+
+describe('computeLabelsBBox', () => {
+  it('should pass labels array to label callbacks', async () => {
+    const canvas = createNodeGCanvas(640, 480);
+    await canvas.ready;
+
+    const labels = ['A', 'B', 'C'];
+
+    const scale = new Band();
+    scale.update({ domain: labels, range: [0, 1] });
+
+    const labelFontSize = vi.fn(
+      (_datum: string, _index: number, _data: string[]) => 12,
+    );
+
+    const component = {
+      label: true,
+      labelFontSize,
+    };
+
+    computeLabelsBBox(component, scale);
+
+    expect(labelFontSize).toHaveBeenCalledTimes(3);
+    expect(labelFontSize.mock.calls).toEqual([
+      ['A', 0, ['A', 'B', 'C']],
+      ['B', 1, ['A', 'B', 'C']],
+      ['C', 2, ['A', 'B', 'C']],
+    ]);
+
+    const dataArgs = labelFontSize.mock.calls.map(([, , data]) => data);
+    expect(new Set(dataArgs).size).toBe(1);
+    expect(dataArgs[0]).toEqual(labels);
+  });
+
+  it('should pass labels array to keyed callbacks', async () => {
+    const canvas = createNodeGCanvas(640, 480);
+    await canvas.ready;
+
+    const labels = ['A', 'B', 'C'];
+    const scale = new Band();
+    scale.update({ domain: labels, range: [0, 1] });
+
+    const itemLabelFontSize = vi.fn(
+      (_datum: string, _index: number, data: string[]) =>
+        data.length ? 12 : 0,
+    );
+
+    const component = {
+      label: true,
+      itemLabelFontSize,
+    };
+
+    computeLabelsBBox(component, scale, 'itemLabel');
+
+    expect(itemLabelFontSize).toHaveBeenCalledTimes(3);
+    expect(itemLabelFontSize.mock.calls).toEqual([
+      ['A', 0, ['A', 'B', 'C']],
+      ['B', 1, ['A', 'B', 'C']],
+      ['C', 2, ['A', 'B', 'C']],
+    ]);
+  });
+});

--- a/__tests__/unit/runtime/component.spec.ts
+++ b/__tests__/unit/runtime/component.spec.ts
@@ -1,13 +1,18 @@
 import { vi } from 'vitest';
 import { Band } from '@antv/scale';
+import { Canvas } from '@antv/g';
 import { computeLabelsBBox } from '../../../src/runtime/component';
 import { createNodeGCanvas } from '../../integration/utils/createNodeGCanvas';
 
 describe('computeLabelsBBox', () => {
-  it('should pass labels array to label callbacks', async () => {
-    const canvas = createNodeGCanvas(640, 480);
-    await canvas.ready;
+  let canvas: Canvas;
 
+  beforeEach(async () => {
+    canvas = createNodeGCanvas(640, 480);
+    await canvas.ready;
+  });
+
+  it('should pass labels array to label callbacks', async () => {
     const labels = ['A', 'B', 'C'];
 
     const scale = new Band();
@@ -37,9 +42,6 @@ describe('computeLabelsBBox', () => {
   });
 
   it('should pass labels array to keyed callbacks', async () => {
-    const canvas = createNodeGCanvas(640, 480);
-    await canvas.ready;
-
     const labels = ['A', 'B', 'C'];
     const scale = new Band();
     scale.update({ domain: labels, range: [0, 1] });

--- a/src/runtime/component.ts
+++ b/src/runtime/component.ts
@@ -1068,7 +1068,7 @@ export function computeLabelsBBox(
     Object.fromEntries(
       Object.entries(labelStyle).map(([key, value]) => [
         key,
-        typeof value === 'function' ? value(d, i) : value,
+        typeof value === 'function' ? value(d, i, labels) : value,
       ]),
     ),
   );


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] benchmarks are included
- [x] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change
- Requirement: pass labels array to label style callbacks
- Reason: render phase callbacks already get full labels, but bbox compute path only passed (d, i); align behavior and keep API consistent
- Framework testing points: \_\_tests\_\_/unit/runtime/component.spec.ts
- Concerns: none