### PR TITLE
fix: remove auto transform column

### DIFF
--- a/src/runtime/transform.ts
+++ b/src/runtime/transform.ts
@@ -360,10 +360,6 @@ function normalizedDataSource(data) {
   // Return null as a placeholder.
   if (!data) return { type: 'inline', value: null };
   if (Array.isArray(data)) return { type: 'inline', value: data };
-  // Check if data is column-major format (object with all array values)
-  if (isColumnMajorData(data)) {
-    return { type: 'column', value: data };
-  }
   const { type = 'inline', ...rest } = data;
   return { ...rest, type };
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] benchmarks are included
- [ ] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change
官网中地图都白屏了
https://github.com/antvis/G2/pull/7274/changes/d8eaa0c0bf8d3ae2cce4f3f6f5fc23188e0ae001 引入了一个自动转换列数据的逻辑，会意外将地图的数据也识别为列数据
去除这个自动转换逻辑，列数据需显式声明 type: column
<!-- Provide a description of the change below this comment. -->
